### PR TITLE
Use ternaries for array defaulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.3 2025-11-06
+
+### Changed
+
+* Use ternary instead of or-defaulting for array defaults in dipole functions
+    * Eliminates issue with ambiguous truthiness of arrays under some circumstances
+
 ## 3.0.2 2025-11-05
 
 ### Changed

--- a/cfsem/bindings.py
+++ b/cfsem/bindings.py
@@ -492,7 +492,7 @@ def flux_density_dipole(
     loc = _3tup_contig(loc)
     moment = _3tup_contig(moment)
     xyzp = _3tup_contig(xyzp)
-    outer_radius = outer_radius or zeros_like(loc[0])
+    outer_radius = outer_radius if outer_radius is not None else zeros_like(loc[0])
     outer_radius = ascontiguousarray(outer_radius).ravel()
 
     bx, by, bz = em_flux_density_dipole(loc, moment, xyzp, outer_radius, par)  # [T]
@@ -523,7 +523,7 @@ def vector_potential_dipole(
     loc = _3tup_contig(loc)
     moment = _3tup_contig(moment)
     xyzp = _3tup_contig(xyzp)
-    outer_radius = outer_radius or zeros_like(loc[0])
+    outer_radius = outer_radius if outer_radius is not None else zeros_like(loc[0])
     outer_radius = ascontiguousarray(outer_radius).ravel()
 
     ax, ay, az = em_vector_potential_dipole(loc, moment, xyzp, outer_radius, par)  # [T]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cfsem"
-version = "3.0.2"
+version = "3.0.3"
 description = "Quasi-steady electromagnetics including filamentized approximations, Biot-Savart, and Grad-Shafranov."
 authors = [{name = "Commonwealth Fusion Systems", email = "jlogan@cfs.energy"}]
 requires-python = ">=3.10, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "cfsem"
-version = "3.0.2"
+version = "3.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "findiff" },


### PR DESCRIPTION
## 3.0.3 2025-11-06

### Changed

* Use ternary instead of or-defaulting for array defaults in dipole functions
    * Eliminates issue with ambiguous truthiness of arrays under some circumstances
