### PR TITLE
Generalize 2D FEM to plane strain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 6.0.0 2026-04-24
+
+### Changed
+
+* Rust
+    * !Generalize axisymmetric stress solver to cover both axisymmetric and plane-strain
+    * !Rename items from "axisymmetric" to indicate more general usage
+* Python
+    * !Rename axisymmetric_fem module to fem2d
+    * !Update FEM bindings to match changes to Rust backend
+    * Add handling for explicit 9-point quad mesh input
+
+
 ## 5.4.0 2026-04-24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfsem"
-version = "5.4.0"
+version = "6.0.0"
 dependencies = [
  "branches",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfsem"
-version = "5.4.0"
+version = "6.0.0"
 edition = "2024"
 authors = ["Commonwealth Fusion Systems <jlogan@cfs.energy>"]
 license = "MIT"

--- a/cfsem/solenoid_stress/__init__.py
+++ b/cfsem/solenoid_stress/__init__.py
@@ -3,7 +3,7 @@
 This subpackage includes three complementary toolsets:
 
 - a 1D finite-difference radial stress solver for deck-of-cards winding-pack models,
-- a 2D axisymmetric quadrilateral FEM implementation centered on reusable sparse load and
+- a 2D quadrilateral FEM implementation centered on reusable sparse load and
   recovery operators, with convenience methods for `build_rhs(...)`, `solve(...)`, and
   quadrature-field recovery,
 - analytic reference formulas used for validation and convergence studies.
@@ -21,35 +21,41 @@ from .thick_wall_cylinder_handcalc import (
     s_hoop_thick_wall_cylinder,
     s_radial_thick_wall_cylinder,
 )
-from .axisymmetric_fem import (
-    AxisymmetricFEMModel,
+from .fem2d import (
     ElementMeasures,
     ElementQuadrature,
     ElevatedQuad9Mesh,
     QuadratureFieldSamples,
-    assemble_axisymmetric,
+    Structural2DFEMModel,
+    assemble_structural_2d,
     cfsem_radial_material,
     infer_quad9_mesh,
     isotropic_axisymmetric_material,
     isotropic_axisymmetric_thermal_material,
+    isotropic_plane_strain_material,
+    isotropic_plane_strain_thermal_material,
     orthotropic_axisymmetric_thermal_material,
+    orthotropic_plane_strain_thermal_material,
     pack_material_tables_from_tags,
 )
 
 __all__ = [
-    "AxisymmetricFEMModel",
     "ElementMeasures",
     "ElementQuadrature",
     "ElevatedQuad9Mesh",
     "QuadratureFieldSamples",
     "SolenoidStress1D",
     "SolenoidStress1DOperators",
-    "assemble_axisymmetric",
+    "Structural2DFEMModel",
+    "assemble_structural_2d",
     "cfsem_radial_material",
     "infer_quad9_mesh",
     "isotropic_axisymmetric_material",
     "isotropic_axisymmetric_thermal_material",
+    "isotropic_plane_strain_material",
+    "isotropic_plane_strain_thermal_material",
     "orthotropic_axisymmetric_thermal_material",
+    "orthotropic_plane_strain_thermal_material",
     "pack_material_tables_from_tags",
     "s_hoop_thick_wall_cylinder",
     "s_long_solenoid",

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -1,43 +1,8 @@
-"""
-2D-axisymmetric elasticity finite-element assembly for solenoid stress problems.
+"""2D structural elasticity finite-element assembly.
 
-This module provides a small displacement-based axisymmetric finite-element solver
-for the `(r, z)` meridian plane. The primary backend abstraction is an assembled,
-reusable model that stores sparse load operators, sparse quadrature-recovery
-operators, and the reduced stiffness matrix. The Rust backend also caches the LU
-factorization and provides shared material, mesh-elevation, and quadrature-recovery
-conveniences. Python wraps that model, normalizes NumPy-facing inputs, and reshapes
-the returned arrays.
-
-The element formulation follows the standard small-strain Galerkin construction
-
-`K_e = integral(B^T D B 2*pi*r dA)`
-
-with consistent body-force, surface-pressure, and surface-traction load vectors. The axisymmetric
-engineering-strain vector is ordered as `[e_rr, e_zz, e_tt, g_rz]`. In Bower's terminology, the
-underlying equations are the strain-displacement equation, the elastic stress-strain law, the
-equation of static equilibrium for stresses, and the boundary conditions on displacement and
-stress.
-
-References:
-    [1] Allan F. Bower,
-        *Applied Mechanics of Solids*,
-        CRC Press, 2009.
-        See especially Section 8.1 and Table 8.3 for the general displacement-based
-        finite-element construction and 2D interpolation functions.
-
-    [2] E. L. Wilson,
-        "Structural Analysis of Axisymmetric Solids,"
-        *AIAA Journal*, 3(12), pp. 2269-2274, 1965.
-
-    [3] R. A. Mitchell, R. M. Woolley, and C. R. Fisher,
-        "Formulation and experimental verification of an axisymmetric finite-element structural
-        analysis,"
-        *Journal of Research of the National Bureau of Standards Section C*, 75C, 1971.
-
-    [4] I. Fried,
-        "Notes on the finite element analysis of the axisymmetric elastic solid,"
-        *International Journal of Solids and Structures*, 10(3), 1974.
+This module provides a small displacement-based quadrilateral FEM solver for axisymmetric and
+plane-strain structural reductions. The backend stores sparse load operators, sparse
+quadrature-recovery operators, and a reduced stiffness matrix for repeated load solves.
 """
 
 from __future__ import annotations
@@ -52,19 +17,27 @@ import scipy.sparse as sp
 
 import cfsem.cfsem as _cfsem_bindings
 
-_assemble_model_axisymmetric_f32 = _cfsem_bindings.solenoid_stress_fem_assemble_model_axisymmetric_f32
-_assemble_model_axisymmetric_f64 = _cfsem_bindings.solenoid_stress_fem_assemble_model_axisymmetric_f64
+_assemble_model_2d_f32 = _cfsem_bindings.solenoid_stress_fem_assemble_model_2d_f32
+_assemble_model_2d_f64 = _cfsem_bindings.solenoid_stress_fem_assemble_model_2d_f64
 _cfsem_radial_material_f32 = _cfsem_bindings.solenoid_stress_fem_cfsem_radial_material_f32
 _cfsem_radial_material_f64 = _cfsem_bindings.solenoid_stress_fem_cfsem_radial_material_f64
 _infer_quad9_mesh_f32 = _cfsem_bindings.solenoid_stress_fem_infer_quad9_mesh_f32
 _infer_quad9_mesh_f64 = _cfsem_bindings.solenoid_stress_fem_infer_quad9_mesh_f64
 _isotropic_axisymmetric_material_f32 = _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_material_f32
 _isotropic_axisymmetric_material_f64 = _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_material_f64
+_isotropic_plane_strain_material_f32 = _cfsem_bindings.solenoid_stress_fem_isotropic_plane_strain_material_f32
+_isotropic_plane_strain_material_f64 = _cfsem_bindings.solenoid_stress_fem_isotropic_plane_strain_material_f64
 _isotropic_axisymmetric_thermal_material_f32 = (
     _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f32
 )
 _isotropic_axisymmetric_thermal_material_f64 = (
     _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f64
+)
+_isotropic_plane_strain_thermal_material_f32 = (
+    _cfsem_bindings.solenoid_stress_fem_isotropic_plane_strain_thermal_material_f32
+)
+_isotropic_plane_strain_thermal_material_f64 = (
+    _cfsem_bindings.solenoid_stress_fem_isotropic_plane_strain_thermal_material_f64
 )
 _orthotropic_axisymmetric_thermal_material_f32 = (
     _cfsem_bindings.solenoid_stress_fem_orthotropic_axisymmetric_thermal_material_f32
@@ -137,27 +110,27 @@ def _csc_matrix_from_binding(
 
 @dataclass(frozen=True, slots=True)
 class ElementMeasures:
-    """Per-element meridian area and swept volume.
+    """Per-element cross-section area and represented volume.
 
-    `areas` and `swept_volumes` both have shape `(nelem,)`.
-    `areas` has units `[area]` and `swept_volumes` has units `[volume]`.
+    `areas` and `volumes` both have shape `(nelem,)`.
+    `areas` has units `[area]` and `volumes` has units `[volume]`.
     """
 
     areas: npt.NDArray[np.floating[Any]]
-    swept_volumes: npt.NDArray[np.floating[Any]]
+    volumes: npt.NDArray[np.floating[Any]]
 
 
 @dataclass(frozen=True, slots=True)
 class ElementQuadrature:
     """Per-element physical quadrature points and mapped weights.
 
-    `points_rz` has shape `(nelem, nq_per_element, 2)`.
+    `points` has shape `(nelem, nq_per_element, 2)`.
     `weights_area` and `weights_volume` have shape `(nelem, nq_per_element)`.
-    `points_rz` has units `[length]`, `weights_area` has units `[area]`, and
+    `points` has units `[length]`, `weights_area` has units `[area]`, and
     `weights_volume` has units `[volume]`.
     """
 
-    points_rz: npt.NDArray[np.floating[Any]]
+    points: npt.NDArray[np.floating[Any]]
     weights_area: npt.NDArray[np.floating[Any]]
     weights_volume: npt.NDArray[np.floating[Any]]
     nq_per_element: int
@@ -184,8 +157,8 @@ class ElevatedQuad9Mesh:
     center_node_indices: npt.NDArray[np.int64]
 
 
-class AxisymmetricFEMModel:
-    """Reusable axisymmetric FEM model with sparse operators and reduced solve state.
+class Structural2DFEMModel:
+    """Reusable 2D structural FEM model with sparse operators and reduced solve state.
 
     The stored sparse operators are the primary reusable objects:
     - `body_force_to_rhs`, `pressure_to_rhs`, `traction_to_rhs`, and `temperature_to_rhs`
@@ -224,6 +197,7 @@ class AxisymmetricFEMModel:
         elevated: ElevatedQuad9Mesh | None,
         pressure_faces: npt.NDArray[np.uint64],
         traction_faces: npt.NDArray[np.uint64],
+        formulation: str,
         element_type: str,
         stiffness: sp.csc_matrix,
         body_force_to_rhs: sp.csr_matrix,
@@ -231,7 +205,7 @@ class AxisymmetricFEMModel:
         traction_to_rhs: sp.csr_matrix,
         temperature_to_rhs: sp.csr_matrix,
         constant_rhs: npt.NDArray[np.floating[Any]],
-        quadrature_points_rz: npt.NDArray[np.floating[Any]],
+        quadrature_points: npt.NDArray[np.floating[Any]],
         strain_operator: sp.csr_matrix,
         stress_operator: sp.csr_matrix,
         thermal_strain_operator: sp.csr_matrix,
@@ -264,7 +238,7 @@ class AxisymmetricFEMModel:
         self.traction_faces = traction_faces
         self.analysis_nodes = analysis_nodes
         self.analysis_elements = analysis_elements
-        self.quadrature_points_rz = quadrature_points_rz
+        self.quadrature_points = quadrature_points
         self.strain_operator = strain_operator
         self.stress_operator = stress_operator
         self.thermal_strain_operator = thermal_strain_operator
@@ -276,7 +250,18 @@ class AxisymmetricFEMModel:
         self.free_dofs = free_dofs
         self.fixed_dofs = fixed_dofs
         self.fixed_values = fixed_values
+        self.formulation = formulation
         self.element_type = element_type
+        if formulation == "axisymmetric":
+            self.coordinate_labels = ("r", "z")
+            self.displacement_labels = ("u_r", "u_z")
+            self.tensor_labels = ("rr", "zz", "tt", "rz")
+            self.measure_label = "swept_volume"
+        else:
+            self.coordinate_labels = ("x", "y")
+            self.displacement_labels = ("u_x", "u_y")
+            self.tensor_labels = ("xx", "yy", "zz", "xy")
+            self.measure_label = "volume"
         self.ndof_full = int(ndof_full)
         self.ndof_reduced = int(ndof_reduced)
         self.nelem = int(nelem)
@@ -314,7 +299,7 @@ class AxisymmetricFEMModel:
 
         Returns:
             ElementQuadrature: Quadrature data with:
-                `points_rz` of shape `(nelem, nq_per_element, 2)` and units `[length]`,
+                `points` of shape `(nelem, nq_per_element, 2)` and units `[length]`,
                 `weights_area` of shape `(nelem, nq_per_element)` and units `[area]`,
                 `weights_volume` of shape `(nelem, nq_per_element)` and units `[volume]`.
         """
@@ -324,11 +309,11 @@ class AxisymmetricFEMModel:
             return cache
         points_flat, weights_area_flat, weights_volume_flat, nq = self._backend.element_quadrature()
         nelem = self.analysis_elements.shape[0]
-        points_rz = np.asarray(points_flat, dtype=self.dtype).reshape(nelem, int(nq), 2)
+        points = np.asarray(points_flat, dtype=self.dtype).reshape(nelem, int(nq), 2)
         weights_area = np.asarray(weights_area_flat, dtype=self.dtype).reshape(nelem, int(nq))
         weights_volume = np.asarray(weights_volume_flat, dtype=self.dtype).reshape(nelem, int(nq))
         cache = ElementQuadrature(
-            points_rz=points_rz,
+            points=points,
             weights_area=weights_area,
             weights_volume=weights_volume,
             nq_per_element=int(nq),
@@ -337,21 +322,21 @@ class AxisymmetricFEMModel:
         return cache
 
     def element_measures(self) -> ElementMeasures:
-        """Return meridian area and swept volume for each element.
+        """Return cross-section area and represented volume for each element.
 
         Returns:
             ElementMeasures: Per-element measures with:
                 `areas` of shape `(nelem,)` and units `[area]`,
-                `swept_volumes` of shape `(nelem,)` and units `[volume]`.
+                `volumes` of shape `(nelem,)` and units `[volume]`.
         """
 
         cache = self._element_measures_cache
         if cache is not None:
             return cache
-        areas, swept_volumes = self._backend.element_measures()
+        areas, volumes = self._backend.element_measures()
         cache = ElementMeasures(
             areas=np.asarray(areas, dtype=self.dtype),
-            swept_volumes=np.asarray(swept_volumes, dtype=self.dtype),
+            volumes=np.asarray(volumes, dtype=self.dtype),
         )
         self._element_measures_cache = cache
         return cache
@@ -483,7 +468,7 @@ class AxisymmetricFEMModel:
 
         Returns:
             QuadratureFieldSamples: Recovered quadrature fields where:
-                `points_rz` has shape `(nelem, nq_per_element, 2)` and units `[length]`,
+                `points` has shape `(nelem, nq_per_element, 2)` and units `[length]`,
                 `strain`, `thermal_strain`, and `elastic_strain` have shape
                 `(nelem, nq_per_element, 4)` and units `[strain]`,
                 `stress` has shape `(nelem, nq_per_element, 4)` and units `[stress]`.
@@ -511,7 +496,7 @@ class AxisymmetricFEMModel:
         nelem = self.analysis_elements.shape[0]
         nq = int(nq)
         return QuadratureFieldSamples(
-            points_rz=np.asarray(points_flat, dtype=self.dtype).reshape(nelem, nq, 2),
+            points=np.asarray(points_flat, dtype=self.dtype).reshape(nelem, nq, 2),
             strain=np.asarray(strain_flat, dtype=self.dtype).reshape(nelem, nq, 4),
             thermal_strain=np.asarray(thermal_strain_flat, dtype=self.dtype).reshape(nelem, nq, 4),
             elastic_strain=np.asarray(elastic_strain_flat, dtype=self.dtype).reshape(nelem, nq, 4),
@@ -524,12 +509,12 @@ class QuadratureFieldSamples:
     """Recovered strain and stress at element quadrature points.
 
     Each field has shape `(nelem, nq_per_element, 4)` with component ordering
-    `[rr, zz, tt, rz]`. `points_rz` has shape `(nelem, nq_per_element, 2)`.
-    `points_rz` has units `[length]`, `strain`, `thermal_strain`, and `elastic_strain`
+    `[rr, zz, tt, rz]`. `points` has shape `(nelem, nq_per_element, 2)`.
+    `points` has units `[length]`, `strain`, `thermal_strain`, and `elastic_strain`
     have units `[strain]`, and `stress` has units `[stress]`.
     """
 
-    points_rz: npt.NDArray[np.floating[Any]]
+    points: npt.NDArray[np.floating[Any]]
     strain: npt.NDArray[np.floating[Any]]
     thermal_strain: npt.NDArray[np.floating[Any]]
     elastic_strain: npt.NDArray[np.floating[Any]]
@@ -557,6 +542,53 @@ def _normalize_element_type(element_type: str) -> str:
         "quad9",
     }, f"unsupported element_type {element_type!r}; use 'quad4' or 'quad9'"
     return normalized
+
+
+def _normalize_formulation(formulation: str) -> str:
+    normalized = str(formulation).strip().lower()
+    assert normalized in {
+        "axisymmetric",
+        "plane_strain",
+    }, f"unsupported formulation {formulation!r}; use 'axisymmetric' or 'plane_strain'"
+    return normalized
+
+
+def _formulation_code(formulation: str) -> int:
+    if formulation == "axisymmetric":
+        return 0
+    if formulation == "plane_strain":
+        return 1
+    raise ValueError(f"unsupported formulation {formulation!r}")
+
+
+def _normalize_thickness(
+    formulation: str,
+    thickness: float | None,
+    dtype: np.dtype[Any],
+) -> np.floating[Any]:
+    if formulation == "axisymmetric":
+        assert thickness is None, "thickness is only valid for formulation='plane_strain'"
+        return np.asarray(0.0, dtype=dtype)[()]
+    assert thickness is not None, "thickness is required for formulation='plane_strain'"
+    value = np.asarray(thickness, dtype=dtype)[()]
+    assert value > 0.0, f"thickness must be positive; got {thickness!r}"
+    return value
+
+
+def _normalize_material_orientation_angles(
+    material_orientation_angles: ArrayLike | None,
+    nelem: int,
+    dtype: np.dtype[Any],
+) -> npt.NDArray[np.floating[Any]]:
+    if material_orientation_angles is None:
+        return np.zeros((0,), dtype=dtype)
+    angles = np.asarray(material_orientation_angles, dtype=dtype)
+    if angles.ndim == 0:
+        angles = np.broadcast_to(angles, (nelem,)).copy()
+    assert angles.ndim == 1 and angles.shape[0] == nelem, (
+        f"material_orientation_angles must be a scalar or have shape ({nelem},); " f"got {angles.shape}"
+    )
+    return np.ascontiguousarray(angles)
 
 
 def _resolve_float_dtype(*values: object) -> np.dtype[np.float32] | np.dtype[np.float64]:
@@ -716,8 +748,7 @@ def _normalize_thermal_material_table(
     assert ids.ndim == 1, f"material_ids must have shape (nelem,); got {ids.shape}"
     assert not isinstance(
         thermal_material_table, Mapping
-    ), "thermal_material_table must be a dense array; use pack_material_tables_from_tags(...)"
-    " for tagged inputs"
+    ), "thermal_material_table must be a dense array; use pack_material_tables_from_tags(...) for tagged inputs"
     table = np.asarray(thermal_material_table, dtype=dtype)
     assert (
         table.ndim == 2 and table.shape[1] == 5
@@ -912,28 +943,38 @@ def _dispatch_pair(dtype: np.dtype[Any], f32: Any, f64: Any) -> Any:
     return f64
 
 
-def assemble_axisymmetric(
+def assemble_structural_2d(
     nodes: ArrayLike,
     elements: ArrayLike,
     material_ids: ArrayLike,
     material_table: ArrayLike,
+    *,
+    formulation: str = "axisymmetric",
+    thickness: float | None = None,
+    material_orientation_angles: ArrayLike | None = None,
     pressure_faces: ArrayLike | None = None,
     traction_faces: ArrayLike | None = None,
     thermal_material_table: ArrayLike | None = None,
     prescribed: Mapping[int, float] | None = None,
     quadrature: str | int = "gl3",
     element_type: str = "quad4",
-) -> AxisymmetricFEMModel:
-    """Assemble the reusable axisymmetric FEM model.
+) -> Structural2DFEMModel:
+    """Assemble the reusable 2D structural FEM model.
 
     Args:
-        nodes: Corner-node coordinates with shape `(nnode, 2)` in `(r, z)` order. Units are
-            `[length]`.
+        nodes: Corner-node coordinates with shape `(nnode, 2)`. Coordinates are `(r, z)` for
+            `formulation="axisymmetric"` and `(x, y)` for `formulation="plane_strain"`.
+            Units are `[length]`.
         elements: Quad4 connectivity with shape `(nelem, 4)`. Corner nodes must be ordered
-            counter-clockwise in the `(r, z)` meridian plane.
+            counter-clockwise in the 2D analysis plane.
         material_ids: Dense material row indices with shape `(nelem,)`.
         material_table: Elastic stress-strain matrices with shape `(nmat, 4, 4)`. Matrix units
             are `[stress / strain] = [pressure]`.
+        formulation: Symmetry reduction, either `"axisymmetric"` or `"plane_strain"`.
+        thickness: Plane-strain out-of-plane thickness. Required only for
+            `formulation="plane_strain"`.
+        material_orientation_angles: Optional scalar or per-element angles, in radians, rotating
+            local material axes into the global 2D frame before assembly.
         pressure_faces: Optional pressure-load topology with shape `(n_pressure_faces, 2)`. Each
             row is `[element_index, local_face]`.
         traction_faces: Optional traction-load topology with shape `(n_traction_faces, 2)`. Each
@@ -947,7 +988,7 @@ def assemble_axisymmetric(
         element_type: Analysis element family, either `quad4` or `quad9`.
 
     Returns:
-        AxisymmetricFEMModel: Reusable model storing the reduced stiffness matrix, sparse load
+        Structural2DFEMModel: Reusable model storing the reduced stiffness matrix, sparse load
         operators, sparse quadrature-recovery operators, and cached solve state.
 
     Raises:
@@ -969,16 +1010,23 @@ def assemble_axisymmetric(
     traction_faces_arr = _normalize_face_pairs("traction_faces", traction_faces)
     prescribed_dofs, prescribed_values = _normalize_prescribed_dirichlet(prescribed, dtype)
     quadrature_code = _quadrature_code(quadrature)
+    normalized_formulation = _normalize_formulation(formulation)
+    thickness_value = _normalize_thickness(normalized_formulation, thickness, dtype)
     normalized_element_type = _normalize_element_type(element_type)
     if normalized_element_type == "quad4":
         analysis_nodes, analysis_elements, elevated = nodes_arr, elements_arr, None
     else:
         elevated = infer_quad9_mesh(nodes_arr, elements_arr)
         analysis_nodes, analysis_elements = elevated.analysis_nodes, elevated.analysis_elements
+    material_orientation_angles_arr = _normalize_material_orientation_angles(
+        material_orientation_angles,
+        int(analysis_elements.shape[0]),
+        dtype,
+    )
     low_level = _dispatch_pair(
         dtype,
-        _assemble_model_axisymmetric_f32,
-        _assemble_model_axisymmetric_f64,
+        _assemble_model_2d_f32,
+        _assemble_model_2d_f64,
     )
     backend = low_level(
         analysis_nodes,
@@ -988,9 +1036,12 @@ def assemble_axisymmetric(
         pressure_faces_arr,
         traction_faces_arr,
         np.zeros((0, 5), dtype=dtype) if thermal_material_table_arr is None else thermal_material_table_arr,
+        material_orientation_angles_arr,
         prescribed_dofs,
         prescribed_values,
         4 if normalized_element_type == "quad4" else 9,
+        _formulation_code(normalized_formulation),
+        thickness_value,
         quadrature_code,
     )
 
@@ -1026,7 +1077,7 @@ def assemble_axisymmetric(
             thermal_stress_operator = _to_csr_matrix(analysis_thermal_stress_operator @ temperature_elevation)
         n_temperature_nodes = nodes_arr.shape[0]
 
-    return AxisymmetricFEMModel(
+    return Structural2DFEMModel(
         backend=backend,
         dtype=dtype,
         input_nodes=nodes_arr,
@@ -1036,6 +1087,7 @@ def assemble_axisymmetric(
         elevated=elevated,
         pressure_faces=pressure_faces_arr,
         traction_faces=traction_faces_arr,
+        formulation=normalized_formulation,
         element_type=normalized_element_type,
         stiffness=stiffness,
         body_force_to_rhs=body_force_to_rhs,
@@ -1043,7 +1095,7 @@ def assemble_axisymmetric(
         traction_to_rhs=traction_to_rhs,
         temperature_to_rhs=_to_csr_matrix(temperature_to_rhs),
         constant_rhs=np.asarray(backend.constant_rhs(), dtype=dtype),
-        quadrature_points_rz=np.asarray(
+        quadrature_points=np.asarray(
             backend.quadrature_points_flat(),
             dtype=dtype,
         ).reshape(analysis_elements.shape[0], int(backend.nq_per_element), 2),
@@ -1119,6 +1171,38 @@ def isotropic_axisymmetric_thermal_material(
     return _as_float_array(binding(alpha, reference_temperature), resolved_dtype)
 
 
+def isotropic_plane_strain_material(
+    youngs_modulus: float,
+    poisson_ratio: float,
+    dtype: npt.DTypeLike = np.float64,
+) -> npt.NDArray[np.floating[Any]]:
+    """Construct the isotropic plane-strain elastic stress-strain matrix."""
+
+    resolved_dtype = np.dtype(dtype)
+    binding = _dispatch_pair(
+        resolved_dtype,
+        _isotropic_plane_strain_material_f32,
+        _isotropic_plane_strain_material_f64,
+    )
+    return _as_float_array(binding(youngs_modulus, poisson_ratio), resolved_dtype).reshape(4, 4)
+
+
+def isotropic_plane_strain_thermal_material(
+    alpha: float,
+    reference_temperature: float = 0.0,
+    dtype: npt.DTypeLike = np.float64,
+) -> npt.NDArray[np.floating[Any]]:
+    """Construct isotropic plane-strain thermal-expansion data."""
+
+    resolved_dtype = np.dtype(dtype)
+    binding = _dispatch_pair(
+        resolved_dtype,
+        _isotropic_plane_strain_thermal_material_f32,
+        _isotropic_plane_strain_thermal_material_f64,
+    )
+    return _as_float_array(binding(alpha, reference_temperature), resolved_dtype)
+
+
 def orthotropic_axisymmetric_thermal_material(
     alpha_r: float,
     alpha_z: float,
@@ -1148,6 +1232,24 @@ def orthotropic_axisymmetric_thermal_material(
         _orthotropic_axisymmetric_thermal_material_f64,
     )
     return _as_float_array(binding(alpha_r, alpha_z, alpha_t, reference_temperature), resolved_dtype)
+
+
+def orthotropic_plane_strain_thermal_material(
+    alpha_x: float,
+    alpha_y: float,
+    alpha_z: float,
+    reference_temperature: float = 0.0,
+    dtype: npt.DTypeLike = np.float64,
+) -> npt.NDArray[np.floating[Any]]:
+    """Construct orthotropic plane-strain thermal-expansion data."""
+
+    return orthotropic_axisymmetric_thermal_material(
+        alpha_x,
+        alpha_y,
+        alpha_z,
+        reference_temperature,
+        dtype,
+    )
 
 
 def cfsem_radial_material(
@@ -1190,16 +1292,19 @@ def _normalize_displacements(
 
 
 __all__ = [
-    "AxisymmetricFEMModel",
+    "Structural2DFEMModel",
     "ElementMeasures",
     "ElementQuadrature",
     "ElevatedQuad9Mesh",
     "QuadratureFieldSamples",
-    "assemble_axisymmetric",
+    "assemble_structural_2d",
     "cfsem_radial_material",
     "infer_quad9_mesh",
     "isotropic_axisymmetric_material",
     "isotropic_axisymmetric_thermal_material",
+    "isotropic_plane_strain_material",
+    "isotropic_plane_strain_thermal_material",
     "orthotropic_axisymmetric_thermal_material",
+    "orthotropic_plane_strain_thermal_material",
     "pack_material_tables_from_tags",
 ]

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -612,9 +612,16 @@ def _normalize_nodes(nodes: ArrayLike, dtype: np.dtype[Any]) -> npt.NDArray[np.f
     return np.ascontiguousarray(arr)
 
 
-def _normalize_elements(elements: ArrayLike) -> npt.NDArray[np.uint64]:
+def _normalize_elements(
+    elements: ArrayLike,
+    nodes_per_element: int | tuple[int, ...] = 4,
+) -> npt.NDArray[np.uint64]:
     arr = np.asarray(elements, dtype=np.uint64)
-    assert arr.ndim == 2 and arr.shape[1] == 4, f"elements must have shape (nelem, 4); got {arr.shape}"
+    expected = (nodes_per_element,) if isinstance(nodes_per_element, int) else nodes_per_element
+    expected_text = " or ".join(f"(nelem, {count})" for count in expected)
+    assert (
+        arr.ndim == 2 and arr.shape[1] in expected
+    ), f"elements must have shape {expected_text}; got {arr.shape}"
     return np.ascontiguousarray(arr)
 
 
@@ -746,9 +753,10 @@ def _normalize_thermal_material_table(
         return None
     ids = np.asarray(material_ids, dtype=np.uint64)
     assert ids.ndim == 1, f"material_ids must have shape (nelem,); got {ids.shape}"
-    assert not isinstance(
-        thermal_material_table, Mapping
-    ), "thermal_material_table must be a dense array; use pack_material_tables_from_tags(...) for tagged inputs"
+    assert not isinstance(thermal_material_table, Mapping), (
+        "thermal_material_table must be a dense array; use pack_material_tables_from_tags(...) "
+        "for tagged inputs"
+    )
     table = np.asarray(thermal_material_table, dtype=dtype)
     assert (
         table.ndim == 2 and table.shape[1] == 5
@@ -965,8 +973,11 @@ def assemble_structural_2d(
         nodes: Corner-node coordinates with shape `(nnode, 2)`. Coordinates are `(r, z)` for
             `formulation="axisymmetric"` and `(x, y)` for `formulation="plane_strain"`.
             Units are `[length]`.
-        elements: Quad4 connectivity with shape `(nelem, 4)`. Corner nodes must be ordered
-            counter-clockwise in the 2D analysis plane.
+        elements: Connectivity with shape `(nelem, 4)` for `element_type="quad4"`. For
+            `element_type="quad9"`, pass either corner-only `(nelem, 4)` connectivity to infer a
+            straight-sided quad9 mesh, or explicit `(nelem, 9)` connectivity in local order
+            `[corner0, corner1, corner2, corner3, face0_mid, face1_mid, face2_mid, face3_mid,
+            center]`. Corner nodes must be ordered counter-clockwise in the 2D analysis plane.
         material_ids: Dense material row indices with shape `(nelem,)`.
         material_table: Elastic stress-strain matrices with shape `(nmat, 4, 4)`. Matrix units
             are `[stress / strain] = [pressure]`.
@@ -997,7 +1008,6 @@ def assemble_structural_2d(
             instead of dense arrays.
     """
 
-    elements_arr = _normalize_elements(elements)
     dtype = _resolve_float_dtype(nodes, material_table, thermal_material_table)
     nodes_arr = _normalize_nodes(nodes, dtype)
     material_ids_arr, material_table_arr = _normalize_materials(material_ids, material_table, dtype)
@@ -1014,10 +1024,15 @@ def assemble_structural_2d(
     thickness_value = _normalize_thickness(normalized_formulation, thickness, dtype)
     normalized_element_type = _normalize_element_type(element_type)
     if normalized_element_type == "quad4":
+        elements_arr = _normalize_elements(elements, 4)
         analysis_nodes, analysis_elements, elevated = nodes_arr, elements_arr, None
     else:
-        elevated = infer_quad9_mesh(nodes_arr, elements_arr)
-        analysis_nodes, analysis_elements = elevated.analysis_nodes, elevated.analysis_elements
+        elements_arr = _normalize_elements(elements, (4, 9))
+        if elements_arr.shape[1] == 4:
+            elevated = infer_quad9_mesh(nodes_arr, elements_arr)
+            analysis_nodes, analysis_elements = elevated.analysis_nodes, elevated.analysis_elements
+        else:
+            analysis_nodes, analysis_elements, elevated = nodes_arr, elements_arr, None
     material_orientation_angles_arr = _normalize_material_orientation_angles(
         material_orientation_angles,
         int(analysis_elements.shape[0]),

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -3,6 +3,37 @@
 This module provides a small displacement-based quadrilateral FEM solver for axisymmetric and
 plane-strain structural reductions. The backend stores sparse load operators, sparse
 quadrature-recovery operators, and a reduced stiffness matrix for repeated load solves.
+
+The element formulation follows the standard small-strain Galerkin construction
+
+`K_e = integral(B^T D B c dA)` where `c` is `2*pi*r` for axisymmetric and the thickness of the
+planar domain for plane strain.
+
+with consistent body-force, surface-pressure, and surface-traction load vectors. The axisymmetric
+engineering-strain vector is ordered as `[e_rr, e_zz, e_tt, g_rz]`. In Bower's terminology, the
+underlying equations are the strain-displacement equation, the elastic stress-strain law, the
+equation of static equilibrium for stresses, and the boundary conditions on displacement and
+stress.
+
+References:
+    [1] Allan F. Bower,
+        *Applied Mechanics of Solids*,
+        CRC Press, 2009.
+        See especially Section 8.1 and Table 8.3 for the general displacement-based
+        finite-element construction and 2D interpolation functions.
+
+    [2] E. L. Wilson,
+        "Structural Analysis of Axisymmetric Solids,"
+        *AIAA Journal*, 3(12), pp. 2269-2274, 1965.
+
+    [3] R. A. Mitchell, R. M. Woolley, and C. R. Fisher,
+        "Formulation and experimental verification of an axisymmetric finite-element structural
+        analysis,"
+        *Journal of Research of the National Bureau of Standards Section C*, 75C, 1971.
+
+    [4] I. Fried,
+        "Notes on the finite element analysis of the axisymmetric elastic solid,"
+        *International Journal of Solids and Structures*, 10(3), 1974.
 """
 
 from __future__ import annotations
@@ -1191,7 +1222,12 @@ def isotropic_plane_strain_material(
     poisson_ratio: float,
     dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
-    """Construct the isotropic plane-strain elastic stress-strain matrix."""
+    """Construct the isotropic plane-strain elastic stress-strain matrix.
+
+    Returns a dense `(4, 4)` constitutive matrix in `[xx, yy, zz, xy]` order. The plane-strain
+    solver sets `epsilon_zz = 0`, but this matrix still recovers the nonzero `sigma_zz` implied
+    by the in-plane strains.
+    """
 
     resolved_dtype = np.dtype(dtype)
     binding = _dispatch_pair(
@@ -1207,7 +1243,11 @@ def isotropic_plane_strain_thermal_material(
     reference_temperature: float = 0.0,
     dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
-    """Construct isotropic plane-strain thermal-expansion data."""
+    """Construct isotropic plane-strain thermal-expansion data.
+
+    Returns a row `[alpha_x, alpha_y, alpha_z, alpha_xy, T_ref]` with equal normal expansion
+    coefficients and zero engineering shear expansion.
+    """
 
     resolved_dtype = np.dtype(dtype)
     binding = _dispatch_pair(
@@ -1256,7 +1296,11 @@ def orthotropic_plane_strain_thermal_material(
     reference_temperature: float = 0.0,
     dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
-    """Construct orthotropic plane-strain thermal-expansion data."""
+    """Construct orthotropic plane-strain thermal-expansion data.
+
+    Returns a row `[alpha_x, alpha_y, alpha_z, alpha_xy, T_ref]` with zero engineering shear
+    expansion. Use `material_orientation_angles` during assembly to rotate local orthotropic axes.
+    """
 
     return orthotropic_axisymmetric_thermal_material(
         alpha_x,

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -565,12 +565,12 @@ def _normalize_thickness(
     formulation: str,
     thickness: float | None,
     dtype: np.dtype[Any],
-) -> np.floating[Any]:
+) -> float:
     if formulation == "axisymmetric":
         assert thickness is None, "thickness is only valid for formulation='plane_strain'"
-        return np.asarray(0.0, dtype=dtype)[()]
+        return float(np.asarray(0.0, dtype=dtype))
     assert thickness is not None, "thickness is required for formulation='plane_strain'"
-    value = np.asarray(thickness, dtype=dtype)[()]
+    value = float(np.asarray(thickness, dtype=dtype))
     assert value > 0.0, f"thickness must be positive; got {thickness!r}"
     return value
 

--- a/docs/python/solenoid_stress.md
+++ b/docs/python/solenoid_stress.md
@@ -21,7 +21,7 @@ This package includes three complementary layers:
 The FEM path supports:
 
 - axisymmetric and plane-strain structural formulations,
-- `quad4` and inferred `quad9` elements,
+- `quad4`, inferred `quad9`, and explicit `quad9` elements,
 - `gl3` and `gl4` quadrature,
 - optional per-element in-plane material orientation angles,
 - reusable reduced-space operators for body force, pressure, traction, and nodal-temperature thermal strain,

--- a/docs/python/solenoid_stress.md
+++ b/docs/python/solenoid_stress.md
@@ -3,7 +3,7 @@
 This package includes three complementary layers:
 
 - a 1D finite-difference radial stress solver for winding-pack models with zero `rz` shear,
-- a 2D axisymmetric quadrilateral FEM solver with a constrained reduced model, reusable sparse load operators, and a cached Rust-side LU solve,
+- a 2D quadrilateral FEM solver with axisymmetric and plane-strain formulations, reusable sparse load operators, and a cached Rust-side LU solve,
 - analytic reference formulas used for validation and convergence studies.
 
 ## 1D Finite-Difference Solver
@@ -16,24 +16,50 @@ This package includes three complementary layers:
 
 ::: cfsem.solenoid_stress.solenoid_1d_structural_rhs
 
-## Axisymmetric FEM
+## 2D FEM
 
 The FEM path supports:
 
+- axisymmetric and plane-strain structural formulations,
 - `quad4` and inferred `quad9` elements,
 - `gl3` and `gl4` quadrature,
+- optional per-element in-plane material orientation angles,
 - reusable reduced-space operators for body force, pressure, traction, and nodal-temperature thermal strain,
 - reduced quadrature-point recovery operators for strain and stress,
 - model-owned Dirichlet constraints applied during assembly.
 
 The intended workflow is:
 
-1. call `assemble_axisymmetric(...)` once with mesh, materials, load topology, and prescribed Dirichlet values,
+1. call `assemble_structural_2d(...)` once with mesh, materials, load topology, and prescribed Dirichlet values,
 2. build each reduced load vector with `model.build_rhs(...)` or the exposed sparse operators,
 3. solve with `model.solve(rhs)`, which reuses a cached LU factorization,
 4. recover quadrature strain and stress with `model.evaluate_quadrature(...)`.
 
-::: cfsem.solenoid_stress.axisymmetric_fem
+### Formulation Notes
+
+The axisymmetric and plane-strain solvers share the same 2D quadrilateral mesh, two displacement
+unknowns per node, and four-component strain/stress storage. The difference is how that 2D mesh
+represents a 3D body.
+
+For `formulation="axisymmetric"`, the coordinates are interpreted as `(r, z)`. Each quadrature
+area sample represents a full ring, so stiffness and load integrals use the volume scale
+`2*pi*r*dA`. The strain vector is `[rr, zz, tt, rz]`; the out-of-plane hoop strain is not an
+independent displacement derivative, but is recovered from the radial displacement as
+`epsilon_tt = u_r / r`.
+
+For `formulation="plane_strain"`, the coordinates are interpreted as `(x, y)`. Each area sample
+represents a prismatic slice with user-supplied `thickness`, so integrals use the volume scale
+`thickness*dA`. The strain vector is `[xx, yy, zz, xy]`; the out-of-plane strain is constrained to
+`epsilon_zz = 0`, while `sigma_zz` can still be nonzero through the constitutive matrix.
+
+Plane strain and plane stress are different 2D reductions. Plane strain models a body that is long,
+periodic, or otherwise constrained in the out-of-plane direction, with zero out-of-plane strain and
+generally nonzero out-of-plane stress. Plane stress models a thin sheet or plate with traction-free
+faces through the thickness, with zero out-of-plane stress and generally nonzero out-of-plane
+strain. This FEM path currently implements axisymmetric and plane-strain reductions; it does not
+implement a plane-stress constitutive reduction.
+
+::: cfsem.solenoid_stress.fem2d
 
 ## Analytic Reference Formulas
 

--- a/examples/solenoid_stress_axisymmetric_fem.py
+++ b/examples/solenoid_stress_axisymmetric_fem.py
@@ -11,8 +11,8 @@ import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 
 import cfsem
-from cfsem.solenoid_stress.axisymmetric_fem import (
-    assemble_axisymmetric,
+from cfsem.solenoid_stress.fem2d import (
+    assemble_structural_2d,
     cfsem_radial_material,
     infer_quad9_mesh,
 )
@@ -1012,7 +1012,7 @@ def solve_case(
         bottom_faces, top_faces = top_bottom_pressure_faces(nr, nz)
         pressure_faces = np.vstack([bottom_faces, top_faces])
 
-    model = assemble_axisymmetric(
+    model = assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=material_ids,
@@ -1023,7 +1023,7 @@ def solve_case(
         element_type=element_type,
     )
     quadrature_data = model.element_quadrature()
-    quadrature_points = quadrature_data.points_rz.reshape(-1, 2)
+    quadrature_points = quadrature_data.points.reshape(-1, 2)
     br_loop_q, bz_loop_q = sample_loop_field(
         quadrature_points[:, 0],
         quadrature_points[:, 1],
@@ -1048,7 +1048,7 @@ def solve_case(
     body_force = np.column_stack((current_density * bz_mean, axial_body_force))
 
     measures = model.element_measures()
-    net_body_force_z = float(np.sum(body_force[:, 1] * measures.swept_volumes))
+    net_body_force_z = float(np.sum(body_force[:, 1] * measures.volumes))
     top_area = np.pi * (ro**2 - ri**2)
     pressure_top = net_body_force_z / (2.0 * top_area) if balance_axial_load else 0.0
     pressure_bottom = -pressure_top

--- a/examples/solenoid_stress_axisymmetric_fem_convergence.py
+++ b/examples/solenoid_stress_axisymmetric_fem_convergence.py
@@ -33,8 +33,8 @@ if os.getenv("CFSEM_TESTING"):
 
 from matplotlib import pyplot as plt
 
-from cfsem.solenoid_stress.axisymmetric_fem import (
-    assemble_axisymmetric,
+from cfsem.solenoid_stress.fem2d import (
+    assemble_structural_2d,
     cfsem_radial_material,
     infer_quad9_mesh,
 )
@@ -319,7 +319,7 @@ def solve_fem_midplane_profile(
     nelem = elements.shape[0]
     material = cfsem_radial_material(ELASTICITY_MODULUS, POISSON_RATIO, dtype=np.float64)
     prescribed = prescribed_z_dofs(analysis_nodes.shape[0])
-    model = assemble_axisymmetric(
+    model = assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(nelem, dtype=np.uint64),
@@ -329,7 +329,7 @@ def solve_fem_midplane_profile(
         element_type=element_type,
     )
     quadrature_data = model.element_quadrature()
-    points = quadrature_data.points_rz.reshape(-1, 2)
+    points = quadrature_data.points.reshape(-1, 2)
     nq = quadrature_data.nq_per_element
     weights = np.asarray(quadrature_data.weights_volume, dtype=np.float64)
     bz_weighted = linear_bz_profile(points[:, 0]).reshape(nelem, nq) * weights
@@ -423,7 +423,7 @@ def plot_discretization_panel(ax, nr: int, nz: int, element_type: str) -> None:
     elevated = infer_quad9_mesh(nodes, elements) if element_type == "quad9" else None
     analysis_nodes = elevated.analysis_nodes if elevated is not None else nodes
     analysis_elements = elevated.analysis_elements if elevated is not None else elements
-    model = assemble_axisymmetric(
+    model = assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -433,7 +433,7 @@ def plot_discretization_panel(ax, nr: int, nz: int, element_type: str) -> None:
         element_type=element_type,
     )
     quadrature_data = model.element_quadrature()
-    quadrature_points = quadrature_data.points_rz.reshape(-1, 2)
+    quadrature_points = quadrature_data.points.reshape(-1, 2)
     fd_grid = build_1d_grid((RO - RI) / nr)[1:-1]
 
     if quadrature_points.shape[0] <= 1_000:

--- a/examples/solenoid_stress_surface_traction.py
+++ b/examples/solenoid_stress_surface_traction.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy.sparse.linalg as spla
 
 from cfsem.solenoid_stress import (
-    assemble_axisymmetric,
+    assemble_structural_2d,
     infer_quad9_mesh,
     isotropic_axisymmetric_material,
     isotropic_axisymmetric_thermal_material,
@@ -198,7 +198,7 @@ def main() -> None:
 
     analysis_nodes = nodes if element_type == "quad4" else infer_quad9_mesh(nodes, elements).analysis_nodes
     prescribed = prescribed_dofs(analysis_nodes)
-    model = assemble_axisymmetric(
+    model = assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),

--- a/src/mesh/quad2d.rs
+++ b/src/mesh/quad2d.rs
@@ -25,6 +25,7 @@ impl<'a, F: Copy, const NODES_PER_ELEMENT: usize> QuadMeshView2d<'a, F, NODES_PE
     /// Validate that every connectivity entry references an existing node.
     pub fn validate_connectivity(&self) -> Result<(), String> {
         let node_count = self.num_nodes();
+        let mut duplicate_elements = Vec::new();
         for (element_index, element) in self.elements.iter().enumerate() {
             let mut unique_nodes = HashSet::with_capacity(NODES_PER_ELEMENT);
             for &node in element {
@@ -36,10 +37,19 @@ impl<'a, F: Copy, const NODES_PER_ELEMENT: usize> QuadMeshView2d<'a, F, NODES_PE
                 unique_nodes.insert(node);
             }
             if unique_nodes.len() != NODES_PER_ELEMENT {
-                eprintln!(
-                    "warning: element {element_index} contains duplicate node indices: {element:?}"
-                );
+                duplicate_elements.push((element_index, *element));
             }
+        }
+        if !duplicate_elements.is_empty() {
+            let entries = duplicate_elements
+                .iter()
+                .map(|(element_index, element)| format!("{element_index} {element:?}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            eprintln!(
+                "warning: {} elements contain duplicate node indices: {entries}",
+                duplicate_elements.len()
+            );
         }
         Ok(())
     }

--- a/src/mesh/triangle3d.rs
+++ b/src/mesh/triangle3d.rs
@@ -65,6 +65,7 @@ fn validate_triangle_mesh_geometry(
         return Err("Triangle refers to non-existent node");
     }
 
+    let mut low_quality_triangles = Vec::new();
     for i in 0..ntri {
         let idx = [triangles.0[i], triangles.1[i], triangles.2[i]];
         let area = triangle_area_from_indices(nodes, idx);
@@ -73,10 +74,19 @@ fn validate_triangle_mesh_geometry(
         }
         let quality = triangle_quality_from_indices(nodes, idx);
         if quality < 1e-3 {
-            eprintln!(
-                "warning: triangle {i} has very poor aspect ratio (quality={quality:.3e}, indices={idx:?})"
-            );
+            low_quality_triangles.push((i, quality, idx));
         }
+    }
+    if !low_quality_triangles.is_empty() {
+        let entries = low_quality_triangles
+            .iter()
+            .map(|(i, quality, idx)| format!("{i} (quality={quality:.3e}, indices={idx:?})"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!(
+            "warning: {} triangles have very poor aspect ratio: {entries}",
+            low_quality_triangles.len()
+        );
     }
 
     Ok((nnode, ntri))

--- a/src/physics/solenoid_stress/assembly.rs
+++ b/src/physics/solenoid_stress/assembly.rs
@@ -5,10 +5,11 @@
 
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::axisym::{accumulate_stiffness, build_b_matrix};
+use crate::physics::solenoid_stress::convenience::rotate_material_in_plane;
 use crate::physics::solenoid_stress::family::QuadElementFamily;
-use crate::physics::solenoid_stress::geometry::validate_axisymmetric_mesh;
+use crate::physics::solenoid_stress::geometry::validate_structural_2d_mesh;
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, StiffnessTriplets, local_dofs, two_pi,
+    DOF_PER_NODE, Real, StiffnessTriplets, Structural2dFormulation, local_dofs,
 };
 
 /// Assemble the full unconstrained stiffness matrix for one quadrilateral family.
@@ -25,6 +26,8 @@ pub(crate) fn assemble_stiffness_for_family<
     mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
     material_ids: &[usize],
     material_table: &[[[F; 4]; 4]],
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
 ) -> Result<StiffnessTriplets<F>, String>
 where
@@ -33,7 +36,7 @@ where
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    validate_axisymmetric_mesh(mesh)?;
+    validate_structural_2d_mesh(mesh, formulation)?;
     if material_ids.len() != mesh.num_elements() {
         return Err(format!(
             "material_ids has length {}, but mesh has {} elements",
@@ -41,10 +44,18 @@ where
             mesh.num_elements()
         ));
     }
+    if let Some(angles) = material_orientation_angles
+        && angles.len() != mesh.num_elements()
+    {
+        return Err(format!(
+            "material_orientation_angles has length {}, but mesh has {} elements",
+            angles.len(),
+            mesh.num_elements()
+        ));
+    }
     let mut rows = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
     let mut cols = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
     let mut vals = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
-    let two_pi = two_pi::<F>();
 
     for element_index in 0..mesh.num_elements() {
         let coords = mesh.element_coords(element_index)?;
@@ -53,15 +64,23 @@ where
         let material = material_table.get(material_id).ok_or_else(|| {
             format!("material_id {material_id} on element {element_index} is out of range")
         })?;
+        let material_storage;
+        let material = if let Some(angles) = material_orientation_angles {
+            material_storage = rotate_material_in_plane(material, angles[element_index]);
+            &material_storage
+        } else {
+            material
+        };
         let mut ke = [[F::zero(); DOF_PER_ELEMENT]; DOF_PER_ELEMENT];
 
         for sample in Family::volume_samples::<F>(&coords, quadrature)? {
             let b = build_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                formulation,
                 &sample.n,
                 &sample.grad_phys,
-                sample.point[0],
+                sample.point,
             )?;
-            let scale = two_pi * sample.point[0] * sample.det_j * sample.weight;
+            let scale = formulation.volume_scale(sample.point, sample.det_j, sample.weight)?;
             accumulate_stiffness(&mut ke, material, &b, scale);
         }
 
@@ -98,6 +117,8 @@ mod tests {
             mesh,
             &material_ids,
             &material_table,
+            None,
+            crate::physics::solenoid_stress::types::Structural2dFormulation::Axisymmetric,
             QuadratureRule::GaussLegendre3,
         )
         .expect("assembly should succeed");

--- a/src/physics/solenoid_stress/axisym.rs
+++ b/src/physics/solenoid_stress/axisym.rs
@@ -11,7 +11,7 @@
 //! `u_z`.  Circumferential displacement is omitted by the axisymmetric assumption, but the hoop
 //! normal strain `e_tt` still appears because moving a ring outward changes its circumference.
 
-use crate::physics::solenoid_stress::types::{DOF_PER_NODE, Real};
+use crate::physics::solenoid_stress::types::{DOF_PER_NODE, Real, Structural2dFormulation};
 
 /// Build the axisymmetric strain-displacement matrix `B` at one quadrature point.
 ///
@@ -23,7 +23,11 @@ use crate::physics::solenoid_stress::types::{DOF_PER_NODE, Real};
 /// - Allan F. Bower, *Applied Mechanics of Solids*, CRC Press, 2009, Section 8.1.
 /// - E. L. Wilson, "Structural Analysis of Axisymmetric Solids," *AIAA Journal*, 3(12), pp. 2269-2274, December 1965. doi:10.2514/3.3356.
 /// - R. A. Mitchell, R. M. Woolley, and C. R. Fisher, "Formulation and experimental verification of an axisymmetric finite-element structural analysis," *Journal of Research of the National Bureau of Standards Section C*, 75C, 1971.
-pub fn build_b_matrix<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+pub fn build_axisymmetric_b_matrix<
+    F: Real,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
     n: &[F; NODES_PER_ELEMENT],
     grad_phys: &[[F; 2]; NODES_PER_ELEMENT],
     radius: F,
@@ -53,6 +57,60 @@ pub fn build_b_matrix<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELE
         b[3][col_z] = dndr;
     }
     Ok(b)
+}
+
+/// Build the plane-strain strain-displacement matrix `B` at one quadrature point.
+///
+/// Multiplying this matrix by the element displacement vector
+/// `[u_x1, u_y1, u_x2, u_y2, ...]^T` gives the strain vector
+/// `[e_xx, e_yy, e_zz, g_xy]^T` at that point, with `e_zz = 0`.
+pub fn build_plane_strain_b_matrix<
+    F: Real,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    grad_phys: &[[F; 2]; NODES_PER_ELEMENT],
+) -> [[F; DOF_PER_ELEMENT]; 4] {
+    const {
+        assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
+    }
+    let mut b = [[F::zero(); DOF_PER_ELEMENT]; 4];
+    for (i, grad) in grad_phys.iter().enumerate() {
+        let col_x = 2 * i;
+        let col_y = col_x + 1;
+        let dndx = grad[0];
+        let dndy = grad[1];
+        // e_xx = du_x/dx
+        b[0][col_x] = dndx;
+        // e_yy = du_y/dy
+        b[1][col_y] = dndy;
+        // e_zz = 0 by the plane-strain kinematic assumption.
+        // g_xy = du_x/dy + du_y/dx in engineering-shear convention.
+        b[3][col_x] = dndy;
+        b[3][col_y] = dndx;
+    }
+    b
+}
+
+/// Build the formulation-specific strain-displacement matrix `B` at one quadrature point.
+pub fn build_b_matrix<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    formulation: Structural2dFormulation<F>,
+    n: &[F; NODES_PER_ELEMENT],
+    grad_phys: &[[F; 2]; NODES_PER_ELEMENT],
+    point: [F; 2],
+) -> Result<[[F; DOF_PER_ELEMENT]; 4], String> {
+    match formulation {
+        Structural2dFormulation::Axisymmetric => {
+            build_axisymmetric_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                n, grad_phys, point[0],
+            )
+        }
+        Structural2dFormulation::PlaneStrain { .. } => Ok(build_plane_strain_b_matrix::<
+            F,
+            NODES_PER_ELEMENT,
+            DOF_PER_ELEMENT,
+        >(grad_phys)),
+    }
 }
 
 /// Accumulate `scale * B^T D B` into the element stiffness matrix.

--- a/src/physics/solenoid_stress/convenience.rs
+++ b/src/physics/solenoid_stress/convenience.rs
@@ -280,6 +280,9 @@ pub fn rotate_thermal_expansion_in_plane<F: Real>(alpha: &[F; 4], angle: F) -> [
 }
 
 /// Rotate thermal material data by an in-plane angle.
+///
+/// The expansion coefficients are transformed with the same engineering-shear convention used by
+/// [`rotate_thermal_expansion_in_plane`], while the reference temperature is unchanged.
 pub fn rotate_thermal_material_in_plane<F: Real>(
     thermal: &ThermalMaterial<F>,
     angle: F,

--- a/src/physics/solenoid_stress/convenience.rs
+++ b/src/physics/solenoid_stress/convenience.rs
@@ -1,4 +1,4 @@
-//! Rust-native convenience helpers layered on top of the axisymmetric FEM backend.
+//! Rust-native convenience helpers layered on top of the 2D structural FEM backend.
 //!
 //! These helpers package common construction and postprocessing tasks so both Rust and Python can
 //! use the same domain-level operations without duplicating elastic stress-strain matrix or
@@ -11,23 +11,23 @@ use crate::physics::solenoid_stress::types::{Real, ThermalMaterial, cast};
 
 /// Per-element quadrature data in element-major flattened form.
 ///
-/// `points_rz`, `weights_area`, and `weights_volume` are stored in the same element-major order.
-/// `points_rz` has flattened shape `(nelem * nq_per_element, 2)`,
+/// `points`, `weights_area`, and `weights_volume` are stored in the same element-major order.
+/// `points` has flattened shape `(nelem * nq_per_element, 2)`,
 /// `weights_area` and `weights_volume` have flattened shape `(nelem * nq_per_element,)`, and
 /// `nq_per_element` gives the number of consecutive quadrature entries belonging to each element.
 #[derive(Debug, Clone)]
-pub struct AxisymmetricElementQuadrature<F: Real> {
-    /// Physical quadrature-point coordinates `(r, z)` in element-major order.
+pub struct Structural2dElementQuadrature<F: Real> {
+    /// Physical quadrature-point coordinates in element-major order.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 2)`.
     /// Units: `[length]`.
-    pub points_rz: Vec<[F; 2]>,
-    /// Mapped meridian-area weights `det(J) w` in element-major order.
+    pub points: Vec<[F; 2]>,
+    /// Mapped analysis-plane area weights `det(J) w` in element-major order.
     ///
     /// Flattened shape: `(nelem * nq_per_element,)`.
     /// Units: `[area]`.
     pub weights_area: Vec<F>,
-    /// Mapped swept-volume weights `2*pi*r det(J) w` in element-major order.
+    /// Mapped represented-volume weights in element-major order.
     ///
     /// Flattened shape: `(nelem * nq_per_element,)`.
     /// Units: `[volume]`.
@@ -36,36 +36,36 @@ pub struct AxisymmetricElementQuadrature<F: Real> {
     pub nq_per_element: usize,
 }
 
-/// Per-element meridian area and swept volume.
+/// Per-element analysis-plane area and represented volume.
 ///
 /// Both vectors have shape `(nelem,)`.
 #[derive(Debug, Clone)]
-pub struct AxisymmetricElementMeasures<F: Real> {
-    /// Meridian-plane area of each element.
+pub struct Structural2dElementMeasures<F: Real> {
+    /// Analysis-plane area of each element.
     ///
     /// Shape: `(nelem,)`.
     /// Units: `[area]`.
     pub areas: Vec<F>,
-    /// Swept 3D volume represented by each axisymmetric element.
+    /// Represented 3D volume for each element.
     ///
     /// Shape: `(nelem,)`.
     /// Units: `[volume]`.
-    pub swept_volumes: Vec<F>,
+    pub volumes: Vec<F>,
 }
 
 /// Recovered quadrature-point fields in element-major flattened form.
 ///
 /// Each field vector stores one `[rr, zz, tt, rz]` sample per quadrature point in element-major
-/// order. `points_rz` has flattened shape `(nelem * nq_per_element, 2)`. Each tensor field has
+/// order. `points` has flattened shape `(nelem * nq_per_element, 2)`. Each tensor field has
 /// flattened shape `(nelem * nq_per_element, 4)`. `nq_per_element` records how many consecutive
 /// samples belong to each element.
 #[derive(Debug, Clone)]
 pub struct QuadratureFieldSamples<F: Real> {
-    /// Physical quadrature-point coordinates `(r, z)` in element-major order.
+    /// Physical quadrature-point coordinates in element-major order.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 2)`.
     /// Units: `[length]`.
-    pub points_rz: Vec<[F; 2]>,
+    pub points: Vec<[F; 2]>,
     /// Total strain samples `[e_rr, e_zz, e_tt, g_rz]`.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 4)`.
@@ -199,6 +199,94 @@ pub fn orthotropic_axisymmetric_thermal_material<F: Real>(
     ThermalMaterial {
         alpha: [alpha_r, alpha_z, alpha_t, F::zero()],
         reference_temperature,
+    }
+}
+
+/// Rotate a four-component elastic material matrix by an in-plane angle.
+///
+/// The local component order is `[11, 22, 33, 12]`.  The returned global matrix is expressed in
+/// `[rr, zz, tt, rz]` for axisymmetric use or `[xx, yy, zz, xy]` for plane-strain use.  The angle
+/// is measured from global axis 0 to local material axis 1.
+pub fn rotate_material_in_plane<F: Real>(material: &[[F; 4]; 4], angle: F) -> [[F; 4]; 4] {
+    if angle == F::zero() {
+        return *material;
+    }
+    let c = angle.cos();
+    let s = angle.sin();
+    let c2 = c * c;
+    let s2 = s * s;
+    let cs = c * s;
+    let two = cast::<F>(2.0);
+
+    // local_strain = strain_to_local * global_strain
+    let strain_to_local = [
+        [c2, s2, F::zero(), cs],
+        [s2, c2, F::zero(), -cs],
+        [F::zero(), F::zero(), F::one(), F::zero()],
+        [-two * cs, two * cs, F::zero(), c2 - s2],
+    ];
+    // global_stress = stress_to_global * local_stress
+    let stress_to_global = [
+        [c2, s2, F::zero(), -two * cs],
+        [s2, c2, F::zero(), two * cs],
+        [F::zero(), F::zero(), F::one(), F::zero()],
+        [cs, -cs, F::zero(), c2 - s2],
+    ];
+
+    let mut local_times_strain = [[F::zero(); 4]; 4];
+    for row in 0..4 {
+        for col in 0..4 {
+            let mut value = F::zero();
+            for (k, strain_row) in strain_to_local.iter().enumerate() {
+                value = value + material[row][k] * strain_row[col];
+            }
+            local_times_strain[row][col] = value;
+        }
+    }
+
+    let mut rotated = [[F::zero(); 4]; 4];
+    for row in 0..4 {
+        for col in 0..4 {
+            let mut value = F::zero();
+            for (k, local_row) in local_times_strain.iter().enumerate() {
+                value = value + stress_to_global[row][k] * local_row[col];
+            }
+            rotated[row][col] = value;
+        }
+    }
+    rotated
+}
+
+/// Rotate four-component thermal expansion coefficients by an in-plane angle.
+///
+/// The local input order is `[alpha_1, alpha_2, alpha_3, alpha_12]`; the returned vector is in the
+/// global four-component order for the active 2D formulation.
+pub fn rotate_thermal_expansion_in_plane<F: Real>(alpha: &[F; 4], angle: F) -> [F; 4] {
+    if angle == F::zero() {
+        return *alpha;
+    }
+    let c = angle.cos();
+    let s = angle.sin();
+    let c2 = c * c;
+    let s2 = s * s;
+    let cs = c * s;
+    let two = cast::<F>(2.0);
+    [
+        c2 * alpha[0] + s2 * alpha[1] - cs * alpha[3],
+        s2 * alpha[0] + c2 * alpha[1] + cs * alpha[3],
+        alpha[2],
+        two * cs * alpha[0] - two * cs * alpha[1] + (c2 - s2) * alpha[3],
+    ]
+}
+
+/// Rotate thermal material data by an in-plane angle.
+pub fn rotate_thermal_material_in_plane<F: Real>(
+    thermal: &ThermalMaterial<F>,
+    angle: F,
+) -> ThermalMaterial<F> {
+    ThermalMaterial {
+        alpha: rotate_thermal_expansion_in_plane(&thermal.alpha, angle),
+        reference_temperature: thermal.reference_temperature,
     }
 }
 

--- a/src/physics/solenoid_stress/family.rs
+++ b/src/physics/solenoid_stress/family.rs
@@ -1,12 +1,9 @@
 //! Family-specific quadrilateral sampling and metadata for the axisymmetric FEM backend.
 
-use crate::mesh::QuadratureRule;
 use crate::mesh::elements::quad2d::{quad4, quad9};
-use crate::physics::solenoid_stress::geometry::{
-    FaceSample, VolumeSample, face_samples_quad4, face_samples_quad9, volume_samples_quad4,
-    volume_samples_quad9,
-};
-use crate::physics::solenoid_stress::model::AxisymmetricElementType;
+use crate::mesh::{QuadratureRule, sampling};
+use crate::physics::solenoid_stress::geometry::{FaceSample, VolumeSample};
+use crate::physics::solenoid_stress::model::Structural2dElementType;
 use crate::physics::solenoid_stress::types::Real;
 
 /// Family-specific differences that remain after stiffness, load, and recovery assembly have been
@@ -19,7 +16,7 @@ use crate::physics::solenoid_stress::types::Real;
 /// - connectivity flattening for Python-facing metadata export.
 pub(crate) trait QuadElementFamily<const NODES_PER_ELEMENT: usize> {
     /// Return the public element-family tag corresponding to this internal family marker.
-    fn element_type() -> AxisymmetricElementType;
+    fn element_type() -> Structural2dElementType;
 
     /// Flatten element connectivity into one element-major `Vec<usize>` for metadata export.
     fn flatten_elements(elements: &[[usize; NODES_PER_ELEMENT]]) -> Vec<usize> {
@@ -49,8 +46,8 @@ pub(crate) struct Quad4Family;
 
 impl QuadElementFamily<{ quad4::NODES_PER_ELEMENT }> for Quad4Family {
     /// Identify this marker as the public `quad4` family.
-    fn element_type() -> AxisymmetricElementType {
-        AxisymmetricElementType::Quad4
+    fn element_type() -> Structural2dElementType {
+        Structural2dElementType::Quad4
     }
 
     /// Delegate `quad4` volume sampling to the generic mesh sampling layer.
@@ -58,7 +55,7 @@ impl QuadElementFamily<{ quad4::NODES_PER_ELEMENT }> for Quad4Family {
         coords: &[[F; 2]; quad4::NODES_PER_ELEMENT],
         quadrature: QuadratureRule,
     ) -> Result<Vec<VolumeSample<F, { quad4::NODES_PER_ELEMENT }>>, String> {
-        volume_samples_quad4(coords, quadrature)
+        sampling::volume_samples_quad4(coords, quadrature)
     }
 
     /// Delegate `quad4` face sampling to the generic mesh sampling layer.
@@ -67,7 +64,7 @@ impl QuadElementFamily<{ quad4::NODES_PER_ELEMENT }> for Quad4Family {
         local_face: u8,
         quadrature: QuadratureRule,
     ) -> Result<Vec<FaceSample<F, { quad4::NODES_PER_ELEMENT }>>, String> {
-        face_samples_quad4(coords, local_face, quadrature)
+        sampling::face_samples_quad4(coords, local_face, quadrature)
     }
 }
 
@@ -76,8 +73,8 @@ pub(crate) struct Quad9Family;
 
 impl QuadElementFamily<{ quad9::NODES_PER_ELEMENT }> for Quad9Family {
     /// Identify this marker as the public `quad9` family.
-    fn element_type() -> AxisymmetricElementType {
-        AxisymmetricElementType::Quad9
+    fn element_type() -> Structural2dElementType {
+        Structural2dElementType::Quad9
     }
 
     /// Delegate `quad9` volume sampling to the generic mesh sampling layer.
@@ -85,7 +82,7 @@ impl QuadElementFamily<{ quad9::NODES_PER_ELEMENT }> for Quad9Family {
         coords: &[[F; 2]; quad9::NODES_PER_ELEMENT],
         quadrature: QuadratureRule,
     ) -> Result<Vec<VolumeSample<F, { quad9::NODES_PER_ELEMENT }>>, String> {
-        volume_samples_quad9(coords, quadrature)
+        sampling::volume_samples_quad9(coords, quadrature)
     }
 
     /// Delegate `quad9` face sampling to the generic mesh sampling layer.
@@ -94,6 +91,6 @@ impl QuadElementFamily<{ quad9::NODES_PER_ELEMENT }> for Quad9Family {
         local_face: u8,
         quadrature: QuadratureRule,
     ) -> Result<Vec<FaceSample<F, { quad9::NODES_PER_ELEMENT }>>, String> {
-        face_samples_quad9(coords, local_face, quadrature)
+        sampling::face_samples_quad9(coords, local_face, quadrature)
     }
 }

--- a/src/physics/solenoid_stress/geometry.rs
+++ b/src/physics/solenoid_stress/geometry.rs
@@ -4,10 +4,8 @@
 //! module adds the axisymmetric-specific validation and the `2*pi*r`-weighted element summaries
 //! needed by the structural solver.
 
-use crate::mesh::elements::quad2d::{quad4, quad9};
-use crate::mesh::sampling;
-use crate::mesh::{QuadMeshView2d, QuadratureRule};
-use crate::physics::solenoid_stress::types::Real;
+use crate::mesh::QuadMeshView2d;
+use crate::physics::solenoid_stress::types::{Real, Structural2dFormulation};
 
 pub use crate::mesh::{FaceSample, VolumeSample};
 
@@ -34,78 +32,20 @@ pub(crate) fn validate_axisymmetric_mesh<F: Real, const NODES_PER_ELEMENT: usize
     mesh.validate_connectivity()
 }
 
-/// Reject volume quadrature samples whose evaluated radius is invalid for axisymmetry.
-fn validate_axisymmetric_volume_samples<F: Real, const NODES_PER_ELEMENT: usize>(
-    samples: Vec<VolumeSample<F, NODES_PER_ELEMENT>>,
-) -> Result<Vec<VolumeSample<F, NODES_PER_ELEMENT>>, String> {
-    for sample in &samples {
-        if sample.point[0] < F::zero() {
-            return Err(format!(
-                "quadrature point has negative radius {:?}; axisymmetric radius must be nonnegative",
-                sample.point[0]
-            ));
+/// Validate mesh connectivity and formulation-specific coordinate constraints.
+pub(crate) fn validate_structural_2d_mesh<F: Real, const NODES_PER_ELEMENT: usize>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    formulation: Structural2dFormulation<F>,
+) -> Result<(), String> {
+    match formulation {
+        Structural2dFormulation::Axisymmetric => validate_axisymmetric_mesh(mesh),
+        Structural2dFormulation::PlaneStrain { thickness } => {
+            if thickness <= F::zero() {
+                return Err(format!(
+                    "plane-strain thickness must be positive; got {thickness:?}"
+                ));
+            }
+            mesh.validate_connectivity()
         }
     }
-    Ok(samples)
-}
-
-/// Reject face quadrature samples whose evaluated radius is invalid for axisymmetry.
-fn validate_axisymmetric_face_samples<F: Real, const NODES_PER_ELEMENT: usize>(
-    samples: Vec<FaceSample<F, NODES_PER_ELEMENT>>,
-) -> Result<Vec<FaceSample<F, NODES_PER_ELEMENT>>, String> {
-    for sample in &samples {
-        if sample.point[0] < F::zero() {
-            return Err(format!(
-                "face quadrature point has negative radius {:?}; axisymmetric radius must be nonnegative",
-                sample.point[0]
-            ));
-        }
-    }
-    Ok(samples)
-}
-
-/// Evaluate axisymmetric volume quadrature samples for one `quad4` element.
-///
-/// Returned sample points live in meridian coordinates `(r, z)` with `r >= 0`.
-pub fn volume_samples_quad4<F: Real>(
-    coords: &[[F; 2]; quad4::NODES_PER_ELEMENT],
-    quadrature: QuadratureRule,
-) -> Result<Vec<VolumeSample<F, { quad4::NODES_PER_ELEMENT }>>, String> {
-    validate_axisymmetric_volume_samples(sampling::volume_samples_quad4(coords, quadrature)?)
-}
-
-/// Evaluate axisymmetric volume quadrature samples for one `quad9` element.
-///
-/// Returned sample points live in meridian coordinates `(r, z)` with `r >= 0`.
-pub fn volume_samples_quad9<F: Real>(
-    coords: &[[F; 2]; quad9::NODES_PER_ELEMENT],
-    quadrature: QuadratureRule,
-) -> Result<Vec<VolumeSample<F, { quad9::NODES_PER_ELEMENT }>>, String> {
-    validate_axisymmetric_volume_samples(sampling::volume_samples_quad9(coords, quadrature)?)
-}
-
-/// Evaluate axisymmetric face quadrature samples for one `quad4` element face.
-///
-/// Returned sample points live in meridian coordinates `(r, z)` with `r >= 0`.
-pub fn face_samples_quad4<F: Real>(
-    coords: &[[F; 2]; quad4::NODES_PER_ELEMENT],
-    local_face: u8,
-    quadrature: QuadratureRule,
-) -> Result<Vec<FaceSample<F, { quad4::NODES_PER_ELEMENT }>>, String> {
-    validate_axisymmetric_face_samples(sampling::face_samples_quad4(
-        coords, local_face, quadrature,
-    )?)
-}
-
-/// Evaluate axisymmetric face quadrature samples for one `quad9` element face.
-///
-/// Returned sample points live in meridian coordinates `(r, z)` with `r >= 0`.
-pub fn face_samples_quad9<F: Real>(
-    coords: &[[F; 2]; quad9::NODES_PER_ELEMENT],
-    local_face: u8,
-    quadrature: QuadratureRule,
-) -> Result<Vec<FaceSample<F, { quad9::NODES_PER_ELEMENT }>>, String> {
-    validate_axisymmetric_face_samples(sampling::face_samples_quad9(
-        coords, local_face, quadrature,
-    )?)
 }

--- a/src/physics/solenoid_stress/loads/body_force.rs
+++ b/src/physics/solenoid_stress/loads/body_force.rs
@@ -1,7 +1,9 @@
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
-use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_axisymmetric_mesh};
-use crate::physics::solenoid_stress::types::{DOF_PER_NODE, Real, local_dofs, two_pi};
+use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
+use crate::physics::solenoid_stress::types::{
+    DOF_PER_NODE, Real, Structural2dFormulation, local_dofs,
+};
 
 use super::{SparseOperator, scatter_local_matrix};
 
@@ -21,16 +23,15 @@ fn body_force_element_kernel<
     const DOF_PER_ELEMENT: usize,
 >(
     samples: &[VolumeSample<F, NODES_PER_ELEMENT>],
-) -> [[F; 2]; DOF_PER_ELEMENT] {
+    formulation: Structural2dFormulation<F>,
+) -> Result<[[F; 2]; DOF_PER_ELEMENT], String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     let mut local = [[F::zero(); 2]; DOF_PER_ELEMENT];
-    let two_pi = two_pi::<F>();
 
     for sample in samples {
-        // `2*pi*r*det(J)*w` is the physical swept volume represented by this quadrature point.
-        let scale = two_pi * sample.point[0] * sample.det_j * sample.weight;
+        let scale = formulation.volume_scale(sample.point, sample.det_j, sample.weight)?;
         for local_node in 0..NODES_PER_ELEMENT {
             // Even-numbered rows act on radial DOFs and odd-numbered rows act on axial DOFs.
             local[2 * local_node][0] = local[2 * local_node][0] + scale * sample.n[local_node];
@@ -39,7 +40,7 @@ fn body_force_element_kernel<
         }
     }
 
-    local
+    Ok(local)
 }
 
 /// Assemble the global body-force-to-RHS operator for one quadrilateral family.
@@ -62,6 +63,7 @@ pub(crate) fn body_force_operator_for_family<
     const DOF_PER_ELEMENT: usize,
 >(
     mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
 ) -> Result<SparseOperator<F>, String>
 where
@@ -70,7 +72,7 @@ where
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    validate_axisymmetric_mesh(mesh)?;
+    validate_structural_2d_mesh(mesh, formulation)?;
     let ndof = mesh.num_nodes() * 2;
     let ncol = 2 * mesh.num_elements();
     let mut rows = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * 2);
@@ -81,7 +83,10 @@ where
         let coords = mesh.element_coords(element_index)?;
         let nodes = mesh.element_nodes(element_index)?;
         let samples = Family::volume_samples::<F>(&coords, quadrature)?;
-        let local = body_force_element_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples);
+        let local = body_force_element_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            &samples,
+            formulation,
+        )?;
         let global_rows = local_dofs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&nodes);
         let global_cols = [2 * element_index, 2 * element_index + 1];
         scatter_local_matrix(

--- a/src/physics/solenoid_stress/loads/pressure.rs
+++ b/src/physics/solenoid_stress/loads/pressure.rs
@@ -1,8 +1,8 @@
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
-use crate::physics::solenoid_stress::geometry::{FaceSample, validate_axisymmetric_mesh};
+use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, PressureLoad, Real, local_dofs, two_pi,
+    DOF_PER_NODE, PressureLoad, Real, Structural2dFormulation, local_dofs,
 };
 
 use super::{SparseOperator, scatter_local_vector};
@@ -16,18 +16,18 @@ use super::{SparseOperator, scatter_local_vector};
 /// Each vector entry therefore has units of area.
 fn pressure_face_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
     samples: &[FaceSample<F, NODES_PER_ELEMENT>],
-) -> [F; DOF_PER_ELEMENT] {
+    formulation: Structural2dFormulation<F>,
+) -> Result<[F; DOF_PER_ELEMENT], String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     let mut local = [F::zero(); DOF_PER_ELEMENT];
-    let two_pi = two_pi::<F>();
 
     for sample in samples {
         // Rotating the physical tangent gives `n * |dx/ds|`, so the line Jacobian is already
         // embedded in `normal_area`.
         let normal_area = [sample.tangent[1], -sample.tangent[0]];
-        let scale = -two_pi * sample.point[0] * sample.weight;
+        let scale = -formulation.face_scale(sample.point, F::one(), sample.weight)?;
         for local_node in 0..NODES_PER_ELEMENT {
             local[2 * local_node] =
                 local[2 * local_node] + scale * sample.n[local_node] * normal_area[0];
@@ -36,7 +36,7 @@ fn pressure_face_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_E
         }
     }
 
-    local
+    Ok(local)
 }
 
 /// Assemble the global pressure-to-RHS operator for one quadrilateral family.
@@ -59,6 +59,7 @@ pub(crate) fn pressure_operator_for_family<
 >(
     mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
     pressure_faces: &[PressureLoad],
+    formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
 ) -> Result<SparseOperator<F>, String>
 where
@@ -67,7 +68,7 @@ where
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    validate_axisymmetric_mesh(mesh)?;
+    validate_structural_2d_mesh(mesh, formulation)?;
     let ndof = mesh.num_nodes() * 2;
     let ncol = pressure_faces.len();
     let mut rows = Vec::with_capacity(pressure_faces.len() * DOF_PER_ELEMENT);
@@ -85,7 +86,8 @@ where
         let coords = mesh.element_coords(load.element)?;
         let nodes = mesh.element_nodes(load.element)?;
         let samples = Family::face_samples::<F>(&coords, load.local_face, quadrature)?;
-        let local = pressure_face_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples);
+        let local =
+            pressure_face_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples, formulation)?;
         let global_rows = local_dofs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&nodes);
         scatter_local_vector(
             &mut rows,

--- a/src/physics/solenoid_stress/loads/thermal.rs
+++ b/src/physics/solenoid_stress/loads/thermal.rs
@@ -2,10 +2,13 @@ use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::axisym::{
     accumulate_b_transpose_vector, build_b_matrix, constitutive_times_strain,
 };
+use crate::physics::solenoid_stress::convenience::{
+    rotate_material_in_plane, rotate_thermal_material_in_plane,
+};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
-use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_axisymmetric_mesh};
+use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, ThermalMaterial, local_dofs, two_pi,
+    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, local_dofs,
 };
 
 use super::{SparseOperator, ThermalLoadOperator, scatter_local_matrix};
@@ -33,6 +36,7 @@ fn thermal_element_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER
     samples: &[VolumeSample<F, NODES_PER_ELEMENT>],
     material: &[[F; 4]; 4],
     thermal: &ThermalMaterial<F>,
+    formulation: Structural2dFormulation<F>,
 ) -> Result<LocalThermalKernel<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>, String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
@@ -41,7 +45,6 @@ fn thermal_element_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER
         temperature_to_rhs: [[F::zero(); NODES_PER_ELEMENT]; DOF_PER_ELEMENT],
         reference_rhs: [F::zero(); DOF_PER_ELEMENT],
     };
-    let two_pi = two_pi::<F>();
     let thermal_stress_unit = constitutive_times_strain(material, &thermal.alpha);
 
     for sample in samples {
@@ -49,11 +52,12 @@ fn thermal_element_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER
         // quadrature scale contributes a physical volume. The resulting local block has units
         // `[force / temperature]`.
         let b = build_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            formulation,
             &sample.n,
             &sample.grad_phys,
-            sample.point[0],
+            sample.point,
         )?;
-        let scale = two_pi * sample.point[0] * sample.det_j * sample.weight;
+        let scale = formulation.volume_scale(sample.point, sample.det_j, sample.weight)?;
         let mut local_unit_rhs = [F::zero(); DOF_PER_ELEMENT];
         accumulate_b_transpose_vector(&mut local_unit_rhs, &b, &thermal_stress_unit, scale);
 
@@ -104,6 +108,8 @@ pub(crate) fn temperature_operator_for_family<
     material_ids: &[usize],
     material_table: &[[[F; 4]; 4]],
     thermal_material_table: &[ThermalMaterial<F>],
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
 ) -> Result<ThermalLoadOperator<F>, String>
 where
@@ -112,11 +118,20 @@ where
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    validate_axisymmetric_mesh(mesh)?;
+    validate_structural_2d_mesh(mesh, formulation)?;
     if material_ids.len() != mesh.num_elements() {
         return Err(format!(
             "material_ids has length {}, but mesh has {} elements",
             material_ids.len(),
+            mesh.num_elements()
+        ));
+    }
+    if let Some(angles) = material_orientation_angles
+        && angles.len() != mesh.num_elements()
+    {
+        return Err(format!(
+            "material_orientation_angles has length {}, but mesh has {} elements",
+            angles.len(),
             mesh.num_elements()
         ));
     }
@@ -137,9 +152,21 @@ where
         let thermal = thermal_material_table.get(material_id).ok_or_else(|| {
             format!("thermal material_id {material_id} on element {element_index} is out of range")
         })?;
+        let material_storage;
+        let thermal_storage;
+        let (material, thermal) = if let Some(angles) = material_orientation_angles {
+            material_storage = rotate_material_in_plane(material, angles[element_index]);
+            thermal_storage = rotate_thermal_material_in_plane(thermal, angles[element_index]);
+            (&material_storage, &thermal_storage)
+        } else {
+            (material, thermal)
+        };
         let samples = Family::volume_samples::<F>(&coords, quadrature)?;
         let local = thermal_element_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-            &samples, material, thermal,
+            &samples,
+            material,
+            thermal,
+            formulation,
         )?;
         let global_rows = local_dofs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&nodes);
         scatter_local_matrix(

--- a/src/physics/solenoid_stress/loads/traction.rs
+++ b/src/physics/solenoid_stress/loads/traction.rs
@@ -1,8 +1,8 @@
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
-use crate::physics::solenoid_stress::geometry::{FaceSample, validate_axisymmetric_mesh};
+use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, TractionLoad, local_dofs, two_pi,
+    DOF_PER_NODE, Real, Structural2dFormulation, TractionLoad, local_dofs,
 };
 
 use super::{SparseOperator, scatter_local_matrix};
@@ -19,18 +19,18 @@ use super::{SparseOperator, scatter_local_matrix};
 /// Each block entry therefore has units of area.
 fn traction_face_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
     samples: &[FaceSample<F, NODES_PER_ELEMENT>],
-) -> [[F; 2]; DOF_PER_ELEMENT] {
+    formulation: Structural2dFormulation<F>,
+) -> Result<[[F; 2]; DOF_PER_ELEMENT], String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     let mut local = [[F::zero(); 2]; DOF_PER_ELEMENT];
-    let two_pi = two_pi::<F>();
 
     for sample in samples {
         // `|dx/ds|` is the physical line Jacobian for the face quadrature parameter.
         let tangent_norm =
             (sample.tangent[0] * sample.tangent[0] + sample.tangent[1] * sample.tangent[1]).sqrt();
-        let scale = two_pi * sample.point[0] * tangent_norm * sample.weight;
+        let scale = formulation.face_scale(sample.point, tangent_norm, sample.weight)?;
         for local_node in 0..NODES_PER_ELEMENT {
             // The two columns encode independent unit tractions in the global radial and axial
             // directions, so the block is diagonal in those two traction components.
@@ -40,7 +40,7 @@ fn traction_face_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_E
         }
     }
 
-    local
+    Ok(local)
 }
 
 /// Assemble the global traction-to-RHS operator for one quadrilateral family.
@@ -64,6 +64,7 @@ pub(crate) fn traction_operator_for_family<
 >(
     mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
     traction_faces: &[TractionLoad],
+    formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
 ) -> Result<SparseOperator<F>, String>
 where
@@ -72,7 +73,7 @@ where
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    validate_axisymmetric_mesh(mesh)?;
+    validate_structural_2d_mesh(mesh, formulation)?;
     let ndof = mesh.num_nodes() * 2;
     let ncol = 2 * traction_faces.len();
     let mut rows = Vec::with_capacity(traction_faces.len() * DOF_PER_ELEMENT * 2);
@@ -90,7 +91,8 @@ where
         let coords = mesh.element_coords(load.element)?;
         let nodes = mesh.element_nodes(load.element)?;
         let samples = Family::face_samples::<F>(&coords, load.local_face, quadrature)?;
-        let local = traction_face_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples);
+        let local =
+            traction_face_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples, formulation)?;
         let global_rows = local_dofs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&nodes);
         let global_cols = [2 * load_index, 2 * load_index + 1];
         scatter_local_matrix(

--- a/src/physics/solenoid_stress/mod.rs
+++ b/src/physics/solenoid_stress/mod.rs
@@ -498,13 +498,17 @@ mod types;
 
 pub use crate::mesh::QuadratureRule;
 pub use convenience::{
-    AxisymmetricElementMeasures, AxisymmetricElementQuadrature, ElevatedQuad9Mesh,
-    QuadratureFieldSamples, cfsem_radial_material, infer_quad9_mesh,
+    ElevatedQuad9Mesh, QuadratureFieldSamples, Structural2dElementMeasures,
+    Structural2dElementQuadrature, cfsem_radial_material, infer_quad9_mesh,
     isotropic_axisymmetric_material, isotropic_axisymmetric_thermal_material,
-    orthotropic_axisymmetric_thermal_material,
+    orthotropic_axisymmetric_thermal_material, rotate_material_in_plane,
+    rotate_thermal_expansion_in_plane, rotate_thermal_material_in_plane,
 };
 pub use model::{
-    AxisymmetricElementType, AxisymmetricElements, AxisymmetricModel, ReducedRecoveryOperators,
-    assemble_axisymmetric,
+    ReducedRecoveryOperators, Structural2dElementType, Structural2dElements, Structural2dModel,
+    assemble_structural_2d,
 };
-pub use types::{DOF_PER_NODE, PressureLoad, Real, ThermalMaterial, TractionLoad, dof_per_element};
+pub use types::{
+    DOF_PER_NODE, PressureLoad, Real, Structural2dFormulation, ThermalMaterial, TractionLoad,
+    dof_per_element,
+};

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -1,4 +1,4 @@
-//! Reduced-model assembly and solve wrapper for the axisymmetric structural FEM.
+//! Reduced-model assembly and solve wrapper for the 2D structural FEM.
 
 use faer::Col;
 use faer::linalg::solvers::Solve;
@@ -9,7 +9,7 @@ use crate::mesh::elements::quad2d::{quad4, quad9};
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::assembly::assemble_stiffness_for_family;
 use crate::physics::solenoid_stress::convenience::{
-    AxisymmetricElementMeasures, AxisymmetricElementQuadrature, QuadratureFieldSamples,
+    QuadratureFieldSamples, Structural2dElementMeasures, Structural2dElementQuadrature,
 };
 use crate::physics::solenoid_stress::family::{Quad4Family, Quad9Family, QuadElementFamily};
 use crate::physics::solenoid_stress::loads::{
@@ -18,19 +18,19 @@ use crate::physics::solenoid_stress::loads::{
 };
 use crate::physics::solenoid_stress::recovery::quadrature_field_operators_for_family;
 use crate::physics::solenoid_stress::types::{
-    PressureLoad, Real, ThermalMaterial, TractionLoad, dof_per_element, two_pi,
+    PressureLoad, Real, Structural2dFormulation, ThermalMaterial, TractionLoad, dof_per_element,
 };
 
-/// Public element-family selector for the axisymmetric structural solver.
+/// Public element-family selector for the 2D structural solver.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AxisymmetricElementType {
-    /// Bilinear four-node quadrilateral in the meridian plane.
+pub enum Structural2dElementType {
+    /// Bilinear four-node quadrilateral in the analysis plane.
     Quad4,
-    /// Quadratic nine-node quadrilateral in the meridian plane.
+    /// Quadratic nine-node quadrilateral in the analysis plane.
     Quad9,
 }
 
-impl AxisymmetricElementType {
+impl Structural2dElementType {
     /// Return the canonical public string spelling used by the Python wrapper and docs.
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -45,7 +45,7 @@ impl AxisymmetricElementType {
             4 => Ok(Self::Quad4),
             9 => Ok(Self::Quad9),
             _ => Err(format!(
-                "unsupported axisymmetric FEM element code {code}; use 4 or 9"
+                "unsupported structural 2D FEM element code {code}; use 4 or 9"
             )),
         }
     }
@@ -55,8 +55,8 @@ impl AxisymmetricElementType {
 ///
 /// Each variant stores element-node connectivity in the node ordering expected by the
 /// corresponding quadrilateral family. Element corner nodes must be ordered
-/// counter-clockwise in the `(r, z)` meridian plane.
-pub enum AxisymmetricElements<'a> {
+/// counter-clockwise in the 2D analysis plane.
+pub enum Structural2dElements<'a> {
     Quad4(&'a [[usize; 4]]),
     Quad9(&'a [[usize; 9]]),
 }
@@ -65,7 +65,7 @@ pub enum AxisymmetricElements<'a> {
 ///
 /// All sparse operators in this struct act on the reduced displacement vector produced by the
 /// constrained solve, except for the thermal operators, which act on the nodal temperature field.
-/// `points_rz` has flattened shape `(nelem * nq_per_element, 2)`. Each operator and constant
+/// `points` has flattened shape `(nelem * nq_per_element, 2)`. Each operator and constant
 /// vector acts on or stores flattened quadrature-point blocks with row ordering
 /// `[rr, zz, tt, rz]`, so those arrays have flattened shape `(4 * nelem * nq_per_element,)`.
 #[derive(Debug, Clone)]
@@ -74,7 +74,7 @@ pub struct ReducedRecoveryOperators<F: Real> {
     ///
     /// Flattened shape: `(nelem * nq_per_element, 2)`.
     /// Units: `[length]`.
-    pub points_rz: Vec<[F; 2]>,
+    pub points: Vec<[F; 2]>,
     /// CSR operator mapping reduced displacements `[length]` to quadrature-point strains
     /// `[dimensionless]`.
     ///
@@ -118,7 +118,7 @@ pub struct ReducedRecoveryOperators<F: Real> {
     pub n_temperature_nodes: usize,
 }
 
-/// Fully assembled reduced axisymmetric structural model.
+/// Fully assembled reduced 2D structural model.
 ///
 /// The public system stored here is the Dirichlet-reduced system.  `stiffness`, the load
 /// operators, and `constant_rhs` all live in reduced displacement space, while the recovery
@@ -127,7 +127,7 @@ pub struct ReducedRecoveryOperators<F: Real> {
 /// `(nelem * nodes_per_element,)`, `pressure_faces` has shape `(n_pressure_faces, 2)`, and
 /// `traction_faces` has shape `(n_traction_faces, 2)`.
 #[derive(Debug)]
-pub struct AxisymmetricModel<F: Real> {
+pub struct Structural2dModel<F: Real> {
     /// Reduced structural stiffness matrix in CSC form.
     ///
     /// This matrix maps reduced displacements `[length]` to reduced generalized nodal forces
@@ -170,7 +170,7 @@ pub struct AxisymmetricModel<F: Real> {
     ///
     /// Shape: `(n_traction_faces, 2)`.
     pub traction_faces: Vec<[usize; 2]>,
-    /// Analysis mesh nodes `(r, z)` used by the backend.
+    /// Analysis mesh nodes used by the backend.
     ///
     /// Shape: `(n_analysis_nodes, 2)`.
     /// Units: `[length]`.
@@ -182,9 +182,11 @@ pub struct AxisymmetricModel<F: Real> {
     /// Number of nodes per analysis element.
     pub nodes_per_element: usize,
     /// Analysis element family used by the backend.
-    pub element_type: AxisymmetricElementType,
+    pub element_type: Structural2dElementType,
     /// Volume and face quadrature rule used to assemble the stored operators.
     pub quadrature: QuadratureRule,
+    /// Structural 2D formulation used by the backend.
+    pub formulation: Structural2dFormulation<F>,
     /// Number of displacement DOFs in the unreduced full system.
     pub ndof_full: usize,
     /// Number of displacement DOFs remaining after Dirichlet reduction.
@@ -207,7 +209,7 @@ pub struct AxisymmetricModel<F: Real> {
     lu: Option<Lu<usize, F>>,
 }
 
-impl<F: Real> AxisymmetricModel<F> {
+impl<F: Real> Structural2dModel<F> {
     /// Build one reduced structural right-hand side.
     ///
     /// Args:
@@ -338,41 +340,43 @@ impl<F: Real> AxisymmetricModel<F> {
     ///
     /// Returns:
     ///     Element-major quadrature data with:
-    ///     - `points_rz` length `nelem * nq_per_element`, each entry `(r, z)` with units `[length]`
+    ///     - `points` length `nelem * nq_per_element`, each entry `(r, z)` with units `[length]`
     ///     - `weights_area` length `nelem * nq_per_element` with units `[area]`
     ///     - `weights_volume` length `nelem * nq_per_element` with units `[volume]`
     ///     - `nq_per_element` giving the number of consecutive quadrature entries per element
-    pub fn element_quadrature(&self) -> Result<AxisymmetricElementQuadrature<F>, String> {
+    pub fn element_quadrature(&self) -> Result<Structural2dElementQuadrature<F>, String> {
         match self.element_type {
-            AxisymmetricElementType::Quad4 => {
+            Structural2dElementType::Quad4 => {
                 element_quadrature_for_family::<F, Quad4Family, { quad4::NODES_PER_ELEMENT }>(
                     &self.analysis_nodes,
                     &self.analysis_elements_flat,
                     self.nelem,
+                    self.formulation,
                     self.quadrature,
                 )
             }
-            AxisymmetricElementType::Quad9 => {
+            Structural2dElementType::Quad9 => {
                 element_quadrature_for_family::<F, Quad9Family, { quad9::NODES_PER_ELEMENT }>(
                     &self.analysis_nodes,
                     &self.analysis_elements_flat,
                     self.nelem,
+                    self.formulation,
                     self.quadrature,
                 )
             }
         }
     }
 
-    /// Return per-element meridian area and swept volume from the model quadrature data.
+    /// Return per-element analysis-plane area and represented volume from the model quadrature data.
     ///
     /// Returns:
     ///     Per-element measures with:
     ///     - `areas` shape `(nelem,)` and units `[area]`
-    ///     - `swept_volumes` shape `(nelem,)` and units `[volume]`
-    pub fn element_measures(&self) -> Result<AxisymmetricElementMeasures<F>, String> {
+    ///     - `volumes` shape `(nelem,)` and units `[volume]`
+    pub fn element_measures(&self) -> Result<Structural2dElementMeasures<F>, String> {
         let quadrature = self.element_quadrature()?;
         let mut areas = vec![F::zero(); self.nelem];
-        let mut swept_volumes = vec![F::zero(); self.nelem];
+        let mut volumes = vec![F::zero(); self.nelem];
         for element in 0..self.nelem {
             let start = element * quadrature.nq_per_element;
             let end = start + quadrature.nq_per_element;
@@ -380,13 +384,10 @@ impl<F: Real> AxisymmetricModel<F> {
                 areas[element] = areas[element] + weight;
             }
             for &weight in &quadrature.weights_volume[start..end] {
-                swept_volumes[element] = swept_volumes[element] + weight;
+                volumes[element] = volumes[element] + weight;
             }
         }
-        Ok(AxisymmetricElementMeasures {
-            areas,
-            swept_volumes,
-        })
+        Ok(Structural2dElementMeasures { areas, volumes })
     }
 
     /// Recover quadrature-point strain and stress fields.
@@ -399,7 +400,7 @@ impl<F: Real> AxisymmetricModel<F> {
     ///
     /// Returns:
     ///     Recovered quadrature fields where:
-    ///     - `points_rz` has length `nelem * nq_per_element` and units `[length]`
+    ///     - `points` has length `nelem * nq_per_element` and units `[length]`
     ///     - `strain`, `thermal_strain`, and `elastic_strain` each have length
     ///       `nelem * nq_per_element`, with component order `[rr, zz, tt, rz]` and units `[strain]`
     ///     - `stress` has length `nelem * nq_per_element`, with component order
@@ -463,7 +464,7 @@ impl<F: Real> AxisymmetricModel<F> {
             .collect();
 
         Ok(QuadratureFieldSamples {
-            points_rz: self.recovery.points_rz.clone(),
+            points: self.recovery.points.clone(),
             strain,
             thermal_strain,
             elastic_strain,
@@ -474,56 +475,22 @@ impl<F: Real> AxisymmetricModel<F> {
 }
 
 #[allow(clippy::too_many_arguments)]
-/// Assemble the reduced axisymmetric structural model and all associated operators.
-///
-/// This is the single public Rust entry point for the axisymmetric FEM backend.  It accepts the
-/// analysis mesh, material data, optional load topology, optional thermal material data, and
-/// prescribed Dirichlet displacement values, then returns a reduced model containing:
-/// - the reduced stiffness matrix,
-/// - reduced RHS operators for all supported load types,
-/// - cached metadata describing the analysis mesh and load faces, and
-/// - reduced recovery operators for quadrature-point postprocessing.
-///
-/// Args:
-///     nodes_rz: Corner-node coordinates with shape `(nnode, 2)` in `(r, z)` order. Units are
-///         `[length]`.
-///     elements: Analysis connectivity, either quad4 with shape `(nelem, 4)` or quad9 with shape
-///         `(nelem, 9)`. Corner nodes must be ordered counter-clockwise in the `(r, z)` plane.
-///     material_ids: Dense material row indices with shape `(nelem,)`.
-///     material_table: Elastic stress-strain matrices with shape `(nmat, 4, 4)`. Matrix units
-///         are `[stress / strain] = [pressure]`.
-///     pressure_faces: Pressure-load topology with shape `(n_pressure_faces,)`, one
-///         `PressureLoad` per loaded face.
-///     traction_faces: Traction-load topology with shape `(n_traction_faces,)`, one
-///         `TractionLoad` per loaded face.
-///     thermal_material_table: Optional thermal material table with shape `(nmat,)`, one
-///         `ThermalMaterial` per material row. Each row stores
-///         `[alpha_r, alpha_z, alpha_t, alpha_rz, T_ref]`, where `alpha_*` has units
-///         `[strain / temperature]` and `T_ref` has units `[temperature]`.
-///     prescribed: Prescribed displacement values with shape `(n_prescribed,)`, stored as
-///         `(global_dof, value)` pairs. Displacement units are `[length]`.
-///     quadrature: Volume and face quadrature rule used to assemble the stored operators.
-///
-/// Returns:
-///     Reduced axisymmetric FEM model storing:
-///     - CSC stiffness with shape `(ndof_reduced, ndof_reduced)`
-///     - CSR load operators mapping reusable load amplitudes into the reduced right-hand side
-///     - CSR recovery operators for quadrature-point postprocessing
-///     - `constant_rhs` with shape `(ndof_reduced,)` and units `[energy / distance]`
-///     - analysis mesh and load metadata with the shapes documented on [`AxisymmetricModel`]
-pub fn assemble_axisymmetric<F: Real>(
+/// Assemble the reduced 2D structural model and all associated operators.
+pub fn assemble_structural_2d<F: Real>(
     nodes_rz: &[[F; 2]],
-    elements: AxisymmetricElements<'_>,
+    elements: Structural2dElements<'_>,
     material_ids: &[usize],
     material_table: &[[[F; 4]; 4]],
     pressure_faces: &[PressureLoad],
     traction_faces: &[TractionLoad],
     thermal_material_table: Option<&[ThermalMaterial<F>]>,
+    material_orientation_angles: Option<&[F]>,
     prescribed: &[(usize, F)],
+    formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
-) -> Result<AxisymmetricModel<F>, String> {
+) -> Result<Structural2dModel<F>, String> {
     match elements {
-        AxisymmetricElements::Quad4(elements) => build_model_for_family::<
+        Structural2dElements::Quad4(elements) => build_model_for_family::<
             F,
             Quad4Family,
             { quad4::NODES_PER_ELEMENT },
@@ -536,10 +503,12 @@ pub fn assemble_axisymmetric<F: Real>(
             pressure_faces,
             traction_faces,
             thermal_material_table,
+            material_orientation_angles,
             prescribed,
+            formulation,
             quadrature,
         ),
-        AxisymmetricElements::Quad9(elements) => build_model_for_family::<
+        Structural2dElements::Quad9(elements) => build_model_for_family::<
             F,
             Quad9Family,
             { quad9::NODES_PER_ELEMENT },
@@ -552,7 +521,9 @@ pub fn assemble_axisymmetric<F: Real>(
             pressure_faces,
             traction_faces,
             thermal_material_table,
+            material_orientation_angles,
             prescribed,
+            formulation,
             quadrature,
         ),
     }
@@ -573,7 +544,7 @@ type ReducedLayout<F> = (Vec<usize>, Vec<usize>, Vec<F>, Vec<usize>, Vec<Option<
 ///
 /// This is the family-generic core of the public assembly path.  It builds the unreduced
 /// operators, applies Dirichlet reduction, compresses the final sparse matrices, and packages the
-/// result into the public `AxisymmetricModel`.
+/// result into the public `Structural2dModel`.
 fn build_model_for_family<
     F: Real,
     Family,
@@ -587,9 +558,11 @@ fn build_model_for_family<
     pressure_faces: &[PressureLoad],
     traction_faces: &[TractionLoad],
     thermal_material_table: Option<&[ThermalMaterial<F>]>,
+    material_orientation_angles: Option<&[F]>,
     prescribed: &[(usize, F)],
+    formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
-) -> Result<AxisymmetricModel<F>, String>
+) -> Result<Structural2dModel<F>, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -606,12 +579,15 @@ where
     // Assemble stiffness in the full displacement space first, then apply Dirichlet reduction.
     // This keeps the element kernels simple and pushes all constraint handling into the common
     // reduction helpers below.
-    let stiffness_full = assemble_stiffness_for_family::<
-        F,
-        Family,
-        NODES_PER_ELEMENT,
-        DOF_PER_ELEMENT,
-    >(mesh, material_ids, material_table, quadrature)?;
+    let stiffness_full =
+        assemble_stiffness_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            material_ids,
+            material_table,
+            material_orientation_angles,
+            formulation,
+            quadrature,
+        )?;
     let mut constant_rhs = vec![F::zero(); ndof_reduced];
     let stiffness_reduced = reduce_square_triplets(
         &stiffness_full.rows,
@@ -637,6 +613,8 @@ where
                     material_ids,
                     material_table,
                     thermal_material_table,
+                    material_orientation_angles,
+                    formulation,
                     quadrature,
                 )?;
             let reduced_reference_rhs = free_dofs
@@ -668,19 +646,19 @@ where
         Family,
         NODES_PER_ELEMENT,
         DOF_PER_ELEMENT,
-    >(mesh, quadrature)?)?;
+    >(mesh, formulation, quadrature)?)?;
     let pressure_to_rhs = reduce_operator(pressure_operator_for_family::<
         F,
         Family,
         NODES_PER_ELEMENT,
         DOF_PER_ELEMENT,
-    >(mesh, pressure_faces, quadrature)?)?;
+    >(mesh, pressure_faces, formulation, quadrature)?)?;
     let traction_to_rhs = reduce_operator(traction_operator_for_family::<
         F,
         Family,
         NODES_PER_ELEMENT,
         DOF_PER_ELEMENT,
-    >(mesh, traction_faces, quadrature)?)?;
+    >(mesh, traction_faces, formulation, quadrature)?)?;
 
     // Recovery is assembled in full displacement space, then its displacement columns are reduced.
     // Eliminated fixed-displacement columns become constant strain/stress offsets.
@@ -690,9 +668,11 @@ where
             material_ids,
             material_table,
             thermal_material_table,
+            material_orientation_angles,
+            formulation,
             quadrature,
         )?;
-    let nq_row_count = recovery_full.points_rz.len() * 4;
+    let nq_row_count = recovery_full.points.len() * 4;
     let (strain_operator, strain_constant) = reduce_column_operator(
         recovery_full.strain_rows,
         recovery_full.strain_cols,
@@ -712,21 +692,21 @@ where
         &fixed_lookup,
     )?;
     let thermal_strain_operator = csr_from_parts(
-        recovery_full.points_rz.len() * 4,
+        recovery_full.points.len() * 4,
         recovery_full.ntemp,
         recovery_full.thermal_strain_rows,
         recovery_full.thermal_strain_cols,
         recovery_full.thermal_strain_vals,
     )?;
     let thermal_stress_operator = csr_from_parts(
-        recovery_full.points_rz.len() * 4,
+        recovery_full.points.len() * 4,
         recovery_full.ntemp,
         recovery_full.thermal_stress_rows,
         recovery_full.thermal_stress_cols,
         recovery_full.thermal_stress_vals,
     )?;
 
-    Ok(AxisymmetricModel {
+    Ok(Structural2dModel {
         stiffness,
         body_force_to_rhs,
         pressure_to_rhs,
@@ -734,7 +714,7 @@ where
         temperature_to_rhs,
         constant_rhs,
         recovery: ReducedRecoveryOperators {
-            points_rz: recovery_full.points_rz,
+            points: recovery_full.points,
             strain_operator,
             stress_operator,
             thermal_strain_operator,
@@ -759,6 +739,7 @@ where
         nodes_per_element: NODES_PER_ELEMENT,
         element_type: Family::element_type(),
         quadrature,
+        formulation,
         ndof_full,
         ndof_reduced,
         nelem,
@@ -1016,12 +997,13 @@ fn element_quadrature_for_family<F: Real, Family, const NODES_PER_ELEMENT: usize
     analysis_nodes: &[[F; 2]],
     analysis_elements_flat: &[usize],
     nelem: usize,
+    formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
-) -> Result<AxisymmetricElementQuadrature<F>, String>
+) -> Result<Structural2dElementQuadrature<F>, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
-    let mut points_rz = Vec::new();
+    let mut points = Vec::new();
     let mut weights_area = Vec::new();
     let mut weights_volume = Vec::new();
     let mut nq_per_element = None;
@@ -1044,13 +1026,17 @@ where
         }
         for sample in samples {
             let area_weight = sample.det_j * sample.weight;
-            points_rz.push(sample.point);
+            points.push(sample.point);
             weights_area.push(area_weight);
-            weights_volume.push(area_weight * two_pi::<F>() * sample.point[0]);
+            weights_volume.push(formulation.volume_scale(
+                sample.point,
+                sample.det_j,
+                sample.weight,
+            )?);
         }
     }
-    Ok(AxisymmetricElementQuadrature {
-        points_rz,
+    Ok(Structural2dElementQuadrature {
+        points,
         weights_area,
         weights_volume,
         nq_per_element: nq_per_element.unwrap_or(0),

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -57,7 +57,9 @@ impl Structural2dElementType {
 /// corresponding quadrilateral family. Element corner nodes must be ordered
 /// counter-clockwise in the 2D analysis plane.
 pub enum Structural2dElements<'a> {
+    /// Four-node bilinear quadrilateral connectivity in local corner order.
     Quad4(&'a [[usize; 4]]),
+    /// Nine-node quadratic quadrilateral connectivity in local corner, midside, center order.
     Quad9(&'a [[usize; 9]]),
 }
 

--- a/src/physics/solenoid_stress/recovery.rs
+++ b/src/physics/solenoid_stress/recovery.rs
@@ -34,9 +34,14 @@ use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::axisym::{
     build_b_matrix, constitutive_times_b, constitutive_times_strain,
 };
+use crate::physics::solenoid_stress::convenience::{
+    rotate_material_in_plane, rotate_thermal_material_in_plane,
+};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
-use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_axisymmetric_mesh};
-use crate::physics::solenoid_stress::types::{DOF_PER_NODE, Real, ThermalMaterial, local_dofs};
+use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
+use crate::physics::solenoid_stress::types::{
+    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, local_dofs,
+};
 
 /// Sparse quadrature-point recovery operators before reduction into the model-owned CSR form.
 ///
@@ -47,7 +52,7 @@ pub struct QuadratureFieldOperators<F: Real> {
     /// Quadrature-point coordinates `(r, z)` in element-major order.
     ///
     /// Units: `[length]`.
-    pub points_rz: Vec<[F; 2]>,
+    pub points: Vec<[F; 2]>,
     /// Sparse row indices for the strain operator triplets.
     pub strain_rows: Vec<usize>,
     /// Sparse column indices for the strain operator triplets.
@@ -158,15 +163,17 @@ fn quadrature_sample_kernel<
     material: &[[F; 4]; 4],
     thermal_material: Option<&ThermalMaterial<F>>,
     thermal_stress_unit: Option<&[F; 4]>,
+    formulation: Structural2dFormulation<F>,
 ) -> Result<LocalQuadratureSampleKernel<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>, String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     // `B` maps nodal displacements `[length]` to strain `[dimensionless]`.
     let strain = build_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        formulation,
         &sample.n,
         &sample.grad_phys,
-        sample.point[0],
+        sample.point,
     )?;
     // `D B` maps nodal displacements `[length]` to stress `[pressure]`. The elastic stress-strain
     // matrix is applied here with the local per-material `4 x 4` matrix; there is no assembled
@@ -222,6 +229,8 @@ pub(crate) fn quadrature_field_operators_for_family<
     material_ids: &[usize],
     material_table: &[[[F; 4]; 4]],
     thermal_material_table: Option<&[ThermalMaterial<F>]>,
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
 ) -> Result<QuadratureFieldOperators<F>, String>
 where
@@ -230,7 +239,7 @@ where
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    validate_axisymmetric_mesh(mesh)?;
+    validate_structural_2d_mesh(mesh, formulation)?;
     if material_ids.len() != mesh.num_elements() {
         return Err(format!(
             "material_ids has length {}, but mesh has {} elements",
@@ -238,10 +247,19 @@ where
             mesh.num_elements()
         ));
     }
+    if let Some(angles) = material_orientation_angles
+        && angles.len() != mesh.num_elements()
+    {
+        return Err(format!(
+            "material_orientation_angles has length {}, but mesh has {} elements",
+            angles.len(),
+            mesh.num_elements()
+        ));
+    }
 
     let nq_per_element = quadrature.points_per_element();
     let nsamples = mesh.num_elements() * nq_per_element;
-    let mut points_rz = Vec::with_capacity(nsamples);
+    let mut points = Vec::with_capacity(nsamples);
     let mut strain_rows = Vec::with_capacity(nsamples * (DOF_PER_ELEMENT + 4));
     let mut strain_cols = Vec::with_capacity(nsamples * (DOF_PER_ELEMENT + 4));
     let mut strain_vals = Vec::with_capacity(nsamples * (DOF_PER_ELEMENT + 4));
@@ -264,7 +282,7 @@ where
         let material = material_table.get(material_id).ok_or_else(|| {
             format!("material_id {material_id} on element {element_index} is out of range")
         })?;
-        let thermal_material = thermal_material_table
+        let thermal_material_base = thermal_material_table
             .map(|table| {
                 table.get(material_id).ok_or_else(|| {
                     format!(
@@ -273,6 +291,16 @@ where
                 })
             })
             .transpose()?;
+        let material_storage;
+        let thermal_storage;
+        let (material, thermal_material) = if let Some(angles) = material_orientation_angles {
+            material_storage = rotate_material_in_plane(material, angles[element_index]);
+            thermal_storage = thermal_material_base
+                .map(|thermal| rotate_thermal_material_in_plane(thermal, angles[element_index]));
+            (&material_storage, thermal_storage.as_ref())
+        } else {
+            (material, thermal_material_base)
+        };
         let global_dofs = local_dofs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&nodes);
         let thermal_stress_unit =
             thermal_material.map(|thermal| constitutive_times_strain(material, &thermal.alpha));
@@ -286,10 +314,11 @@ where
                 material,
                 thermal_material,
                 thermal_stress_unit.as_ref(),
+                formulation,
             )?;
             let row_base = 4 * (element_index * nq_per_element + q_local);
             let global_rows = [row_base, row_base + 1, row_base + 2, row_base + 3];
-            points_rz.push(sample.point);
+            points.push(sample.point);
             scatter_local_matrix(
                 &mut strain_rows,
                 &mut strain_cols,
@@ -334,7 +363,7 @@ where
     }
 
     Ok(QuadratureFieldOperators {
-        points_rz,
+        points,
         strain_rows,
         strain_cols,
         strain_vals,
@@ -357,13 +386,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::quadrature_field_operators_for_family;
-    use crate::mesh::QuadratureRule;
+    use crate::mesh::{QuadratureRule, sampling};
     use crate::physics::solenoid_stress::axisym::{build_b_matrix, constitutive_times_b};
     use crate::physics::solenoid_stress::convenience::isotropic_axisymmetric_material;
     use crate::physics::solenoid_stress::family::Quad4Family;
-    use crate::physics::solenoid_stress::geometry::volume_samples_quad4;
     use crate::physics::solenoid_stress::test_utils::single_element_quad4_mesh;
-    use crate::physics::solenoid_stress::types::dof_per_element;
+    use crate::physics::solenoid_stress::types::{Structural2dFormulation, dof_per_element};
 
     /// Apply one triplet operator to a dense vector for direct-reference comparison in tests.
     fn apply_triplets(
@@ -392,6 +420,8 @@ mod tests {
                 &material_ids,
                 &material_table,
                 None,
+                None,
+                Structural2dFormulation::Axisymmetric,
                 QuadratureRule::GaussLegendre3,
             )
             .expect("operator assembly should succeed");
@@ -401,23 +431,28 @@ mod tests {
             &operators.strain_rows,
             &operators.strain_cols,
             &operators.strain_vals,
-            operators.points_rz.len() * 4,
+            operators.points.len() * 4,
             &u,
         );
         let stress = apply_triplets(
             &operators.stress_rows,
             &operators.stress_cols,
             &operators.stress_vals,
-            operators.points_rz.len() * 4,
+            operators.points.len() * 4,
             &u,
         );
 
         let coords = mesh.element_coords(0).expect("element coords");
-        let samples =
-            volume_samples_quad4(&coords, QuadratureRule::GaussLegendre3).expect("samples");
+        let samples = sampling::volume_samples_quad4(&coords, QuadratureRule::GaussLegendre3)
+            .expect("samples");
         for (q_local, sample) in samples.into_iter().enumerate() {
-            let b = build_b_matrix::<f64, 4, 8>(&sample.n, &sample.grad_phys, sample.point[0])
-                .expect("B matrix");
+            let b = build_b_matrix::<f64, 4, 8>(
+                Structural2dFormulation::Axisymmetric,
+                &sample.n,
+                &sample.grad_phys,
+                sample.point,
+            )
+            .expect("B matrix");
             let db = constitutive_times_b(&material_table[0], &b);
             for component in 0..4 {
                 let row = 4 * q_local + component;

--- a/src/physics/solenoid_stress/types.rs
+++ b/src/physics/solenoid_stress/types.rs
@@ -33,7 +33,10 @@ pub enum Structural2dFormulation<F: Real> {
     /// Axisymmetric reduction in `(r, z)` with hoop strain `e_tt = u_r / r`.
     Axisymmetric,
     /// Plane-strain reduction in `(x, y)` with `e_zz = 0` and finite model thickness.
-    PlaneStrain { thickness: F },
+    PlaneStrain {
+        /// Out-of-plane thickness used to convert analysis-plane integrals into 3D volume.
+        thickness: F,
+    },
 }
 
 impl<F: Real> Structural2dFormulation<F> {
@@ -145,10 +148,12 @@ pub struct TractionLoad {
     pub local_face: u8,
 }
 
-/// Per-material thermal-expansion data for the axisymmetric thermoelastic model.
+/// Per-material thermal-expansion data for the 2D thermoelastic model.
 #[derive(Clone, Copy, Debug)]
 pub struct ThermalMaterial<F: Real> {
-    /// Thermal strain coefficients in axisymmetric strain order `[rr, zz, tt, rz]`.
+    /// Thermal strain coefficients in the active four-component strain order.
+    ///
+    /// Axisymmetric models use `[rr, zz, tt, rz]`; plane-strain models use `[xx, yy, zz, xy]`.
     ///
     /// Units: `[strain / temperature]`.
     pub alpha: [F; 4],

--- a/src/physics/solenoid_stress/types.rs
+++ b/src/physics/solenoid_stress/types.rs
@@ -27,6 +27,75 @@ pub fn two_pi<F: Real>() -> F {
     cast(2.0 * core::f64::consts::PI)
 }
 
+/// Structural 2D reduction used by the quadrilateral FEM backend.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Structural2dFormulation<F: Real> {
+    /// Axisymmetric reduction in `(r, z)` with hoop strain `e_tt = u_r / r`.
+    Axisymmetric,
+    /// Plane-strain reduction in `(x, y)` with `e_zz = 0` and finite model thickness.
+    PlaneStrain { thickness: F },
+}
+
+impl<F: Real> Structural2dFormulation<F> {
+    /// Parse the compact formulation code used by the low-level Python binding.
+    pub fn from_code(code: u8, thickness: F) -> Result<Self, String> {
+        match code {
+            0 => Ok(Self::Axisymmetric),
+            1 => {
+                if thickness <= F::zero() {
+                    return Err(format!(
+                        "plane-strain thickness must be positive; got {thickness:?}"
+                    ));
+                }
+                Ok(Self::PlaneStrain { thickness })
+            }
+            _ => Err(format!(
+                "unsupported structural 2D formulation code {code}; use 0 for axisymmetric or 1 for plane_strain"
+            )),
+        }
+    }
+
+    /// Return the canonical public string spelling used by the Python wrapper and docs.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Axisymmetric => "axisymmetric",
+            Self::PlaneStrain { .. } => "plane_strain",
+        }
+    }
+
+    /// Return the axisymmetric swept-volume or planar-thickness measure for one volume sample.
+    pub fn volume_scale(self, point: [F; 2], det_j: F, weight: F) -> Result<F, String> {
+        match self {
+            Self::Axisymmetric => {
+                if point[0] < F::zero() {
+                    return Err(format!(
+                        "quadrature point has negative radius {:?}; axisymmetric radius must be nonnegative",
+                        point[0]
+                    ));
+                }
+                Ok(two_pi::<F>() * point[0] * det_j * weight)
+            }
+            Self::PlaneStrain { thickness } => Ok(thickness * det_j * weight),
+        }
+    }
+
+    /// Return the axisymmetric swept-surface or planar-thickness measure for one face sample.
+    pub fn face_scale(self, point: [F; 2], line_jacobian: F, weight: F) -> Result<F, String> {
+        match self {
+            Self::Axisymmetric => {
+                if point[0] < F::zero() {
+                    return Err(format!(
+                        "face quadrature point has negative radius {:?}; axisymmetric radius must be nonnegative",
+                        point[0]
+                    ));
+                }
+                Ok(two_pi::<F>() * point[0] * line_jacobian * weight)
+            }
+            Self::PlaneStrain { thickness } => Ok(thickness * line_jacobian * weight),
+        }
+    }
+}
+
 /// Number of displacement unknowns carried by each node in the axisymmetric structural solver.
 pub const DOF_PER_NODE: usize = 2;
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -213,6 +213,21 @@ fn read_axisym_thermal_material_table<F: physics::solenoid_stress::Real + NumpyE
     Ok(out)
 }
 
+fn read_axisym_material_orientation_angles<F: NumpyElement + Copy>(
+    name: &str,
+    angles: PyReadonlyArray1<'_, F>,
+) -> PyResult<Vec<F>> {
+    let view = angles.as_array();
+    let shape = view.shape();
+    if shape.len() != 1 {
+        return Err(PyInteropError::DimensionalityError {
+            msg: format!("{name} must have shape (nelem,) or be empty"),
+        }
+        .into());
+    }
+    Ok(view.iter().copied().collect())
+}
+
 fn read_axisym_pressure_faces(
     pressure_faces: PyReadonlyArray2<'_, u64>,
 ) -> PyResult<Vec<physics::solenoid_stress::PressureLoad>> {
@@ -270,7 +285,7 @@ fn parse_solenoid_fem_quadrature(
         .map_err(|msg| PyInteropError::ValueError { msg }.into())
 }
 
-fn flatten_axisym_points<F: Copy>(points: Vec<[F; 2]>) -> Vec<F> {
+fn flatten_points<F: Copy>(points: Vec<[F; 2]>) -> Vec<F> {
     let mut points_flat = Vec::with_capacity(points.len() * 2);
     for point in points {
         points_flat.push(point[0]);
@@ -338,18 +353,18 @@ fn read_axisym_prescribed<F: NumpyElement + Copy>(
 }
 
 #[pyclass(module = "cfsem", unsendable)]
-struct SolenoidStressAxisymmetricModelF64 {
-    inner: physics::solenoid_stress::AxisymmetricModel<f64>,
+struct SolenoidStress2dModelF64 {
+    inner: physics::solenoid_stress::Structural2dModel<f64>,
 }
 
 #[pyclass(module = "cfsem", unsendable)]
-struct SolenoidStressAxisymmetricModelF32 {
-    inner: physics::solenoid_stress::AxisymmetricModel<f32>,
+struct SolenoidStress2dModelF32 {
+    inner: physics::solenoid_stress::Structural2dModel<f32>,
 }
 
 /// Low-level PyO3 wrapper for the reusable axisymmetric FEM model.
 ///
-/// The public Python API lives in `cfsem.solenoid_stress.axisymmetric_fem`. This wrapper exposes
+/// The public Python API lives in `cfsem.solenoid_stress.fem2d`. This wrapper exposes
 /// raw arrays and sparse storage tuples so the higher-level Python module can normalize inputs,
 /// build SciPy sparse matrices, and present a cleaner user-facing surface.
 macro_rules! impl_solenoid_stress_model_pyclass {
@@ -391,8 +406,13 @@ macro_rules! impl_solenoid_stress_model_pyclass {
                 self.inner.element_type.as_str().to_string()
             }
 
+            #[getter]
+            fn formulation(&self) -> String {
+                self.inner.formulation.as_str().to_string()
+            }
+
             fn analysis_nodes_flat<'py>(&self, py: Python<'py>) -> Py<PyArray1<$ty>> {
-                PyArray1::from_vec(py, flatten_axisym_points(self.inner.analysis_nodes.clone())).unbind()
+                PyArray1::from_vec(py, flatten_points(self.inner.analysis_nodes.clone())).unbind()
             }
 
             fn analysis_elements_flat<'py>(&self, py: Python<'py>) -> Py<PyArray1<usize>> {
@@ -424,7 +444,7 @@ macro_rules! impl_solenoid_stress_model_pyclass {
             }
 
             fn quadrature_points_flat<'py>(&self, py: Python<'py>) -> Py<PyArray1<$ty>> {
-                PyArray1::from_vec(py, flatten_axisym_points(self.inner.recovery.points_rz.clone()))
+                PyArray1::from_vec(py, flatten_points(self.inner.recovery.points.clone()))
                     .unbind()
             }
 
@@ -685,7 +705,7 @@ macro_rules! impl_solenoid_stress_model_pyclass {
                     .element_quadrature()
                     .map_err(|msg| PyInteropError::ValueError { msg })?;
                 Ok((
-                    PyArray1::from_vec(py, flatten_axisym_points(quadrature.points_rz)).unbind(),
+                    PyArray1::from_vec(py, flatten_points(quadrature.points)).unbind(),
                     PyArray1::from_vec(py, quadrature.weights_area).unbind(),
                     PyArray1::from_vec(py, quadrature.weights_volume).unbind(),
                     quadrature.nq_per_element,
@@ -702,7 +722,7 @@ macro_rules! impl_solenoid_stress_model_pyclass {
                     .map_err(|msg| PyInteropError::ValueError { msg })?;
                 Ok((
                     PyArray1::from_vec(py, measures.areas).unbind(),
-                    PyArray1::from_vec(py, measures.swept_volumes).unbind(),
+                    PyArray1::from_vec(py, measures.volumes).unbind(),
                 ))
             }
 
@@ -730,7 +750,7 @@ macro_rules! impl_solenoid_stress_model_pyclass {
                     .evaluate_quadrature(displacements_full, nodal_temperature)
                     .map_err(|msg| PyInteropError::ValueError { msg })?;
                 Ok((
-                    PyArray1::from_vec(py, flatten_axisym_points(samples.points_rz)).unbind(),
+                    PyArray1::from_vec(py, flatten_points(samples.points)).unbind(),
                     PyArray1::from_vec(py, flatten_rank4_samples(samples.strain)).unbind(),
                     PyArray1::from_vec(py, flatten_rank4_samples(samples.thermal_strain)).unbind(),
                     PyArray1::from_vec(py, flatten_rank4_samples(samples.elastic_strain)).unbind(),
@@ -742,10 +762,10 @@ macro_rules! impl_solenoid_stress_model_pyclass {
     };
 }
 
-impl_solenoid_stress_model_pyclass!(SolenoidStressAxisymmetricModelF64, f64);
-impl_solenoid_stress_model_pyclass!(SolenoidStressAxisymmetricModelF32, f32);
+impl_solenoid_stress_model_pyclass!(SolenoidStress2dModelF64, f64);
+impl_solenoid_stress_model_pyclass!(SolenoidStress2dModelF32, f32);
 
-fn assemble_axisymmetric_model_low_level<F: physics::solenoid_stress::Real + NumpyElement>(
+fn assemble_structural_2d_model_low_level<F: physics::solenoid_stress::Real + NumpyElement>(
     nodes: PyReadonlyArray2<'_, F>,
     elements: PyReadonlyArray2<'_, u64>,
     material_ids: PyReadonlyArray1<'_, u64>,
@@ -753,14 +773,20 @@ fn assemble_axisymmetric_model_low_level<F: physics::solenoid_stress::Real + Num
     pressure_faces: PyReadonlyArray2<'_, u64>,
     traction_faces: PyReadonlyArray2<'_, u64>,
     thermal_material_table: PyReadonlyArray2<'_, F>,
+    material_orientation_angles: PyReadonlyArray1<'_, F>,
     prescribed_dofs: PyReadonlyArray1<'_, u64>,
     prescribed_values: PyReadonlyArray1<'_, F>,
     element_type: u8,
+    formulation: u8,
+    thickness: F,
     quadrature: u8,
-) -> PyResult<physics::solenoid_stress::AxisymmetricModel<F>> {
+) -> PyResult<physics::solenoid_stress::Structural2dModel<F>> {
     let quadrature = parse_solenoid_fem_quadrature(quadrature)?;
-    let element_type = physics::solenoid_stress::AxisymmetricElementType::from_code(element_type)
+    let element_type = physics::solenoid_stress::Structural2dElementType::from_code(element_type)
         .map_err(|msg| PyInteropError::ValueError { msg })?;
+    let formulation =
+        physics::solenoid_stress::Structural2dFormulation::from_code(formulation, thickness)
+            .map_err(|msg| PyInteropError::ValueError { msg })?;
     let nodes = read_axisym_nodes("nodes", nodes)?;
     let material_ids = read_axisym_material_ids("material_ids", material_ids)?;
     let material_table = read_axisym_material_table("material_table", material_table)?;
@@ -768,36 +794,46 @@ fn assemble_axisymmetric_model_low_level<F: physics::solenoid_stress::Real + Num
     let traction_faces = read_axisym_traction_faces(traction_faces)?;
     let thermal_material_table =
         read_axisym_thermal_material_table("thermal_material_table", thermal_material_table)?;
+    let material_orientation_angles = read_axisym_material_orientation_angles(
+        "material_orientation_angles",
+        material_orientation_angles,
+    )?;
     let prescribed = read_axisym_prescribed(prescribed_dofs, prescribed_values)?;
     let thermal_material_table =
         (!thermal_material_table.is_empty()).then_some(thermal_material_table.as_slice());
+    let material_orientation_angles =
+        (!material_orientation_angles.is_empty()).then_some(material_orientation_angles.as_slice());
     match element_type {
-        physics::solenoid_stress::AxisymmetricElementType::Quad4 => {
+        physics::solenoid_stress::Structural2dElementType::Quad4 => {
             let elements = read_axisym_elements::<4>("elements", elements)?;
-            physics::solenoid_stress::assemble_axisymmetric(
+            physics::solenoid_stress::assemble_structural_2d(
                 &nodes,
-                physics::solenoid_stress::AxisymmetricElements::Quad4(&elements),
+                physics::solenoid_stress::Structural2dElements::Quad4(&elements),
                 &material_ids,
                 &material_table,
                 &pressure_faces,
                 &traction_faces,
                 thermal_material_table,
+                material_orientation_angles,
                 &prescribed,
+                formulation,
                 quadrature,
             )
             .map_err(|msg| PyInteropError::ValueError { msg }.into())
         }
-        physics::solenoid_stress::AxisymmetricElementType::Quad9 => {
+        physics::solenoid_stress::Structural2dElementType::Quad9 => {
             let elements = read_axisym_elements::<9>("elements", elements)?;
-            physics::solenoid_stress::assemble_axisymmetric(
+            physics::solenoid_stress::assemble_structural_2d(
                 &nodes,
-                physics::solenoid_stress::AxisymmetricElements::Quad9(&elements),
+                physics::solenoid_stress::Structural2dElements::Quad9(&elements),
                 &material_ids,
                 &material_table,
                 &pressure_faces,
                 &traction_faces,
                 thermal_material_table,
+                material_orientation_angles,
                 &prescribed,
+                formulation,
                 quadrature,
             )
             .map_err(|msg| PyInteropError::ValueError { msg }.into())
@@ -805,9 +841,9 @@ fn assemble_axisymmetric_model_low_level<F: physics::solenoid_stress::Real + Num
     }
 }
 
-/// Low-level binding for `physics::solenoid_stress::assemble_axisymmetric` using `f64`.
+/// Low-level binding for `physics::solenoid_stress::assemble_structural_2d` using `f64`.
 #[pyfunction]
-fn solenoid_stress_fem_assemble_model_axisymmetric_f64(
+fn solenoid_stress_fem_assemble_model_2d_f64(
     nodes: PyReadonlyArray2<'_, f64>,
     elements: PyReadonlyArray2<'_, u64>,
     material_ids: PyReadonlyArray1<'_, u64>,
@@ -815,13 +851,16 @@ fn solenoid_stress_fem_assemble_model_axisymmetric_f64(
     pressure_faces: PyReadonlyArray2<'_, u64>,
     traction_faces: PyReadonlyArray2<'_, u64>,
     thermal_material_table: PyReadonlyArray2<'_, f64>,
+    material_orientation_angles: PyReadonlyArray1<'_, f64>,
     prescribed_dofs: PyReadonlyArray1<'_, u64>,
     prescribed_values: PyReadonlyArray1<'_, f64>,
     element_type: u8,
+    formulation: u8,
+    thickness: f64,
     quadrature: u8,
-) -> PyResult<SolenoidStressAxisymmetricModelF64> {
-    Ok(SolenoidStressAxisymmetricModelF64 {
-        inner: assemble_axisymmetric_model_low_level::<f64>(
+) -> PyResult<SolenoidStress2dModelF64> {
+    Ok(SolenoidStress2dModelF64 {
+        inner: assemble_structural_2d_model_low_level::<f64>(
             nodes,
             elements,
             material_ids,
@@ -829,17 +868,20 @@ fn solenoid_stress_fem_assemble_model_axisymmetric_f64(
             pressure_faces,
             traction_faces,
             thermal_material_table,
+            material_orientation_angles,
             prescribed_dofs,
             prescribed_values,
             element_type,
+            formulation,
+            thickness,
             quadrature,
         )?,
     })
 }
 
-/// Low-level binding for `physics::solenoid_stress::assemble_axisymmetric` using `f32`.
+/// Low-level binding for `physics::solenoid_stress::assemble_structural_2d` using `f32`.
 #[pyfunction]
-fn solenoid_stress_fem_assemble_model_axisymmetric_f32(
+fn solenoid_stress_fem_assemble_model_2d_f32(
     nodes: PyReadonlyArray2<'_, f32>,
     elements: PyReadonlyArray2<'_, u64>,
     material_ids: PyReadonlyArray1<'_, u64>,
@@ -847,13 +889,16 @@ fn solenoid_stress_fem_assemble_model_axisymmetric_f32(
     pressure_faces: PyReadonlyArray2<'_, u64>,
     traction_faces: PyReadonlyArray2<'_, u64>,
     thermal_material_table: PyReadonlyArray2<'_, f32>,
+    material_orientation_angles: PyReadonlyArray1<'_, f32>,
     prescribed_dofs: PyReadonlyArray1<'_, u64>,
     prescribed_values: PyReadonlyArray1<'_, f32>,
     element_type: u8,
+    formulation: u8,
+    thickness: f32,
     quadrature: u8,
-) -> PyResult<SolenoidStressAxisymmetricModelF32> {
-    Ok(SolenoidStressAxisymmetricModelF32 {
-        inner: assemble_axisymmetric_model_low_level::<f32>(
+) -> PyResult<SolenoidStress2dModelF32> {
+    Ok(SolenoidStress2dModelF32 {
+        inner: assemble_structural_2d_model_low_level::<f32>(
             nodes,
             elements,
             material_ids,
@@ -861,9 +906,12 @@ fn solenoid_stress_fem_assemble_model_axisymmetric_f32(
             pressure_faces,
             traction_faces,
             thermal_material_table,
+            material_orientation_angles,
             prescribed_dofs,
             prescribed_values,
             element_type,
+            formulation,
+            thickness,
             quadrature,
         )?,
     })
@@ -901,6 +949,26 @@ fn solenoid_stress_fem_isotropic_axisymmetric_material_f32<'py>(
     PyArray1::from_vec(py, flat).unbind()
 }
 
+/// Low-level binding for the isotropic plane-strain constitutive helper returning a flattened `4 x 4` matrix.
+#[pyfunction]
+fn solenoid_stress_fem_isotropic_plane_strain_material_f64<'py>(
+    py: Python<'py>,
+    youngs_modulus: f64,
+    poisson_ratio: f64,
+) -> Py<PyArray1<f64>> {
+    solenoid_stress_fem_isotropic_axisymmetric_material_f64(py, youngs_modulus, poisson_ratio)
+}
+
+/// Low-level binding for the isotropic plane-strain constitutive helper returning a flattened `4 x 4` matrix.
+#[pyfunction]
+fn solenoid_stress_fem_isotropic_plane_strain_material_f32<'py>(
+    py: Python<'py>,
+    youngs_modulus: f32,
+    poisson_ratio: f32,
+) -> Py<PyArray1<f32>> {
+    solenoid_stress_fem_isotropic_axisymmetric_material_f32(py, youngs_modulus, poisson_ratio)
+}
+
 /// Low-level binding for the isotropic thermal-material helper returning `[alpha_r, alpha_z, alpha_t, alpha_rz, T_ref]`.
 #[pyfunction]
 fn solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f64<'py>(
@@ -933,6 +1001,34 @@ fn solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f32<'py>(
     flat.extend_from_slice(&material.alpha);
     flat.push(material.reference_temperature);
     PyArray1::from_vec(py, flat).unbind()
+}
+
+/// Low-level binding for the isotropic plane-strain thermal-material helper returning `[alpha_x, alpha_y, alpha_z, alpha_xy, T_ref]`.
+#[pyfunction]
+fn solenoid_stress_fem_isotropic_plane_strain_thermal_material_f64<'py>(
+    py: Python<'py>,
+    alpha: f64,
+    reference_temperature: f64,
+) -> Py<PyArray1<f64>> {
+    solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f64(
+        py,
+        alpha,
+        reference_temperature,
+    )
+}
+
+/// Low-level binding for the isotropic plane-strain thermal-material helper returning `[alpha_x, alpha_y, alpha_z, alpha_xy, T_ref]`.
+#[pyfunction]
+fn solenoid_stress_fem_isotropic_plane_strain_thermal_material_f32<'py>(
+    py: Python<'py>,
+    alpha: f32,
+    reference_temperature: f32,
+) -> Py<PyArray1<f32>> {
+    solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f32(
+        py,
+        alpha,
+        reference_temperature,
+    )
 }
 
 /// Low-level binding for the orthotropic thermal-material helper returning `[alpha_r, alpha_z, alpha_t, alpha_rz, T_ref]`.
@@ -1024,7 +1120,7 @@ fn solenoid_stress_fem_infer_quad9_mesh_f64<'py>(
     let elements = read_axisym_elements::<4>("elements", elements)?;
     let elevated = physics::solenoid_stress::infer_quad9_mesh(&nodes, &elements)
         .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let analysis_nodes = flatten_axisym_points(elevated.analysis_nodes);
+    let analysis_nodes = flatten_points(elevated.analysis_nodes);
     let mut analysis_elements = Vec::with_capacity(elevated.analysis_elements.len() * 9);
     for conn in elevated.analysis_elements {
         analysis_elements.extend(conn.into_iter().map(|node| node as u64));
@@ -1079,7 +1175,7 @@ fn solenoid_stress_fem_infer_quad9_mesh_f32<'py>(
     let elements = read_axisym_elements::<4>("elements", elements)?;
     let elevated = physics::solenoid_stress::infer_quad9_mesh(&nodes, &elements)
         .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let analysis_nodes = flatten_axisym_points(elevated.analysis_nodes);
+    let analysis_nodes = flatten_points(elevated.analysis_nodes);
     let mut analysis_elements = Vec::with_capacity(elevated.analysis_elements.len() * 9);
     for conn in elevated.analysis_elements {
         analysis_elements.extend(conn.into_iter().map(|node| node as u64));
@@ -2953,14 +3049,14 @@ fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(vector_potential_dipole, m.clone())?)?;
 
     // Solenoid stress FEM
-    m.add_class::<SolenoidStressAxisymmetricModelF64>()?;
-    m.add_class::<SolenoidStressAxisymmetricModelF32>()?;
+    m.add_class::<SolenoidStress2dModelF64>()?;
+    m.add_class::<SolenoidStress2dModelF32>()?;
     m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_assemble_model_axisymmetric_f64,
+        solenoid_stress_fem_assemble_model_2d_f64,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_assemble_model_axisymmetric_f32,
+        solenoid_stress_fem_assemble_model_2d_f32,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
@@ -2972,11 +3068,27 @@ fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
+        solenoid_stress_fem_isotropic_plane_strain_material_f64,
+        m.clone()
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        solenoid_stress_fem_isotropic_plane_strain_material_f32,
+        m.clone()
+    )?)?;
+    m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f64,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f32,
+        m.clone()
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        solenoid_stress_fem_isotropic_plane_strain_thermal_material_f64,
+        m.clone()
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        solenoid_stress_fem_isotropic_plane_strain_thermal_material_f32,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -8,8 +8,8 @@ import scipy.interpolate as spi
 import scipy.sparse as sp
 import scipy.sparse.linalg as spla
 
-from cfsem.solenoid_stress import axisymmetric_fem as fem
-from cfsem.solenoid_stress.axisymmetric_fem import (
+from cfsem.solenoid_stress import fem2d as fem
+from cfsem.solenoid_stress.fem2d import (
     cfsem_radial_material,
     isotropic_axisymmetric_material,
 )
@@ -214,7 +214,7 @@ def tolerance(dtype: DType) -> tuple[float, float]:
 
 
 def solve_with_factorized_model(
-    model: fem.AxisymmetricFEMModel,
+    model: fem.Structural2DFEMModel,
     rhs: np.ndarray,
 ) -> np.ndarray:
     if model.stiffness.shape[0] == 0:
@@ -354,8 +354,8 @@ def assemble_model_and_rhs(
     prescribed: dict[int, float] | None = None,
     quadrature: str = "gl3",
     element_type: str = "quad4",
-) -> tuple[fem.AxisymmetricFEMModel, np.ndarray]:
-    model = fem.assemble_axisymmetric(
+) -> tuple[fem.Structural2DFEMModel, np.ndarray]:
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=material_ids,
@@ -386,7 +386,7 @@ def test_element_measures_and_quadrature_match_exact_cylindrical_shell_values(
     nz: int,
 ) -> None:
     nodes, elements = build_annulus_strip_mesh(1.0, 2.0, 1.0, nr=nr, nz=nz, dtype=dtype)
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -403,9 +403,9 @@ def test_element_measures_and_quadrature_match_exact_cylindrical_shell_values(
     rtol, atol = tolerance(dtype)
 
     assert np.all(measures.areas > 0.0)
-    assert np.all(measures.swept_volumes > 0.0)
+    assert np.all(measures.volumes > 0.0)
     assert np.allclose(measures.areas.sum(), expected_area, rtol=rtol, atol=atol)
-    assert np.allclose(measures.swept_volumes.sum(), expected_volume, rtol=rtol, atol=atol)
+    assert np.allclose(measures.volumes.sum(), expected_volume, rtol=rtol, atol=atol)
     assert np.allclose(
         quadrature_data.weights_area.sum(axis=1),
         measures.areas,
@@ -414,7 +414,7 @@ def test_element_measures_and_quadrature_match_exact_cylindrical_shell_values(
     )
     assert np.allclose(
         quadrature_data.weights_volume.sum(axis=1),
-        measures.swept_volumes,
+        measures.volumes,
         rtol=rtol,
         atol=atol,
     )
@@ -430,7 +430,7 @@ def test_body_force_total_matches_requested_total_force(
     nz: int,
 ) -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=nr, nz=nz, dtype=dtype)
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -439,7 +439,7 @@ def test_body_force_total_matches_requested_total_force(
     )
     measures = model.element_measures()
     total_force = np.array([1234.0, -432.0], dtype=dtype)
-    density = total_force / measures.swept_volumes.sum()
+    density = total_force / measures.volumes.sum()
 
     model, rhs = assemble_model_and_rhs(
         nodes=nodes,
@@ -467,7 +467,7 @@ def test_model_dtype_resolution_includes_material_tables() -> None:
     )
     nodal_temperature = np.linspace(294.0, 301.0, nodes.shape[0], dtype=np.float32)
 
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -493,7 +493,7 @@ def test_axisymmetric_model_reuses_factorization_across_load_cases(dtype: DType,
     inner_faces, outer_faces = pressure_faces_for_strip(nr=4, nz=2)
     pressure_faces = np.vstack([inner_faces, outer_faces])
     material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -710,7 +710,7 @@ def test_factorized_solve_reuses_stiffness_with_varying_traction(quadrature: str
     _bottom_faces, top_faces = horizontal_faces_for_strip(nr=3, nz=2)
     material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
     prescribed = prescribed_z_dofs(analysis_node_count_for_element_type(nodes, elements, element_type))
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -834,7 +834,7 @@ def test_linear_radial_temperature_long_cylinder_matches_analytic_midplane_stres
         (nodes[:, 0] - ri) / (ro - ri)
     )
 
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -849,7 +849,7 @@ def test_linear_radial_temperature_long_cylinder_matches_analytic_midplane_stres
     samples = model.evaluate_quadrature(displacement, nodal_temperature=nodal_temperature)
 
     dz = height / nz
-    points = samples.points_rz.reshape(-1, 2)
+    points = samples.points.reshape(-1, 2)
     stress = samples.stress.reshape(-1, 4)
     center_band = np.abs(points[:, 1] - 0.5 * height) <= 0.5 * dz
     assert np.count_nonzero(center_band) > 0
@@ -974,7 +974,7 @@ def test_multimaterial_loads_superpose_linearly(
     zfrac = case.nodes[:, 1] / case.height
     nodal_temperature_hot = reference_temperature + 18.0 * rfrac + 11.0 * zfrac
 
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=case.nodes,
         elements=case.elements,
         material_ids=case.material_ids,
@@ -1076,7 +1076,7 @@ def test_quadrature_recovery_splits_total_elastic_and_thermal_strain_consistentl
     displacement = np.linspace(-2.0e-4, 3.0e-4, 2 * analysis_nnode, dtype=dtype)
     nodal_temperature = np.linspace(292.0, 307.0, nodes.shape[0], dtype=dtype)
 
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -1125,7 +1125,7 @@ def test_pressure_vessel_stresses_match_lame_reference(
     )
     displacement = solve_with_factorized_model(model_fe, rhs)
     samples = model_fe.evaluate_quadrature(displacement)
-    radii = samples.points_rz[..., 0]
+    radii = samples.points[..., 0]
     radial_exact = s_radial_thick_wall_cylinder(radii, ri, ro, pin, pout)
     hoop_exact = s_hoop_thick_wall_cylinder(radii, ri, ro, pin, pout)
 
@@ -1281,7 +1281,7 @@ def test_two_material_pressure_vessel_matches_chained_1d_solver(element_type: st
         r_outer,
         u_outer,
     )
-    sample_r = samples.points_rz[..., 0]
+    sample_r = samples.points[..., 0]
     stress_r_1d = piecewise_interp_two_region(
         sample_r,
         interface_radius,
@@ -1396,12 +1396,12 @@ def test_distorted_2d_mesh_matches_regular_solution_at_common_points(
     regular_displacement = interpolate_field(regular_model.analysis_nodes, regular_u, sample_points)
     distorted_displacement = interpolate_field(distorted_model.analysis_nodes, distorted_u, sample_points)
     regular_stress = interpolate_field(
-        regular_samples.points_rz.reshape(-1, 2),
+        regular_samples.points.reshape(-1, 2),
         regular_samples.stress.reshape(-1, 4),
         sample_points,
     )
     distorted_stress = interpolate_field(
-        distorted_samples.points_rz.reshape(-1, 2),
+        distorted_samples.points.reshape(-1, 2),
         distorted_samples.stress.reshape(-1, 4),
         sample_points,
     )
@@ -1421,7 +1421,7 @@ def test_distorted_2d_mesh_matches_regular_solution_at_common_points(
 def test_model_recovery_and_fixed_dof_branches() -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=1, nz=1, dtype=np.float64)
     material = isotropic_axisymmetric_material(200.0e9, 0.27)
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -1441,7 +1441,7 @@ def test_assembly_and_postprocessing_validation_branches() -> None:
     material = isotropic_axisymmetric_material(200.0e9, 0.27)
 
     with pytest.raises(ValueError, match="material_ids has length 0"):
-        fem.assemble_axisymmetric(
+        fem.assemble_structural_2d(
             nodes=nodes,
             elements=elements,
             material_ids=np.zeros((0,), dtype=np.uint64),
@@ -1449,7 +1449,7 @@ def test_assembly_and_postprocessing_validation_branches() -> None:
         )
 
     with pytest.raises(ValueError, match="unsupported quadrature"):
-        fem.assemble_axisymmetric(
+        fem.assemble_structural_2d(
             nodes=nodes,
             elements=elements,
             material_ids=np.zeros((1,), dtype=np.uint64),
@@ -1458,7 +1458,7 @@ def test_assembly_and_postprocessing_validation_branches() -> None:
         )
 
     with pytest.raises(ValueError, match="displacements must have shape"):
-        model = fem.assemble_axisymmetric(
+        model = fem.assemble_structural_2d(
             nodes=nodes,
             elements=elements,
             material_ids=np.zeros((1,), dtype=np.uint64),
@@ -1476,7 +1476,7 @@ def test_assembly_and_postprocessing_validation_branches() -> None:
         dtype=np.float32,
     )
     with pytest.raises(ValueError, match="too close to zero"):
-        model = fem.assemble_axisymmetric(
+        model = fem.assemble_structural_2d(
             near_axis_nodes,
             np.array([[0, 1, 2, 3]], dtype=np.uint64),
             np.zeros((1,), dtype=np.uint64),
@@ -1490,7 +1490,7 @@ def test_model_zero_load_and_empty_reduction_branches() -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=1, nz=1, dtype=dtype)
     material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
 
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -1503,7 +1503,7 @@ def test_model_zero_load_and_empty_reduction_branches() -> None:
     assert displacement.shape == (model.ndof_full,)
 
     all_fixed = {dof: 0.0 for dof in range(2 * nodes.shape[0])}
-    fixed_model = fem.assemble_axisymmetric(
+    fixed_model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -1521,7 +1521,7 @@ def test_thermal_model_missing_temperature_and_alignment_validation_branches() -
     material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
     thermal_material = fem.isotropic_axisymmetric_thermal_material(1.2e-5, 293.15, dtype=dtype)
 
-    model = fem.assemble_axisymmetric(
+    model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
@@ -1540,7 +1540,7 @@ def test_thermal_model_missing_temperature_and_alignment_validation_branches() -
         material_table_by_tag={7: material},
         thermal_material_table_by_tag={7: thermal_material},
     )
-    packed_model = fem.assemble_axisymmetric(
+    packed_model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=packed_ids,
@@ -1551,7 +1551,7 @@ def test_thermal_model_missing_temperature_and_alignment_validation_branches() -
     assert packed_rhs.shape == (packed_model.ndof_reduced,)
 
     with pytest.raises(AssertionError, match="pack_material_tables_from_tags"):
-        fem.assemble_axisymmetric(
+        fem.assemble_structural_2d(
             nodes=nodes,
             elements=elements,
             material_ids=np.array([0], dtype=np.uint64),
@@ -1572,7 +1572,7 @@ def test_thermal_model_missing_temperature_and_alignment_validation_branches() -
         )
 
     with pytest.raises(AssertionError, match="alpha_rz"):
-        fem.assemble_axisymmetric(
+        fem.assemble_structural_2d(
             nodes=nodes,
             elements=elements,
             material_ids=np.array([0], dtype=np.uint64),
@@ -1673,3 +1673,95 @@ def test_quad9_temperature_elevation_reproduces_affine_temperature_field() -> No
     expected_temperature = a_r * elevated.analysis_nodes[:, 0] + b_z * elevated.analysis_nodes[:, 1] + c0
 
     assert np.allclose(analysis_temperature, expected_temperature, rtol=0.0, atol=1.0e-14)
+
+
+def test_plane_strain_accepts_negative_coordinates_and_recovers_linear_strain() -> None:
+    dtype = np.float64
+    nodes = np.asarray(
+        [
+            [-1.0, -0.5],
+            [2.0, -0.5],
+            [2.0, 1.5],
+            [-1.0, 1.5],
+        ],
+        dtype=dtype,
+    )
+    elements = np.asarray([[0, 1, 2, 3]], dtype=np.uint64)
+    material = fem.isotropic_plane_strain_material(200.0e9, 0.29, dtype=dtype)
+
+    model = fem.assemble_structural_2d(
+        nodes,
+        elements,
+        np.asarray([0], dtype=np.uint64),
+        np.asarray([material]),
+        formulation="plane_strain",
+        thickness=0.12,
+    )
+
+    a, b, c, d = 0.015, -0.02, 0.031, -0.011
+    displacement = np.column_stack(
+        [
+            a * nodes[:, 0] + b * nodes[:, 1],
+            c * nodes[:, 0] + d * nodes[:, 1],
+        ]
+    )
+    samples = model.evaluate_quadrature(displacement)
+
+    expected = np.asarray([a, d, 0.0, b + c], dtype=dtype)
+    assert model.formulation == "plane_strain"
+    assert model.coordinate_labels == ("x", "y")
+    assert model.tensor_labels == ("xx", "yy", "zz", "xy")
+    assert np.allclose(samples.strain.reshape(-1, 4), expected)
+
+    with pytest.raises(ValueError, match="negative radius"):
+        fem.assemble_structural_2d(
+            nodes,
+            elements,
+            np.asarray([0], dtype=np.uint64),
+            np.asarray([material]),
+            formulation="axisymmetric",
+        )
+
+
+def test_material_orientation_angles_rotate_in_plane_for_both_formulations() -> None:
+    dtype = np.float64
+    nodes_axisymmetric = np.asarray(
+        [
+            [0.7, 0.0],
+            [1.1, 0.0],
+            [1.1, 0.3],
+            [0.7, 0.3],
+        ],
+        dtype=dtype,
+    )
+    nodes_planar = np.asarray(
+        [
+            [-0.2, 0.0],
+            [0.2, 0.0],
+            [0.2, 0.3],
+            [-0.2, 0.3],
+        ],
+        dtype=dtype,
+    )
+    elements = np.asarray([[0, 1, 2, 3]], dtype=np.uint64)
+    material = np.diag(np.asarray([4.0, 7.0, 11.0, 3.0], dtype=dtype))
+
+    def dense_stiffness(nodes: np.ndarray, formulation: str, angle: float) -> np.ndarray:
+        model = fem.assemble_structural_2d(
+            nodes,
+            elements,
+            np.asarray([0], dtype=np.uint64),
+            np.asarray([material]),
+            formulation=formulation,
+            thickness=0.2 if formulation == "plane_strain" else None,
+            material_orientation_angles=angle,
+        )
+        return model.stiffness.toarray()
+
+    for nodes, formulation in ((nodes_axisymmetric, "axisymmetric"), (nodes_planar, "plane_strain")):
+        k0 = dense_stiffness(nodes, formulation, 0.0)
+        k_pi = dense_stiffness(nodes, formulation, np.pi)
+        k_half_pi = dense_stiffness(nodes, formulation, 0.5 * np.pi)
+
+        assert np.allclose(k0, k_pi, rtol=1.0e-12, atol=1.0e-12)
+        assert not np.allclose(k0, k_half_pi, rtol=1.0e-6, atol=1.0e-12)

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -1776,24 +1776,44 @@ def test_pack_material_tables_from_tags_sorts_tags_and_rewrites_ids() -> None:
 def test_python_convenience_wrappers_preserve_dtype_and_shapes() -> None:
     dtype = np.dtype(np.float32)
     iso = fem.isotropic_axisymmetric_material(200.0e9, 0.3, dtype=dtype)
+    iso_plane = fem.isotropic_plane_strain_material(200.0e9, 0.3, dtype=dtype)
     reduced = fem.cfsem_radial_material(200.0e9, 0.3, dtype=dtype)
     thermal = fem.isotropic_axisymmetric_thermal_material(1.0e-5, reference_temperature=293.15, dtype=dtype)
+    thermal_plane = fem.isotropic_plane_strain_thermal_material(
+        1.0e-5,
+        reference_temperature=293.15,
+        dtype=dtype,
+    )
     ortho = fem.orthotropic_axisymmetric_thermal_material(
+        1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15, dtype=dtype
+    )
+    ortho_plane = fem.orthotropic_plane_strain_thermal_material(
         1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15, dtype=dtype
     )
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=np.float32)
     elevated = fem.infer_quad9_mesh(nodes, elements)
 
     assert iso.shape == (4, 4)
+    assert iso_plane.shape == (4, 4)
     assert reduced.shape == (4, 4)
     assert thermal.shape == (5,)
+    assert thermal_plane.shape == (5,)
     assert ortho.shape == (5,)
+    assert ortho_plane.shape == (5,)
     assert iso.dtype == dtype
+    assert iso_plane.dtype == dtype
     assert reduced.dtype == dtype
     assert thermal.dtype == dtype
+    assert thermal_plane.dtype == dtype
     assert ortho.dtype == dtype
+    assert ortho_plane.dtype == dtype
     assert elevated.analysis_elements.shape[1] == 9
     assert elevated.analysis_nodes.dtype == dtype
+
+
+def test_private_formulation_code_rejects_unknown_formulation() -> None:
+    with pytest.raises(ValueError, match="unsupported formulation"):
+        fem._formulation_code("plane_stress")
 
 
 def test_quad9_temperature_elevation_reproduces_affine_temperature_field() -> None:

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -5,7 +5,6 @@ from typing import NamedTuple
 import numpy as np
 import pytest
 import scipy.interpolate as spi
-import scipy.sparse as sp
 import scipy.sparse.linalg as spla
 
 from cfsem.solenoid_stress import fem2d as fem
@@ -77,6 +76,112 @@ def build_annulus_strip_mesh(
                 ]
             )
     return nodes, np.asarray(elements, dtype=np.uint64)
+
+
+def build_planar_rect_mesh(
+    x_min: float,
+    x_max: float,
+    y_min: float,
+    y_max: float,
+    nx: int,
+    ny: int,
+    dtype: DType,
+) -> tuple[np.ndarray, np.ndarray]:
+    xs = np.linspace(x_min, x_max, nx + 1, dtype=dtype)
+    ys = np.linspace(y_min, y_max, ny + 1, dtype=dtype)
+    nodes = np.array([[x, y] for y in ys for x in xs], dtype=dtype)
+
+    def node_id(i: int, j: int) -> int:
+        return j * (nx + 1) + i
+
+    elements = []
+    for j in range(ny):
+        for i in range(nx):
+            elements.append(
+                [
+                    node_id(i, j),
+                    node_id(i + 1, j),
+                    node_id(i + 1, j + 1),
+                    node_id(i, j + 1),
+                ]
+            )
+    return nodes, np.asarray(elements, dtype=np.uint64)
+
+
+def build_annular_hole_mesh(
+    hole_radius: float,
+    outer_radius: float,
+    nr: int,
+    ntheta: int,
+    dtype: DType,
+) -> tuple[np.ndarray, np.ndarray]:
+    radii = np.linspace(hole_radius, outer_radius, nr + 1, dtype=dtype)
+    theta = np.linspace(0.0, 2.0 * np.pi, ntheta, endpoint=False, dtype=dtype)
+    nodes = np.array([[r * np.cos(t), r * np.sin(t)] for r in radii for t in theta], dtype=dtype)
+
+    def node_id(i: int, j: int) -> int:
+        return i * ntheta + (j % ntheta)
+
+    elements = []
+    for j in range(ntheta):
+        for i in range(nr):
+            elements.append(
+                [
+                    node_id(i, j),
+                    node_id(i + 1, j),
+                    node_id(i + 1, j + 1),
+                    node_id(i, j + 1),
+                ]
+            )
+    return nodes, np.asarray(elements, dtype=np.uint64)
+
+
+def outer_faces_for_annular_hole_mesh(nr: int, ntheta: int) -> np.ndarray:
+    return np.asarray([[j * nr + nr - 1, 1] for j in range(ntheta)], dtype=np.uint64)
+
+
+def kirsch_polar_stress(
+    remote_stress: float,
+    hole_radius: float,
+    r: np.ndarray,
+    theta: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    radius_ratio_2 = (hole_radius / r) ** 2
+    radius_ratio_4 = radius_ratio_2**2
+    cos2 = np.cos(2.0 * theta)
+    sin2 = np.sin(2.0 * theta)
+    sigma_rr = 0.5 * remote_stress * (
+        1.0 - radius_ratio_2 + (1.0 - 4.0 * radius_ratio_2 + 3.0 * radius_ratio_4) * cos2
+    )
+    sigma_tt = 0.5 * remote_stress * (
+        1.0 + radius_ratio_2 - (1.0 + 3.0 * radius_ratio_4) * cos2
+    )
+    sigma_rt = -0.5 * remote_stress * (1.0 + 2.0 * radius_ratio_2 - 3.0 * radius_ratio_4) * sin2
+    return sigma_rr, sigma_tt, sigma_rt
+
+
+def cartesian_traction_from_polar_stress(
+    sigma_rr: np.ndarray,
+    sigma_rt: np.ndarray,
+    theta: np.ndarray,
+) -> np.ndarray:
+    return np.column_stack(
+        [
+            sigma_rr * np.cos(theta) - sigma_rt * np.sin(theta),
+            sigma_rr * np.sin(theta) + sigma_rt * np.cos(theta),
+        ]
+    )
+
+
+def hoop_stress_from_cartesian(stress_xy: np.ndarray, points: np.ndarray) -> np.ndarray:
+    theta = np.arctan2(points[:, 1], points[:, 0])
+    sin_theta = np.sin(theta)
+    cos_theta = np.cos(theta)
+    return (
+        stress_xy[:, 0] * sin_theta**2
+        + stress_xy[:, 1] * cos_theta**2
+        - 2.0 * stress_xy[:, 3] * sin_theta * cos_theta
+    )
 
 
 def distort_annulus_strip_mesh(
@@ -1765,3 +1870,183 @@ def test_material_orientation_angles_rotate_in_plane_for_both_formulations() -> 
 
         assert np.allclose(k0, k_pi, rtol=1.0e-12, atol=1.0e-12)
         assert not np.allclose(k0, k_half_pi, rtol=1.0e-6, atol=1.0e-12)
+
+
+@pytest.mark.parametrize("element_type", ELEMENT_TYPES)
+@pytest.mark.parametrize("quadrature", QUADRATURES)
+def test_plane_strain_affine_patch_solve_is_exact(element_type: str, quadrature: str) -> None:
+    dtype = np.float64
+    nodes, elements = build_planar_rect_mesh(-1.25, 1.75, -0.8, 1.4, nx=2, ny=2, dtype=dtype)
+    analysis_nodes = analysis_nodes_for_element_type(nodes, elements, element_type)
+    material = fem.isotropic_plane_strain_material(185.0e9, 0.31, dtype=dtype)
+
+    a, b, c, d = 0.017, -0.023, 0.019, -0.013
+
+    def affine_displacement(points: np.ndarray) -> np.ndarray:
+        return np.column_stack(
+            [
+                a * points[:, 0] + b * points[:, 1],
+                c * points[:, 0] + d * points[:, 1],
+            ]
+        )
+
+    x_min, y_min = np.min(analysis_nodes, axis=0)
+    x_max, y_max = np.max(analysis_nodes, axis=0)
+    boundary = np.flatnonzero(
+        np.isclose(analysis_nodes[:, 0], x_min)
+        | np.isclose(analysis_nodes[:, 0], x_max)
+        | np.isclose(analysis_nodes[:, 1], y_min)
+        | np.isclose(analysis_nodes[:, 1], y_max)
+    )
+    boundary_displacement = affine_displacement(analysis_nodes)
+    prescribed = {
+        2 * int(node) + component: float(boundary_displacement[node, component])
+        for node in boundary
+        for component in range(2)
+    }
+
+    model = fem.assemble_structural_2d(
+        nodes,
+        elements,
+        np.zeros(elements.shape[0], dtype=np.uint64),
+        np.asarray([material]),
+        formulation="plane_strain",
+        thickness=0.35,
+        prescribed=prescribed,
+        element_type=element_type,
+        quadrature=quadrature,
+    )
+    displacement = model.solve(model.build_rhs())
+    samples = model.evaluate_quadrature(displacement)
+
+    expected_displacement = affine_displacement(model.analysis_nodes).reshape(-1)
+    expected_strain = np.asarray([a, d, 0.0, b + c], dtype=dtype)
+    assert np.allclose(displacement, expected_displacement, rtol=1.0e-11, atol=1.0e-12)
+    assert np.allclose(samples.strain.reshape(-1, 4), expected_strain, rtol=1.0e-12, atol=1.0e-13)
+
+
+@pytest.mark.parametrize("element_type", ELEMENT_TYPES)
+@pytest.mark.parametrize("quadrature", QUADRATURES)
+def test_plane_strain_uniaxial_stress_has_nonzero_out_of_plane_stress(
+    element_type: str,
+    quadrature: str,
+) -> None:
+    dtype = np.float64
+    youngs_modulus = 210.0e9
+    poisson_ratio = 0.28
+    remote_stress = 12.5e6
+    nodes, elements = build_planar_rect_mesh(-0.6, 0.9, -0.4, 0.5, nx=3, ny=3, dtype=dtype)
+    analysis_nodes = analysis_nodes_for_element_type(nodes, elements, element_type)
+    material = fem.isotropic_plane_strain_material(youngs_modulus, poisson_ratio, dtype=dtype)
+
+    epsilon_xx = remote_stress * (1.0 - poisson_ratio**2) / youngs_modulus
+    epsilon_yy = -poisson_ratio * (1.0 + poisson_ratio) * remote_stress / youngs_modulus
+    displacement_field = np.column_stack(
+        [
+            epsilon_xx * analysis_nodes[:, 0],
+            epsilon_yy * analysis_nodes[:, 1],
+        ]
+    )
+
+    x_min, y_min = np.min(analysis_nodes, axis=0)
+    x_max, y_max = np.max(analysis_nodes, axis=0)
+    boundary = np.flatnonzero(
+        np.isclose(analysis_nodes[:, 0], x_min)
+        | np.isclose(analysis_nodes[:, 0], x_max)
+        | np.isclose(analysis_nodes[:, 1], y_min)
+        | np.isclose(analysis_nodes[:, 1], y_max)
+    )
+    prescribed = {
+        2 * int(node) + component: float(displacement_field[node, component])
+        for node in boundary
+        for component in range(2)
+    }
+    model = fem.assemble_structural_2d(
+        nodes,
+        elements,
+        np.zeros(elements.shape[0], dtype=np.uint64),
+        np.asarray([material]),
+        formulation="plane_strain",
+        thickness=0.2,
+        prescribed=prescribed,
+        element_type=element_type,
+        quadrature=quadrature,
+    )
+    displacement = model.solve(model.build_rhs())
+    samples = model.evaluate_quadrature(displacement)
+
+    expected_stress = np.asarray(
+        [remote_stress, 0.0, poisson_ratio * remote_stress, 0.0],
+        dtype=dtype,
+    )
+    assert np.allclose(samples.strain[..., 2], 0.0, rtol=0.0, atol=1.0e-14)
+    assert np.allclose(samples.stress.reshape(-1, 4), expected_stress, rtol=1.0e-11, atol=2.0e-6)
+
+
+@pytest.mark.parametrize("element_type", ELEMENT_TYPES)
+@pytest.mark.parametrize("quadrature", QUADRATURES)
+@pytest.mark.parametrize("resolution_scale", [1, 2])
+def test_plane_strain_circular_hole_matches_kirsch_stress_concentration(
+    element_type: str,
+    quadrature: str,
+    resolution_scale: int,
+) -> None:
+    dtype = np.float64
+    hole_radius = 1.0
+    outer_radius = 8.0
+    nr = 32 * resolution_scale
+    ntheta = 256 * resolution_scale
+    remote_stress = 8.0e6
+    poisson_ratio = 0.29
+    nodes, elements = build_annular_hole_mesh(hole_radius, outer_radius, nr, ntheta, dtype)
+    outer_faces = outer_faces_for_annular_hole_mesh(nr, ntheta)
+    face_theta = (np.arange(ntheta, dtype=dtype) + 0.5) * (2.0 * np.pi / ntheta)
+    sigma_rr, _sigma_tt, sigma_rt = kirsch_polar_stress(
+        remote_stress,
+        hole_radius,
+        np.full(ntheta, outer_radius, dtype=dtype),
+        face_theta,
+    )
+    traction_values = cartesian_traction_from_polar_stress(sigma_rr, sigma_rt, face_theta).astype(dtype)
+
+    material = fem.isotropic_plane_strain_material(200.0e9, poisson_ratio, dtype=dtype)
+    prescribed = {
+        0: 0.0,
+        1: 0.0,
+        2 * ntheta + 1: 0.0,
+    }
+    model = fem.assemble_structural_2d(
+        nodes,
+        elements,
+        np.zeros(elements.shape[0], dtype=np.uint64),
+        np.asarray([material]),
+        formulation="plane_strain",
+        thickness=1.0,
+        traction_faces=outer_faces,
+        prescribed=prescribed,
+        quadrature=quadrature,
+        element_type=element_type,
+    )
+    displacement = solve_with_factorized_model(model, model.build_rhs(traction_values=traction_values))
+    samples = model.evaluate_quadrature(displacement)
+
+    points = samples.points.reshape(-1, 2)
+    stress = samples.stress.reshape(-1, 4)
+    radius = np.linalg.norm(points, axis=1)
+    theta = np.mod(np.arctan2(points[:, 1], points[:, 0]), 2.0 * np.pi)
+    fit_layers = 2.5 if element_type == "quad9" else 3.5
+    fit_degree = 3 if element_type == "quad9" else 2
+    near_hole = radius < hole_radius + fit_layers * (outer_radius - hole_radius) / nr
+    near_peak = near_hole & (np.abs(theta - 0.5 * np.pi) < 0.04)
+    assert np.count_nonzero(near_peak) >= 12
+
+    # The Kirsch stress concentration is a boundary value at r = a.  Recovered FEM stresses live
+    # at interior quadrature points, so compare a near-boundary extrapolation to Kt = 3.
+    hoop = hoop_stress_from_cartesian(stress[near_peak], points[near_peak]) / remote_stress
+    radial_offset = radius[near_peak] - hole_radius
+    boundary_fit = np.polyfit(radial_offset, hoop, deg=fit_degree)
+    stress_concentration = float(np.polyval(boundary_fit, 0.0))
+
+    assert np.isclose(stress_concentration, 3.0, rtol=0.02)
+    expected_sigma_zz = poisson_ratio * (stress[near_peak, 0] + stress[near_peak, 1])
+    assert np.allclose(stress[near_peak, 2], expected_sigma_zz, rtol=1.0e-10)

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -87,6 +87,8 @@ def build_planar_rect_mesh(
     ny: int,
     dtype: DType,
 ) -> tuple[np.ndarray, np.ndarray]:
+    """Build a structured rectangular quad4 mesh in the Cartesian analysis plane."""
+
     xs = np.linspace(x_min, x_max, nx + 1, dtype=dtype)
     ys = np.linspace(y_min, y_max, ny + 1, dtype=dtype)
     nodes = np.array([[x, y] for y in ys for x in xs], dtype=dtype)
@@ -115,6 +117,8 @@ def build_annular_hole_mesh(
     ntheta: int,
     dtype: DType,
 ) -> tuple[np.ndarray, np.ndarray]:
+    """Build a straight-sided annular quad4 mesh for circular-hole validation."""
+
     radii = np.linspace(hole_radius, outer_radius, nr + 1, dtype=dtype)
     theta = np.linspace(0.0, 2.0 * np.pi, ntheta, endpoint=False, dtype=dtype)
     nodes = np.array([[r * np.cos(t), r * np.sin(t)] for r in radii for t in theta], dtype=dtype)
@@ -143,6 +147,8 @@ def build_annular_hole_quad9_mesh(
     ntheta: int,
     dtype: DType,
 ) -> tuple[np.ndarray, np.ndarray]:
+    """Build an explicit curved quad9 annular mesh with polar midside and center nodes."""
+
     radii = np.linspace(hole_radius, outer_radius, 2 * nr + 1, dtype=dtype)
     theta = np.linspace(0.0, 2.0 * np.pi, 2 * ntheta, endpoint=False, dtype=dtype)
     nodes = np.array([[r * np.cos(t), r * np.sin(t)] for r in radii for t in theta], dtype=dtype)
@@ -172,6 +178,8 @@ def build_annular_hole_quad9_mesh(
 
 
 def outer_faces_for_annular_hole_mesh(nr: int, ntheta: int) -> np.ndarray:
+    """Return `[element, local_face]` rows for the annular mesh outer boundary."""
+
     return np.asarray([[j * nr + nr - 1, 1] for j in range(ntheta)], dtype=np.uint64)
 
 
@@ -217,7 +225,7 @@ def cartesian_traction_from_polar_stress(
 
 
 def hoop_stress_from_cartesian(stress_xy: np.ndarray, points: np.ndarray) -> np.ndarray:
-    """Project Cartesian plane-stress components onto the local circumferential direction."""
+    """Project in-plane Cartesian stress components onto the local circumferential direction."""
 
     theta = np.arctan2(points[:, 1], points[:, 0])
     sin_theta = np.sin(theta)

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -136,6 +136,41 @@ def build_annular_hole_mesh(
     return nodes, np.asarray(elements, dtype=np.uint64)
 
 
+def build_annular_hole_quad9_mesh(
+    hole_radius: float,
+    outer_radius: float,
+    nr: int,
+    ntheta: int,
+    dtype: DType,
+) -> tuple[np.ndarray, np.ndarray]:
+    radii = np.linspace(hole_radius, outer_radius, 2 * nr + 1, dtype=dtype)
+    theta = np.linspace(0.0, 2.0 * np.pi, 2 * ntheta, endpoint=False, dtype=dtype)
+    nodes = np.array([[r * np.cos(t), r * np.sin(t)] for r in radii for t in theta], dtype=dtype)
+
+    def node_id(i: int, j: int) -> int:
+        return i * (2 * ntheta) + (j % (2 * ntheta))
+
+    elements = []
+    for j in range(ntheta):
+        for i in range(nr):
+            i0 = 2 * i
+            j0 = 2 * j
+            elements.append(
+                [
+                    node_id(i0, j0),
+                    node_id(i0 + 2, j0),
+                    node_id(i0 + 2, j0 + 2),
+                    node_id(i0, j0 + 2),
+                    node_id(i0 + 1, j0),
+                    node_id(i0 + 2, j0 + 1),
+                    node_id(i0 + 1, j0 + 2),
+                    node_id(i0, j0 + 1),
+                    node_id(i0 + 1, j0 + 1),
+                ]
+            )
+    return nodes, np.asarray(elements, dtype=np.uint64)
+
+
 def outer_faces_for_annular_hole_mesh(nr: int, ntheta: int) -> np.ndarray:
     return np.asarray([[j * nr + nr - 1, 1] for j in range(ntheta)], dtype=np.uint64)
 
@@ -146,6 +181,12 @@ def kirsch_polar_stress(
     r: np.ndarray,
     theta: np.ndarray,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return the Kirsch infinite-plate stress field around a circular hole.
+
+    The remote load is uniaxial tension in the global x direction. Returned components are
+    `[sigma_rr, sigma_tt, sigma_rt]` in the local polar frame at `(r, theta)`.
+    """
+
     radius_ratio_2 = (hole_radius / r) ** 2
     radius_ratio_4 = radius_ratio_2**2
     cos2 = np.cos(2.0 * theta)
@@ -165,6 +206,8 @@ def cartesian_traction_from_polar_stress(
     sigma_rt: np.ndarray,
     theta: np.ndarray,
 ) -> np.ndarray:
+    """Convert polar radial-face stresses into global Cartesian traction components."""
+
     return np.column_stack(
         [
             sigma_rr * np.cos(theta) - sigma_rt * np.sin(theta),
@@ -174,6 +217,8 @@ def cartesian_traction_from_polar_stress(
 
 
 def hoop_stress_from_cartesian(stress_xy: np.ndarray, points: np.ndarray) -> np.ndarray:
+    """Project Cartesian plane-stress components onto the local circumferential direction."""
+
     theta = np.arctan2(points[:, 1], points[:, 0])
     sin_theta = np.sin(theta)
     cos_theta = np.cos(theta)
@@ -1872,9 +1917,56 @@ def test_material_orientation_angles_rotate_in_plane_for_both_formulations() -> 
         assert not np.allclose(k0, k_half_pi, rtol=1.0e-6, atol=1.0e-12)
 
 
+def test_explicit_quad9_input_uses_supplied_analysis_mesh() -> None:
+    """Explicit quad9 connectivity should preserve supplied geometry and recover affine strain."""
+
+    dtype = np.float64
+    nodes = np.asarray(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 1.0],
+            [0.0, 1.0],
+            [0.5, 0.0],
+            [1.0, 0.5],
+            [0.5, 1.0],
+            [0.0, 0.5],
+            [0.5, 0.5],
+        ],
+        dtype=dtype,
+    )
+    elements = np.asarray([[0, 1, 2, 3, 4, 5, 6, 7, 8]], dtype=np.uint64)
+    material = fem.isotropic_plane_strain_material(185.0e9, 0.31, dtype=dtype)
+    model = fem.assemble_structural_2d(
+        nodes,
+        elements,
+        np.asarray([0], dtype=np.uint64),
+        np.asarray([material]),
+        formulation="plane_strain",
+        thickness=0.35,
+        element_type="quad9",
+    )
+
+    a, b, c, d = 0.013, -0.017, 0.019, -0.011
+    displacement = np.column_stack(
+        [
+            a * nodes[:, 0] + b * nodes[:, 1],
+            c * nodes[:, 0] + d * nodes[:, 1],
+        ]
+    )
+    samples = model.evaluate_quadrature(displacement)
+
+    assert model.input_elements.shape == (1, 9)
+    assert np.array_equal(model.analysis_elements, elements)
+    assert np.allclose(model.analysis_nodes, nodes)
+    assert np.allclose(samples.strain.reshape(-1, 4), np.asarray([a, d, 0.0, b + c]))
+
+
 @pytest.mark.parametrize("element_type", ELEMENT_TYPES)
 @pytest.mark.parametrize("quadrature", QUADRATURES)
 def test_plane_strain_affine_patch_solve_is_exact(element_type: str, quadrature: str) -> None:
+    """A compatible affine displacement field should solve exactly and recover constant strain."""
+
     dtype = np.float64
     nodes, elements = build_planar_rect_mesh(-1.25, 1.75, -0.8, 1.4, nx=2, ny=2, dtype=dtype)
     analysis_nodes = analysis_nodes_for_element_type(nodes, elements, element_type)
@@ -1931,6 +2023,8 @@ def test_plane_strain_uniaxial_stress_has_nonzero_out_of_plane_stress(
     element_type: str,
     quadrature: str,
 ) -> None:
+    """Plane strain should enforce zero out-of-plane strain while retaining sigma_zz."""
+
     dtype = np.float64
     youngs_modulus = 210.0e9
     poisson_ratio = 0.28
@@ -1991,14 +2085,20 @@ def test_plane_strain_circular_hole_matches_kirsch_stress_concentration(
     quadrature: str,
     resolution_scale: int,
 ) -> None:
+    """A large plate with a circular hole should recover the Kirsch Kt=3 stress concentration."""
+
     dtype = np.float64
     hole_radius = 1.0
     outer_radius = 8.0
-    nr = 32 * resolution_scale
-    ntheta = 256 * resolution_scale
+    base_nr, base_ntheta = (16, 128) if element_type == "quad9" else (32, 256)
+    nr = base_nr * resolution_scale
+    ntheta = base_ntheta * resolution_scale
     remote_stress = 8.0e6
     poisson_ratio = 0.29
-    nodes, elements = build_annular_hole_mesh(hole_radius, outer_radius, nr, ntheta, dtype)
+    if element_type == "quad9":
+        nodes, elements = build_annular_hole_quad9_mesh(hole_radius, outer_radius, nr, ntheta, dtype)
+    else:
+        nodes, elements = build_annular_hole_mesh(hole_radius, outer_radius, nr, ntheta, dtype)
     outer_faces = outer_faces_for_annular_hole_mesh(nr, ntheta)
     face_theta = (np.arange(ntheta, dtype=dtype) + 0.5) * (2.0 * np.pi / ntheta)
     sigma_rr, _sigma_tt, sigma_rt = kirsch_polar_stress(


### PR DESCRIPTION
## 6.0.0 2026-04-24

### Changed

* Rust
    * !Generalize axisymmetric stress solver to cover both axisymmetric and plane-strain
    * !Rename items from "axisymmetric" to indicate more general usage
* Python
    * !Rename axisymmetric_fem module to fem2d
    * !Update FEM bindings to match changes to Rust backend
    * Add handling for explicit 9-point quad mesh input
