### PR TITLE
Implement vector potential calcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.1.0 2024-08-27
+
+### Added
+
+* Add vector potential calcs for linear and circular filaments
+* Add parallel options for circular-filament calcs
+* Add parametrization of unit tests over parallel and serial variants
+* Add optional parallel flags to functions that use functions with new parallel options
+
+### Changed
+
 ## 2.0.4 2024-07-10
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfsem"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cbed55153f04ab37ca424a26fcce4bd6fe8f482bca97bd3d5052bfba620466"
+checksum = "2b3e27e61569347c86debb5a8032a62c7acb3b6da51d14f68dd948cf7625dd79"
 dependencies = [
  "nalgebra",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = "0.21.2"
 numpy = "0.21.0"  # This must match pyo3 version!
-cfsem = "1.0.0"
+cfsem = "1.1.0"
 
 [profile.release]
 opt-level = 3

--- a/cfsem/__init__.py
+++ b/cfsem/__init__.py
@@ -9,6 +9,7 @@ from cfsem.types import Array3xN
 
 from cfsem.bindings import (
     flux_circular_filament,
+    flux_density_linear_filament,
     flux_density_biot_savart,
     flux_density_circular_filament,
     gs_operator_order2,
@@ -16,6 +17,8 @@ from cfsem.bindings import (
     inductance_piecewise_linear_filaments,
     filament_helix_path,
     rotate_filaments_about_path,
+    vector_potential_linear_filament,
+    vector_potential_circular_filament,
 )
 
 from ._cfsem import ellipe, ellipk
@@ -29,6 +32,7 @@ https://www.physics.nist.gov/cuu/pdf/wall_2018.pdf .
 __all__ = [
     "flux_circular_filament",
     "flux_density_biot_savart",
+    "flux_density_linear_filament",
     "flux_density_circular_filament",
     "gs_operator_order2",
     "gs_operator_order4",
@@ -47,6 +51,8 @@ __all__ = [
     "ellipe",
     "ellipk",
     "rotate_filaments_about_path",
+    "vector_potential_linear_filament",
+    "vector_potential_circular_filament",
 ]
 
 
@@ -240,7 +246,9 @@ def self_inductance_lyle6(r: float, dr: float, dz: float, n: float) -> float:
     return self_inductance  # [H]
 
 
-def mutual_inductance_of_circular_filaments(rzn1: NDArray, rzn2: NDArray) -> float:
+def mutual_inductance_of_circular_filaments(
+    rzn1: NDArray, rzn2: NDArray, par: bool = True
+) -> float:
     """
     Analytic mutual inductance between a pair of ideal cylindrically-symmetric coaxial filaments.
 
@@ -251,19 +259,22 @@ def mutual_inductance_of_circular_filaments(rzn1: NDArray, rzn2: NDArray) -> flo
     Args:
         rzn1 (array): 3x1 array (r [m], z [m], n []) coordinates and number of turns
         rzn2 (array): 3x1 array (r [m], z [m], n []) coordinates and number of turns
+        par: Whether to use the parallel variant
 
     Returns:
         float: [H] mutual inductance
     """
 
     m = mutual_inductance_of_cylindrical_coils(
-        rzn1.reshape((3, 1)), rzn2.reshape((3, 1))
+        rzn1.reshape((3, 1)), rzn2.reshape((3, 1)), par
     )
 
     return m  # [H]
 
 
-def mutual_inductance_of_cylindrical_coils(f1: NDArray, f2: NDArray) -> float:
+def mutual_inductance_of_cylindrical_coils(
+    f1: NDArray, f2: NDArray, par: bool = True
+) -> float:
     """
     Analytical mutual inductance between two coaxial collections of ideal filaments.
 
@@ -274,6 +285,7 @@ def mutual_inductance_of_cylindrical_coils(f1: NDArray, f2: NDArray) -> float:
     Args:
         f1: 3 x N array of filament definitions like (r [m], z [m], n [])
         f2: 3 x N array of filament definitions like (r [m], z [m], n [])
+        par: Whether to use the parallel variant
 
     Returns:
         [H] mutual inductance of the two discretized coils
@@ -284,7 +296,7 @@ def mutual_inductance_of_cylindrical_coils(f1: NDArray, f2: NDArray) -> float:
     # Using n2 as the current per filament is equivalent to examining a 1A reference current,
     # which gives us the flux per amp (inductance)
     m = np.sum(
-        n1 * flux_circular_filament(n2, r2, z2, r1, z1)
+        n1 * flux_circular_filament(n2, r2, z2, r1, z1, par)
     )  # [H] total mutual inductance
 
     return m  # [H]

--- a/cfsem/__init__.py
+++ b/cfsem/__init__.py
@@ -259,7 +259,7 @@ def mutual_inductance_of_circular_filaments(
     Args:
         rzn1 (array): 3x1 array (r [m], z [m], n []) coordinates and number of turns
         rzn2 (array): 3x1 array (r [m], z [m], n []) coordinates and number of turns
-        par: Whether to use the parallel variant
+        par: Whether to use CPU parallelism
 
     Returns:
         float: [H] mutual inductance
@@ -285,7 +285,7 @@ def mutual_inductance_of_cylindrical_coils(
     Args:
         f1: 3 x N array of filament definitions like (r [m], z [m], n [])
         f2: 3 x N array of filament definitions like (r [m], z [m], n [])
-        par: Whether to use the parallel variant
+        par: Whether to use CPU parallelism
 
     Returns:
         [H] mutual inductance of the two discretized coils

--- a/cfsem/bindings.py
+++ b/cfsem/bindings.py
@@ -11,7 +11,7 @@ from numpy import ascontiguousarray, float64, zeros_like
 from numpy.typing import NDArray
 
 from ._cfsem import flux_circular_filament as em_flux_circular_filament
-from ._cfsem import flux_density_biot_savart as em_flux_density_biot_savart
+from ._cfsem import flux_density_linear_filament as em_flux_density_linear_filament
 from ._cfsem import flux_density_circular_filament as em_flux_density_circular_filament
 from ._cfsem import gs_operator_order2 as em_gs_operator_order2
 from ._cfsem import gs_operator_order4 as em_gs_operator_order4
@@ -20,6 +20,12 @@ from ._cfsem import (
 )
 from ._cfsem import filament_helix_path as em_filament_helix_path
 from ._cfsem import rotate_filaments_about_path as em_rotate_filaments_about_path
+from ._cfsem import (
+    vector_potential_circular_filament as em_vector_potential_circular_filament,
+)
+from ._cfsem import (
+    vector_potential_linear_filament as em_vector_potential_linear_filament,
+)
 
 
 def flux_circular_filament(
@@ -28,6 +34,7 @@ def flux_circular_filament(
     zfil: NDArray[float64],
     rprime: NDArray[float64],
     zprime: NDArray[float64],
+    par: bool = True,
 ) -> NDArray[float64]:
     """
     Flux contributions from some circular filaments to some observation points,
@@ -37,17 +44,11 @@ def flux_circular_filament(
     (`rprime`, `zprime`) observation location with $\\hat{n}$ oriented parallel to the z-axis.
 
     A convenient interpretation of the flux is as the mutual inductance
-    per secondary coil current between a filament at (`rfil`, `zfil`) and a secondary
+    between a circular filament at (`rfil`, `zfil`) and a second circular
     filament at (`rprime`, `zprime`); this can be used to get the mutual inductance
-    between two filamentized coils as the sum of I1 * I2 * flux_from_coil_1_to_coil_2.
+    between two filamentized coils as the sum of flux contributions between each coil's filaments.
     Because mutual inductance is reflexive, the order of the coils can be reversed and
     the same result is obtained.
-
-    This function is fairly well-optimized and runs about >10x faster than an
-    equivalent implementation in numpy+scipy, with lower RAM usage
-    (O(n) in number of observation locations) than what would be required
-    for a tiled implementation. Numba does not have an implementation of
-    elliptic integrals and will not accept scipy's.
 
     Args:
         ifil: [A] filament current
@@ -57,15 +58,58 @@ def flux_circular_filament(
         zprime: [m] Observation point Z-coord
 
     Returns:
-        [T-m^2] or [V-s] psi, poloidal flux at each observation point
+        [Wb] or [T-m^2] or [V-s] psi, poloidal flux at each observation point
     """
     ifil = ascontiguousarray(ifil)
     rfil = ascontiguousarray(rfil)
     zfil = ascontiguousarray(zfil)
     rprime = ascontiguousarray(rprime)
     zprime = ascontiguousarray(zprime)
-    psi = em_flux_circular_filament(ifil, rfil, zfil, rprime, zprime)
-    return psi  # [T-m^2] or [V-s]
+    psi = em_flux_circular_filament(ifil, rfil, zfil, rprime, zprime, par)
+    return psi  # [Wb] or [T-m^2] or [V-s]
+
+
+def vector_potential_circular_filament(
+    ifil: NDArray[float64],
+    rfil: NDArray[float64],
+    zfil: NDArray[float64],
+    rprime: NDArray[float64],
+    zprime: NDArray[float64],
+    par: bool = True,
+) -> NDArray[float64]:
+    """
+    Vector potential contributions from some circular filaments to some observation points.
+    Off-axis A_phi component for a circular current filament in vacuum.
+
+    The vector potential of a loop has zero r- and z- components due to symmetry,
+    and does not vary in the phi-direction.
+
+    Note that to recover the B-field as the curl of A, the curl operator for cylindrical
+    coordinates must be used with the output of this function incorporated into a full
+    3D A-field like [A_r, A_phi, A_z].
+
+    References:
+        [1] J. C. Simpson, J. E. Lane, C. D. Immer, R. C. Youngquist, and T. Steinrock,
+            “Simple Analytic Expressions for the Magnetic Field of a Circular Current Loop,”
+            Jan. 01, 2001. Accessed: Sep. 06, 2022. [Online]. Available: <https://ntrs.nasa.gov/citations/20010038494>
+
+    Args:
+        ifil: [A] filament current
+        rfil: [m] filament R-coord
+        zfil: [m] filament Z-coord
+        rprime: [m] Observation point R-coord
+        zprime: [m] Observation point Z-coord
+
+    Returns:
+        [Wb/m] or [V-s/m] a_phi, vector potential in the toroidal direction
+    """
+    ifil = ascontiguousarray(ifil)
+    rfil = ascontiguousarray(rfil)
+    zfil = ascontiguousarray(zfil)
+    rprime = ascontiguousarray(rprime)
+    zprime = ascontiguousarray(zprime)
+    a_phi = em_vector_potential_circular_filament(ifil, rfil, zfil, rprime, zprime, par)
+    return a_phi  # [Wb/m] or [V-s/m]
 
 
 def flux_density_circular_filament(
@@ -74,6 +118,7 @@ def flux_density_circular_filament(
     zfil: NDArray[float64],
     rprime: NDArray[float64],
     zprime: NDArray[float64],
+    par: bool = True,
 ) -> tuple[NDArray[float64], NDArray[float64]]:
     """
     Off-axis Br,Bz components for a circular current filament in vacuum.
@@ -114,11 +159,11 @@ def flux_density_circular_filament(
     zfil = ascontiguousarray(zfil)
     rprime = ascontiguousarray(rprime)
     zprime = ascontiguousarray(zprime)
-    Br, Bz = em_flux_density_circular_filament(ifil, rfil, zfil, rprime, zprime)
+    Br, Bz = em_flux_density_circular_filament(ifil, rfil, zfil, rprime, zprime, par)
     return Br, Bz  # [T]
 
 
-def flux_density_biot_savart(
+def flux_density_linear_filament(
     xyzp: Array3xN,
     xyzfil: Array3xN,
     dlxyzfil: Array3xN,
@@ -128,11 +173,6 @@ def flux_density_biot_savart(
     """
     Biot-Savart law calculation for B-field contributions from many filament segments
     to many observation points.
-
-    This calc is fairly well-optimized under the constraint to keep peak RAM usage to
-    O(n) in n observation points, which precludes tiling. It comes out about 20% faster
-    than an equivalent implementation in numba, which is about 4x faster than an
-    equivalent implementation in numpy.
 
     Args:
         xyzp: [m] x,y,z coords of observation points
@@ -160,7 +200,50 @@ def flux_density_biot_savart(
         ascontiguousarray(dlxyzfil[2]),
     )
     ifil = ascontiguousarray(ifil)
-    return em_flux_density_biot_savart(xyzp, xyzfil, dlxyzfil, ifil, par)
+    return em_flux_density_linear_filament(xyzp, xyzfil, dlxyzfil, ifil, par)
+
+
+flux_density_biot_savart = flux_density_linear_filament  # For backwards-compatibility
+
+
+def vector_potential_linear_filament(
+    xyzp: Array3xN,
+    xyzfil: Array3xN,
+    dlxyzfil: Array3xN,
+    ifil: NDArray[float64],
+    par: bool = True,
+) -> Array3xN:
+    """
+    Vector potential calculation for A-field contribution from many current filament
+    segments to many observation points.
+
+    Args:
+        xyzp: [m] x,y,z coords of observation points
+        xyzfil: [m] x,y,z coords of current filament origins (start of segment)
+        dlxyzfil: [m] x,y,z length delta of current filaments
+        ifil: [A] current in each filament segment
+        par: Whether to use CPU parallelism
+
+    Returns:
+        [Wb/m] or [V-s/m] (Ax, Ay, Az) magnetic vector potential at observation points
+    """
+    xyzp = (
+        ascontiguousarray(xyzp[0]),
+        ascontiguousarray(xyzp[1]),
+        ascontiguousarray(xyzp[2]),
+    )
+    xyzfil = (
+        ascontiguousarray(xyzfil[0]),
+        ascontiguousarray(xyzfil[1]),
+        ascontiguousarray(xyzfil[2]),
+    )
+    dlxyzfil = (
+        ascontiguousarray(dlxyzfil[0]),
+        ascontiguousarray(dlxyzfil[1]),
+        ascontiguousarray(dlxyzfil[2]),
+    )
+    ifil = ascontiguousarray(ifil)
+    return em_vector_potential_linear_filament(xyzp, xyzfil, dlxyzfil, ifil, par)
 
 
 def inductance_piecewise_linear_filaments(
@@ -200,10 +283,10 @@ def inductance_piecewise_linear_filaments(
     References:
         [1] “Inductance,” Wikipedia. Dec. 12, 2022. Accessed: Jan. 23, 2023. [Online].
             Available: <https://en.wikipedia.org/w/index.php?title=Inductance>
-        
+
         [2] F. E. Neumann, “Allgemeine Gesetze der inducirten elektrischen Ströme,”
             Jan. 1846, doi: [10.1002/andp.18461430103](https://doi.org/10.1002/andp.18461430103)
-        
+
         [3] R. Dengler, “Self inductance of a wire loop as a curve integral,”
             AEM, vol. 5, no. 1, p. 1, Jan. 2016, doi: [10.7716/aem.v5i1.331](https://doi.org/10.7716/aem.v5i1.331)
 

--- a/cfsem/bindings.py
+++ b/cfsem/bindings.py
@@ -56,6 +56,7 @@ def flux_circular_filament(
         zfil: [m] filament Z-coord
         rprime: [m] Observation point R-coord
         zprime: [m] Observation point Z-coord
+        par: Whether to use CPU parallelism
 
     Returns:
         [Wb] or [T-m^2] or [V-s] psi, poloidal flux at each observation point
@@ -99,6 +100,7 @@ def vector_potential_circular_filament(
         zfil: [m] filament Z-coord
         rprime: [m] Observation point R-coord
         zprime: [m] Observation point Z-coord
+        par: Whether to use CPU parallelism
 
     Returns:
         [Wb/m] or [V-s/m] a_phi, vector potential in the toroidal direction
@@ -150,6 +152,7 @@ def flux_density_circular_filament(
         zfil: [m] filament Z-coord
         rprime: [m] Observation point R-coord
         zprime: [m] Observation point Z-coord
+        par: Whether to use CPU parallelism
 
     Returns:
         [T] (Br, Bz) flux density components

--- a/docs/python/flux_density.md
+++ b/docs/python/flux_density.md
@@ -1,8 +1,6 @@
 # Magnetic flux and flux density (B field)
 
-::: cfsem.flux_circular_filament
-
-::: cfsem.flux_density_biot_savart
+::: cfsem.flux_density_linear_filament
 
 ::: cfsem.flux_density_circular_filament
 

--- a/docs/python/inductance.md
+++ b/docs/python/inductance.md
@@ -2,6 +2,8 @@
 
 ## Mutual inductance
 
+::: cfsem.flux_circular_filament
+
 ::: cfsem.mutual_inductance_of_circular_filaments
 
 ::: cfsem.mutual_inductance_of_cylindrical_coils

--- a/docs/python/vector_potential.md
+++ b/docs/python/vector_potential.md
@@ -1,0 +1,5 @@
+# Vector Potential
+
+::: cfsem.vector_potential_circular_filament
+
+::: cfsem.vector_potential_linear_filament

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - "Python API":
       - "python/filament.md"
       - "python/flux_density.md"
+      - "python/vector_potential.md"
       - "python/inductance.md"
       - "python/grad_shafranov.md"
       - "python/math.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cfsem"
-version = "2.0.4"
+version = "2.1.0"
 description = "Quasi-steady electromagnetics including filamentized approximations, Biot-Savart, and Grad-Shafranov."
 authors = [{author = "Commonwealth Fusion Systems", email = "jlogan@cfs.energy"}]
 requires-python = ">=3.9, <3.13"
@@ -16,7 +16,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "numpy >= 2",
-    "interpn >= 0.2.2",
+    "interpn >= 0.2.3",
 ]
 license = "MIT"
 
@@ -25,7 +25,7 @@ dev = [
     # Tests
     "pytest >= 7.1.3",
     "coverage >= 6.5.0",
-    "ruff >= 0.4.2",
+    "ruff >= 0.6.2",
     "pyright >= 1.1.331",
     "scipy >= 1.8",
     # Docs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ fn flux_circular_filament<'py>(
     z: Bound<'py, PyArray1<f64>>,
     rprime: Bound<'py, PyArray1<f64>>,
     zprime: Bound<'py, PyArray1<f64>>,
+    par: bool,
 ) -> PyResult<Py<PyArray1<f64>>> {
     // Get references to contiguous data as slice
     // or error if data is not contiguous
@@ -148,8 +149,14 @@ fn flux_circular_filament<'py>(
     // Initialize output
     let mut psi = vec![0.0; m];
 
+    // Select variant
+    let func = match par {
+        true => physics::circular_filament::flux_circular_filament_par,
+        false => physics::circular_filament::flux_circular_filament,
+    };
+
     // Do calculations
-    match physics::flux_circular_filament(current, r, z, rprime, zprime, &mut psi[..]) {
+    match func(current, r, z, rprime, zprime, &mut psi[..]) {
         Ok(_) => {}
         Err(x) => {
             let err: PyErr = PyInteropError::DimensionalityError { msg: x.to_string() }.into();
@@ -163,6 +170,56 @@ fn flux_circular_filament<'py>(
     })
 }
 
+/// Python bindings for cfsemrs::physics::circular_filament::vector_potential_circular_filament
+#[pyfunction]
+fn vector_potential_circular_filament<'py>(
+    current: Bound<'py, PyArray1<f64>>,
+    r: Bound<'py, PyArray1<f64>>,
+    z: Bound<'py, PyArray1<f64>>,
+    rprime: Bound<'py, PyArray1<f64>>,
+    zprime: Bound<'py, PyArray1<f64>>,
+    par: bool,
+) -> PyResult<Py<PyArray1<f64>>> {
+    // Get references to contiguous data as slice
+    // or error if data is not contiguous
+    let current_readonly = current.readonly();
+    let current = current_readonly.as_slice()?;
+    let r_readonly = r.readonly();
+    let r = r_readonly.as_slice()?;
+    let z_readonly = z.readonly();
+    let z = z_readonly.as_slice()?;
+    let rprime_readonly = rprime.readonly();
+    let rprime = rprime_readonly.as_slice()?;
+    let zprime_readonly = zprime.readonly();
+    let zprime = zprime_readonly.as_slice()?;
+
+    // Get array shapes, make sure they make sense
+    let m = rprime.len();
+
+    // Initialize output
+    let mut out = vec![0.0; m];
+
+    // Select variant
+    let func = match par {
+        true => physics::circular_filament::vector_potential_circular_filament_par,
+        false => physics::circular_filament::vector_potential_circular_filament,
+    };
+
+    // Do calculations
+    match func(current, r, z, rprime, zprime, &mut out[..]) {
+        Ok(_) => {}
+        Err(x) => {
+            let err: PyErr = PyInteropError::DimensionalityError { msg: x.to_string() }.into();
+            return Err(err);
+        }
+    }
+
+    // Acquire global interpreter lock, which will be released when it goes out of scope
+    Python::with_gil(|py| {
+        Ok(PyArray1::from_vec_bound(py, out).unbind()) // Make PyObject
+    })
+}
+
 /// Python bindings for cfsemrs::physics::flux_density_circular_filament
 #[pyfunction]
 fn flux_density_circular_filament<'py>(
@@ -171,6 +228,7 @@ fn flux_density_circular_filament<'py>(
     zfil: Bound<'py, PyArray1<f64>>,
     rprime: Bound<'py, PyArray1<f64>>,
     zprime: Bound<'py, PyArray1<f64>>,
+    par: bool,
 ) -> PyResult<(Py<PyArray1<f64>>, Py<PyArray1<f64>>)> {
     // Get references to contiguous data as slice
     // or error if data is not contiguous
@@ -190,10 +248,14 @@ fn flux_density_circular_filament<'py>(
     let mut br = vec![0.0; n];
     let mut bz = vec![0.0; n];
 
+    // Select variant
+    let func = match par {
+        true => physics::circular_filament::flux_density_circular_filament_par,
+        false => physics::circular_filament::flux_density_circular_filament,
+    };
+
     // Do calculations
-    match physics::flux_density_circular_filament(
-        &current, &rfil, &zfil, &rprime, &zprime, &mut br, &mut bz,
-    ) {
+    match func(&current, &rfil, &zfil, &rprime, &zprime, &mut br, &mut bz) {
         Ok(_) => {}
         Err(x) => {
             let err: PyErr = PyInteropError::DimensionalityError { msg: x.to_string() }.into();
@@ -210,9 +272,9 @@ fn flux_density_circular_filament<'py>(
     })
 }
 
-/// Python bindings for cfsemrs::physics::biotsavart::flux_density_biot_savart
+/// Python bindings for cfsemrs::physics::linear_filament::flux_density_linear_filament
 #[pyfunction]
-fn flux_density_biot_savart<'py>(
+fn flux_density_linear_filament<'py>(
     xyzp: (
         Bound<'py, PyArray1<f64>>,
         Bound<'py, PyArray1<f64>>,
@@ -259,8 +321,8 @@ fn flux_density_biot_savart<'py>(
     let (mut bx, mut by, mut bz) = (vec![0.0; n], vec![0.0; n], vec![0.0; n]);
 
     let func = match par {
-        true => physics::biotsavart::flux_density_biot_savart_par,
-        false => physics::biotsavart::flux_density_biot_savart,
+        true => physics::linear_filament::flux_density_linear_filament_par,
+        false => physics::linear_filament::flux_density_linear_filament,
     };
     match func(xyzp, xyzfil, dlxyzfil, ifil, (&mut bx, &mut by, &mut bz)) {
         Ok(x) => x,
@@ -275,6 +337,82 @@ fn flux_density_biot_savart<'py>(
         let bx: Py<PyArray1<f64>> = PyArray1::from_vec_bound(py, bx).unbind();
         let by: Py<PyArray1<f64>> = PyArray1::from_vec_bound(py, by).unbind();
         let bz: Py<PyArray1<f64>> = PyArray1::from_vec_bound(py, bz).unbind();
+
+        Ok((bx, by, bz))
+    })
+}
+
+/// Python bindings for cfsemrs::physics::linear_filament::vector_potential_linear_filament
+#[pyfunction]
+fn vector_potential_linear_filament<'py>(
+    xyzp: (
+        Bound<'py, PyArray1<f64>>,
+        Bound<'py, PyArray1<f64>>,
+        Bound<'py, PyArray1<f64>>,
+    ), // [m] Test point coords
+    xyzfil: (
+        Bound<'py, PyArray1<f64>>,
+        Bound<'py, PyArray1<f64>>,
+        Bound<'py, PyArray1<f64>>,
+    ), // [m] Filament origin coords (start of segment)
+    dlxyzfil: (
+        Bound<'py, PyArray1<f64>>,
+        Bound<'py, PyArray1<f64>>,
+        Bound<'py, PyArray1<f64>>,
+    ), // [m] Filament length delta
+    ifil: Bound<'py, PyArray1<f64>>, // [A] filament current
+    par: bool,
+) -> PyResult<(Py<PyArray1<f64>>, Py<PyArray1<f64>>, Py<PyArray1<f64>>)> {
+    // Get references to contiguous data as slice
+    // or error if data is not contiguous
+    let xpro = xyzp.0.readonly();
+    let ypro = xyzp.1.readonly();
+    let zpro = xyzp.2.readonly();
+    let xyzp = (xpro.as_slice()?, ypro.as_slice()?, zpro.as_slice()?);
+
+    let xfilro = xyzfil.0.readonly();
+    let yfilro = xyzfil.1.readonly();
+    let zfilro = xyzfil.2.readonly();
+    let xyzfil = (xfilro.as_slice()?, yfilro.as_slice()?, zfilro.as_slice()?);
+
+    let dlxfilro = dlxyzfil.0.readonly();
+    let dlyfilro = dlxyzfil.1.readonly();
+    let dlzfilro = dlxyzfil.2.readonly();
+    let dlxyzfil = (
+        dlxfilro.as_slice()?,
+        dlyfilro.as_slice()?,
+        dlzfilro.as_slice()?,
+    );
+    let ifilro = ifil.readonly();
+    let ifil = ifilro.as_slice()?;
+
+    // Do calculations
+    let n = xyzp.0.len();
+    let (mut outx, mut outy, mut outz) = (vec![0.0; n], vec![0.0; n], vec![0.0; n]);
+
+    let func = match par {
+        true => physics::linear_filament::vector_potential_linear_filament_par,
+        false => physics::linear_filament::vector_potential_linear_filament,
+    };
+    match func(
+        xyzp,
+        xyzfil,
+        dlxyzfil,
+        ifil,
+        (&mut outx, &mut outy, &mut outz),
+    ) {
+        Ok(x) => x,
+        Err(x) => {
+            let err: PyErr = PyInteropError::DimensionalityError { msg: x.to_string() }.into();
+            return Err(err);
+        }
+    };
+
+    // Acquire global interpreter lock, which will be released when it goes out of scope
+    Python::with_gil(|py| {
+        let bx: Py<PyArray1<f64>> = PyArray1::from_vec_bound(py, outx).unbind();
+        let by: Py<PyArray1<f64>> = PyArray1::from_vec_bound(py, outy).unbind();
+        let bz: Py<PyArray1<f64>> = PyArray1::from_vec_bound(py, outz).unbind();
 
         Ok((bx, by, bz))
     })
@@ -430,15 +568,27 @@ fn ellipk(x: f64) -> f64 {
 fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(flux_circular_filament, m.clone())?)?;
     m.add_function(wrap_pyfunction!(flux_density_circular_filament, m.clone())?)?;
-    m.add_function(wrap_pyfunction!(flux_density_biot_savart, m.clone())?)?;
+    m.add_function(wrap_pyfunction!(
+        vector_potential_circular_filament,
+        m.clone()
+    )?)?;
+
+    m.add_function(wrap_pyfunction!(flux_density_linear_filament, m.clone())?)?;
+    m.add_function(wrap_pyfunction!(
+        vector_potential_linear_filament,
+        m.clone()
+    )?)?;
     m.add_function(wrap_pyfunction!(
         inductance_piecewise_linear_filaments,
         m.clone()
     )?)?;
+
     m.add_function(wrap_pyfunction!(gs_operator_order2, m.clone())?)?;
     m.add_function(wrap_pyfunction!(gs_operator_order4, m.clone())?)?;
+
     m.add_function(wrap_pyfunction!(ellipe, m.clone())?)?;
     m.add_function(wrap_pyfunction!(ellipk, m.clone())?)?;
+
     m.add_function(wrap_pyfunction!(filament_helix_path, m.clone())?)?;
     m.add_function(wrap_pyfunction!(rotate_filaments_about_path, m.clone())?)?;
     Ok(())

--- a/test/test_electromagnetics.py
+++ b/test/test_electromagnetics.py
@@ -581,7 +581,7 @@ def test_vector_potential_linear_against_circular_filament(r, z, par):
     ifil = np.ones_like(xfils[1:])
     ax, ay, az = cfsem.vector_potential_linear_filament(
         xyzp, xyzfil, dlxyzfil, ifil, par
-    )  # [T]
+    )  # [V-s/m]
 
     assert np.allclose(a_phi, ay, rtol=1e-12, atol=1e-12)  # Should match circular calc
     assert np.allclose(

--- a/test/test_electromagnetics.py
+++ b/test/test_electromagnetics.py
@@ -39,12 +39,13 @@ def test_self_inductance_piecewise_linear_filaments(r, z, h):
 @mark.parametrize("r1", [0.5, np.pi])
 @mark.parametrize("r2", [0.1, np.pi / 10.0])
 @mark.parametrize("z", [0.0, np.e / 2, -np.e / 2])
-def test_mutual_inductance_piecewise_linear_filaments(r1, r2, z):
+@mark.parametrize("par", [True, False])
+def test_mutual_inductance_piecewise_linear_filaments(r1, r2, z, par):
     # Test against calc for mutual inductance of circular filaments
     rzn1 = np.array([[r1], [z], [1.0]])
     rzn2 = np.array([[r2], [-z / np.e], [1.0]])
 
-    m_circular = cfsem.mutual_inductance_of_circular_filaments(rzn1, rzn2)
+    m_circular = cfsem.mutual_inductance_of_circular_filaments(rzn1, rzn2, par)
 
     n = 100
 
@@ -126,7 +127,7 @@ def test_biot_savart_against_flux_density_circular_filament(r, z, par):
     # Circular filament calc
     # [T]
     Br_circular, Bz_circular = cfsem.flux_density_circular_filament(
-        np.ones(1), np.array([r]), np.array([z]), rprime, zprime
+        np.ones(1), np.array([r]), np.array([z]), rprime, zprime, par
     )
 
     # Biot-Savart calc
@@ -149,7 +150,10 @@ def test_biot_savart_against_flux_density_circular_filament(r, z, par):
 
 @mark.parametrize("r", [0.775, np.pi])
 @mark.parametrize("z", [0.0, np.e / 2, -np.e / 2])
-def test_flux_circular_filament_against_mutual_inductance_of_cylindrical_coils(r, z):
+@mark.parametrize("par", [True, False])
+def test_flux_circular_filament_against_mutual_inductance_of_cylindrical_coils(
+    r, z, par
+):
     # Two single-turn coils with irrelevant cross-section,
     # each discretized into a single filament
     rc1 = r  # Coil center radii
@@ -165,7 +169,7 @@ def test_flux_circular_filament_against_mutual_inductance_of_cylindrical_coils(r
     # Calculate mutual inductance between these two filaments
     f1 = np.array((r1, z1, n1))
     f2 = np.array((r2, z2, n2))
-    m_filaments = cfsem.mutual_inductance_of_cylindrical_coils(f1, f2)
+    m_filaments = cfsem.mutual_inductance_of_cylindrical_coils(f1, f2, par)
 
     # Calculate mutual inductance via python test calc
     # and test the mutual inductance of coils calc.
@@ -175,8 +179,8 @@ def test_flux_circular_filament_against_mutual_inductance_of_cylindrical_coils(r
     assert abs(1 - m_filaments / m_filaments_test) < 1e-6
 
     # Do flux calcs
-    psi_2to1 = np.sum(n1 * cfsem.flux_circular_filament(n2, r2, z2, r1, z1))
-    psi_1to2 = np.sum(n2 * cfsem.flux_circular_filament(n1, r1, z1, r2, z2))
+    psi_2to1 = np.sum(n1 * cfsem.flux_circular_filament(n2, r2, z2, r1, z1, par))
+    psi_1to2 = np.sum(n2 * cfsem.flux_circular_filament(n1, r1, z1, r2, z2, par))
 
     # Because the integrated poloidal flux at a given location is the same as mutual inductance,
     # we should get the same number using our mutual inductance calc
@@ -191,7 +195,8 @@ def test_flux_circular_filament_against_mutual_inductance_of_cylindrical_coils(r
 
 @mark.parametrize("r", [0.775, np.pi])
 @mark.parametrize("z", [0.0, np.e / 2, -np.e / 2])
-def test_flux_density_circular_filament_against_flux_circular_filament(r, z):
+@mark.parametrize("par", [True, False])
+def test_flux_density_circular_filament_against_flux_circular_filament(r, z, par):
     rzn1 = cfsem.filament_coil(r, z, 0.05, 0.05, 1.0, 4, 4)
     rfil, zfil, _ = rzn1.T
     ifil = np.ones_like(rfil)
@@ -204,7 +209,7 @@ def test_flux_density_circular_filament_against_flux_circular_filament(r, z):
     zprime = Z.flatten()
 
     Br, Bz = cfsem.flux_density_circular_filament(
-        ifil, rfil, zfil, rprime, zprime
+        ifil, rfil, zfil, rprime, zprime, par
     )  # [T]
 
     # We can also get B from the derivative of the flux function (Wesson eqn 3.2.2),
@@ -216,12 +221,12 @@ def test_flux_density_circular_filament_against_flux_circular_filament(r, z):
 
     dr = 1e-4
     dz = 1e-4
-    psi = cfsem.flux_circular_filament(ifil, rfil, zfil, rprime, zprime)
+    psi = cfsem.flux_circular_filament(ifil, rfil, zfil, rprime, zprime, par)
     dpsidz = (
-        cfsem.flux_circular_filament(ifil, rfil, zfil, rprime, zprime + dz) - psi
+        cfsem.flux_circular_filament(ifil, rfil, zfil, rprime, zprime + dz, par) - psi
     ) / dz
     dpsidr = (
-        cfsem.flux_circular_filament(ifil, rfil, zfil, rprime + dr, zprime) - psi
+        cfsem.flux_circular_filament(ifil, rfil, zfil, rprime + dr, zprime, par) - psi
     ) / dr
 
     Br_from_psi = -dpsidz / rprime / (2.0 * np.pi)  # [T]
@@ -232,7 +237,8 @@ def test_flux_density_circular_filament_against_flux_circular_filament(r, z):
 
 
 @mark.parametrize("r", [np.e / 100, 0.775, np.pi])
-def test_flux_density_circular_filament_against_ideal_solenoid(r):
+@mark.parametrize("par", [True, False])
+def test_flux_density_circular_filament_against_ideal_solenoid(r, par):
     # We can also check against the ideal solenoid calc to make sure we don't have a systematic
     # offset or scaling error
 
@@ -245,14 +251,15 @@ def test_flux_density_circular_filament_against_ideal_solenoid(r):
         current=1.0, num_turns=ifil.size, length=length
     )  # [T] ideal solenoid Bz at origin
     _, bz_origin = cfsem.flux_density_circular_filament(
-        ifil, rfil, zfil, np.zeros(1), np.zeros(1)
+        ifil, rfil, zfil, np.zeros(1), np.zeros(1), par
     )
 
     assert np.allclose(np.array([b_ideal]), bz_origin, rtol=1e-2)
 
 
 @mark.parametrize("r", [np.e / 100, 0.775, np.pi])
-def test_flux_density_circular_filament_against_ideal_loop(r):
+@mark.parametrize("par", [True, False])
+def test_flux_density_circular_filament_against_ideal_loop(r, par):
     # We can also check against an ideal current loop calc
     # http://hyperphysics.phy-astr.gsu.edu/hbase/magnetic/curloo.html
 
@@ -263,7 +270,7 @@ def test_flux_density_circular_filament_against_ideal_loop(r):
 
     b_ideal = cfsem.MU_0 * current / (2.0 * r)  # [T] ideal loop Bz at origin
     _, bz_origin = cfsem.flux_density_circular_filament(
-        ifil, rfil, zfil, np.zeros(1), np.zeros(1)
+        ifil, rfil, zfil, np.zeros(1), np.zeros(1), par
     )
 
     assert np.allclose(np.array([b_ideal]), bz_origin, rtol=1e-6)
@@ -271,7 +278,8 @@ def test_flux_density_circular_filament_against_ideal_loop(r):
 
 @mark.parametrize("a", [0.775, np.pi])
 @mark.parametrize("z", [0.0, np.e / 2, -np.e / 2])
-def test_flux_density_circular_filament_against_numerical(a, z):
+@mark.parametrize("par", [True, False])
+def test_flux_density_circular_filament_against_numerical(a, z, par):
     # Test the elliptic-integral calc for B-field of a loop against numerical integration
 
     n = 10
@@ -286,7 +294,7 @@ def test_flux_density_circular_filament_against_numerical(a, z):
 
     # Calc using elliptic integral fits
     Br, Bz = cfsem.flux_density_circular_filament(
-        np.array([I]), np.array([a]), np.array([z]), rprime, zprime
+        np.array([I]), np.array([a]), np.array([z]), rprime, zprime, par
     )  # [T]
 
     # Calc using numerical integration around the loop
@@ -302,7 +310,8 @@ def test_flux_density_circular_filament_against_numerical(a, z):
     assert np.allclose(Bz, Bz_num)
 
 
-def test_self_inductance_lyle6_against_filamentization_and_distributed():
+@mark.parametrize("par", [True, False])
+def test_self_inductance_lyle6_against_filamentization_and_distributed(par):
     # Test that the Lyle approximation gives a similar result to
     # a case done by brute-force filamentization w/ a heuristic for self-inductance of a loop
     r, z, dr, dz, nt, nr, nz = (0.8, 0.0, 0.5, 2.0, 3.0, 20, 20)
@@ -323,11 +332,11 @@ def test_self_inductance_lyle6_against_filamentization_and_distributed():
     #  Do filamentized psi and B calcs for convenience,
     #  although ideally we'd do a grad-shafranov solve here for a smoother field
     psi = cfsem.flux_circular_filament(
-        current, rfil, zfil, rmesh.flatten(), zmesh.flatten()
+        current, rfil, zfil, rmesh.flatten(), zmesh.flatten(), par
     )
     psi = psi.reshape(rmesh.shape)
     br, bz = cfsem.flux_density_circular_filament(
-        current, rfil, zfil, rmesh.flatten(), zmesh.flatten()
+        current, rfil, zfil, rmesh.flatten(), zmesh.flatten(), par
     )
     br = br.reshape(rmesh.shape)
     bz = bz.reshape(rmesh.shape)
@@ -505,3 +514,77 @@ def test_self_inductance_annular_ring(major_radius, a, b):
     with raises(ValueError):
         # Larger outer than major
         cfsem.self_inductance_annular_ring(0.1, 0.01, 0.11)
+
+
+@mark.parametrize("r", [0.775, 1.51])
+@mark.parametrize("z", [0.0, np.pi])
+@mark.parametrize("par", [True, False])
+def test_vector_potential_axisymmetric(r, z, par):
+    # Spot-check vector potential against inductance calcs.
+    # More detailed three-way tests against both B-field and inductance
+    # are done in the Rust library.
+
+    # Filament
+    ifil = np.atleast_1d([1.0])  # [A] 1A total reference current
+    rfil = np.atleast_1d([r])
+    zfil = np.atleast_1d([z])
+
+    # Observation points
+    rgrid = np.arange(0.5, 2.0, 0.05)
+    zgrid = np.arange(-3.0, 3.0, 0.05)
+    rmesh, zmesh = np.meshgrid(rgrid, zgrid, indexing="ij")
+
+    psi = cfsem.flux_circular_filament(
+        ifil, rfil, zfil, rmesh.flatten(), zmesh.flatten(), par
+    )
+    a_phi = cfsem.vector_potential_circular_filament(
+        ifil, rfil, zfil, rmesh.flatten(), zmesh.flatten(), par
+    )
+
+    # Integrate vector potential around a loop to get the flux
+    psi_from_a = 2.0 * np.pi * rmesh.flatten() * a_phi  # [Wb]
+
+    # We should not be able to tell the difference above a single roundoff
+    assert np.allclose(psi, psi_from_a, rtol=1e-16, atol=1e-16)
+
+
+@mark.parametrize("r", [0.775, np.pi])
+@mark.parametrize("z", [0.0, np.e / 2, -np.e / 2])
+@mark.parametrize("par", [True, False])
+def test_vector_potential_linear_against_circular_filament(r, z, par):
+    # Note we are mapping between (x, y, z) and (r, phi, z) coordinates here
+
+    # Biot-Savart filaments in cartesian coords
+    n_filaments = int(1e4)
+    phi = np.linspace(0.0, 2.0 * np.pi, n_filaments)
+    xfils = r * np.cos(phi)
+    yfils = r * np.sin(phi)
+    zfils = np.ones_like(xfils) * z
+
+    # Observation grid
+    rs = np.linspace(0.01, r - 0.1, 10)
+    zs = np.linspace(-1.0, 1.0, 10)
+
+    rmesh, zmesh = np.meshgrid(rs, zs, indexing="ij")
+    rprime = rmesh.flatten()
+    zprime = zmesh.flatten()
+
+    # Circular filament calc
+    a_phi = cfsem.vector_potential_circular_filament(
+        np.ones(1), np.array([r]), np.array([z]), rprime, zprime, par
+    )  # [V-s/m]
+
+    # Biot-Savart calc
+    xyzp = (rprime, np.zeros_like(zprime), zprime)
+    xyzfil = (xfils[1:], yfils[1:], zfils[1:])
+    dlxyzfil = (xfils[1:] - xfils[:-1], yfils[1:] - yfils[:-1], zfils[1:] - zfils[:-1])
+    ifil = np.ones_like(xfils[1:])
+    ax, ay, az = cfsem.vector_potential_linear_filament(
+        xyzp, xyzfil, dlxyzfil, ifil, par
+    )  # [T]
+
+    assert np.allclose(a_phi, ay, rtol=1e-12, atol=1e-12)  # Should match circular calc
+    assert np.allclose(
+        az, np.zeros_like(az), atol=1e-9
+    )  # Should sum to zero everywhere
+    assert np.allclose(ax, np.zeros_like(ax), atol=1e-9)  # ...


### PR DESCRIPTION
## 2.1.0 2024-08-27

### Added

* Add vector potential calcs for linear and circular filaments
* Add parallel options for circular-filament calcs
* Add parametrization of unit tests over parallel and serial variants
* Add optional parallel flags to functions that use functions with new parallel options