### PR TITLE
Add single-point quadrature for triangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 6.1.0 2026-04-27
+
+### Changed
+
+* Rust
+    * Add single-point quadrature option for BEM triangles
+* Python
+    * Plumb `gl1` single-point quad into bindings and tests
+
 ## 6.0.0 2026-04-24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfsem"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "branches",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfsem"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2024"
 authors = ["Commonwealth Fusion Systems <jlogan@cfs.energy>"]
 license = "MIT"

--- a/cfsem/bindings.py
+++ b/cfsem/bindings.py
@@ -390,7 +390,7 @@ def flux_density_triangle_mesh(
         triangles: node indices with shape `(ntri, 3)`
         s: [A] nodal stream-function values with shape `(nnode,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [T] (Bx, By, Bz) magnetic flux density at observation points
@@ -420,7 +420,7 @@ def vector_potential_triangle_mesh(
         triangles: node indices with shape `(ntri, 3)`
         s: [A] nodal stream-function values with shape `(nnode,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [Wb/m] or [V-s/m] (Ax, Ay, Az) magnetic vector potential at observation points
@@ -447,7 +447,7 @@ def flux_density_triangle_mesh_mapping(
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [T/A] `(bx_map, by_map, bz_map)` with shape `(nobs, nnode)`
@@ -480,7 +480,7 @@ def vector_potential_triangle_mesh_mapping(
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [V*s/(m*A)] `(ax_map, ay_map, az_map)` with shape `(nobs, nnode)`
@@ -532,7 +532,7 @@ def triangle_mesh_quadrature_points(
     Args:
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         points: [m] quadrature-point coordinates with shape `(ntri, nqp, 3)`
@@ -563,7 +563,7 @@ def triangle_mesh_inductance_matrix(
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [H] dense nodal inductance matrix with shape `(nnode, nnode)`
@@ -594,7 +594,7 @@ def triangle_mesh_inductance_mapping_from_linear_filaments(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         wire_radius: [m] filament radius, scalar or array of length `nfil`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [H] mapping matrix with shape `(nnode_tgt, nfil)`
@@ -629,7 +629,7 @@ def triangle_mesh_inductance_mapping_from_circular_filaments(
         nodes_tgt: [m] target mesh node coordinates with shape `(nnode_tgt, 3)`
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [H] mapping matrix with shape `(nnode_tgt, nfil)`
@@ -663,7 +663,7 @@ def triangle_mesh_flux_linkage_mapping_from_dipoles(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         outer_radius: [m] dipole finite-core radius, scalar or array of length `ndip`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         mapping matrix with shape `(nnode_tgt, ndip)`
@@ -700,7 +700,7 @@ def triangle_mesh_force_mapping(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, nnode_src)`
@@ -737,7 +737,7 @@ def triangle_mesh_self_force_mapping(
         triangles: node indices with shape `(ntri, 3)`
         s: [A] fixed nodal current-potential values with shape `(nnode,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri, nnode)`
@@ -776,7 +776,7 @@ def triangle_mesh_force_mapping_from_linear_filaments(
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         wire_radius: [m] filament radius, scalar or array of length `nfil`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, nfil)`
@@ -820,7 +820,7 @@ def triangle_mesh_force_mapping_from_circular_filaments(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, nfil)`
@@ -863,7 +863,7 @@ def triangle_mesh_force_mapping_from_dipoles(
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         par: Whether to use CPU parallelism
         outer_radius: [m] radius inside which to defer to magnetized sphere calc. Defaults to zeroes.
-        quad: Triangle quadrature rule, one of `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
 
     Returns:
         [N/source_amplitude] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, ndip)`

--- a/examples/field_explorer.py
+++ b/examples/field_explorer.py
@@ -116,7 +116,7 @@ def normalize_boundary_element_strip_count(n_strip_count: int) -> int:
 
 
 def normalize_boundary_element_quadrature(quad: str | None) -> str:
-    return quad if quad in ("gl2", "gl3", "dunavant5") else DEFAULT_BOUNDARY_ELEMENT_QUAD
+    return quad if quad in ("gl1", "gl2", "gl3", "dunavant5") else DEFAULT_BOUNDARY_ELEMENT_QUAD
 
 
 def finite_positive_max(values: np.ndarray) -> float | None:
@@ -2098,6 +2098,7 @@ def create_app():
                                     dcc.Dropdown(
                                         id="boundary-element-quad",
                                         options=[
+                                            {"label": "Gauss-Legendre 1", "value": "gl1"},
                                             {"label": "Gauss-Legendre 2", "value": "gl2"},
                                             {"label": "Gauss-Legendre 3", "value": "gl3"},
                                             {"label": "Dunavant 5", "value": "dunavant5"},

--- a/src/mesh/elements/tri/quadrature.rs
+++ b/src/mesh/elements/tri/quadrature.rs
@@ -1,5 +1,9 @@
 //! Reference-triangle quadrature rules used by the boundary-element triangle kernels.
 
+/// One-point centroid quadrature rule on a triangle.
+/// Format is `[weight, u, v]`.
+const TABLE_GAUSS_LEGENDRE_1: [[f64; 3]; 1] = [[0.5, 1.0 / 3.0, 1.0 / 3.0]];
+
 /// Second-order quadrature integration weights on a triangular surface.
 /// Format is `[weight, u, v]`.
 const TABLE_GAUSS_LEGENDRE_2: [[f64; 3]; 4] = [
@@ -40,6 +44,7 @@ pub const TRIANGLE_MAX_QUADRATURE_POINTS: usize = TABLE_GAUSS_LEGENDRE_3.len();
 
 #[derive(Clone, Copy)]
 pub enum QuadratureKind {
+    GaussLegendre1,
     GaussLegendre2,
     GaussLegendre3,
     Dunavant5,
@@ -48,6 +53,7 @@ pub enum QuadratureKind {
 #[inline]
 pub fn triangle_quadrature_points(quad_kind: QuadratureKind) -> &'static [[f64; 3]] {
     match quad_kind {
+        QuadratureKind::GaussLegendre1 => &TABLE_GAUSS_LEGENDRE_1,
         QuadratureKind::GaussLegendre2 => &TABLE_GAUSS_LEGENDRE_2,
         QuadratureKind::GaussLegendre3 => &TABLE_GAUSS_LEGENDRE_3,
         QuadratureKind::Dunavant5 => &TABLE_DUNAVANT_5,

--- a/src/physics/boundary_element/test.rs
+++ b/src/physics/boundary_element/test.rs
@@ -1133,6 +1133,29 @@ fn test_triangle_mesh_quadrature_points_and_current_density_extractors() {
     }
 }
 
+/// Checks that the single-point rule is the reference-triangle centroid rule.
+#[test]
+fn test_single_point_triangle_quadrature_rule() {
+    let quad_points = triangle_quadrature_points(QuadratureKind::GaussLegendre1);
+
+    assert_eq!(quad_points, &[[0.5, 1.0 / 3.0, 1.0 / 3.0]]);
+    assert_eq!(triangle_quadrature_count(QuadratureKind::GaussLegendre1), 1);
+
+    for p in 0..=1 {
+        for q in 0..=(1 - p) {
+            let approx_int = quad_points
+                .iter()
+                .map(|qp| qp[0] * qp[1].powi(p as i32) * qp[2].powi(q as i32))
+                .sum::<f64>();
+            let exact_int = reference_triangle_monomial_integral(p, q);
+            assert!(
+                approx(approx_int, exact_int, 0.0, 1e-14),
+                "single-point rule failed for u^{p} v^{q}: approx={approx_int:.16e}, exact={exact_int:.16e}"
+            );
+        }
+    }
+}
+
 /// Checks that the Dunavant rule integrates reference-triangle monomials through degree five.
 #[test]
 fn test_dunavant_rule_integrates_reference_triangle_monomials_to_degree_five() {

--- a/src/python.rs
+++ b/src/python.rs
@@ -90,6 +90,7 @@ fn split_triangle_index_array2(
 
 fn parse_triangle_quadrature(quad: &str) -> PyResult<physics::boundary_element::QuadratureKind> {
     match quad {
+        "gl1" => Ok(physics::boundary_element::QuadratureKind::GaussLegendre1),
         "gl2" => Ok(physics::boundary_element::QuadratureKind::GaussLegendre2),
         "gl3" => Ok(physics::boundary_element::QuadratureKind::GaussLegendre3),
         "dunavant5" => Ok(physics::boundary_element::QuadratureKind::Dunavant5),

--- a/test/test_boundary_element.py
+++ b/test/test_boundary_element.py
@@ -5,6 +5,8 @@ from pytest import approx, mark, raises
 
 import cfsem
 
+GL1_TRI_QUAD = np.array([[0.5, 1.0 / 3.0, 1.0 / 3.0]], dtype=np.float64)
+
 GL2_TRI_QUAD = np.array(
     [
         [0.05283121635, 0.1666666667, 0.7886751346],
@@ -134,12 +136,17 @@ def test_triangle_mesh_quadrature_points_and_current_density():
 
     j = cfsem.triangle_mesh_current_density(nodes, triangles, s)
     j_ref = _triangle_current_density_reference(nodes, triangles, s)
+    centroid_points, centroid_weights = cfsem.triangle_mesh_quadrature_points(
+        nodes, triangles, quad="gl1"
+    )
     points, weights = cfsem.triangle_mesh_quadrature_points(nodes, triangles, quad="gl2")
     dunavant_points, dunavant_weights = cfsem.triangle_mesh_quadrature_points(
         nodes, triangles, quad="dunavant5"
     )
 
     assert j.shape == (triangles.shape[0], 3)
+    assert centroid_points.shape == (triangles.shape[0], GL1_TRI_QUAD.shape[0], 3)
+    assert centroid_weights.shape == (triangles.shape[0], GL1_TRI_QUAD.shape[0])
     assert points.shape == (triangles.shape[0], GL2_TRI_QUAD.shape[0], 3)
     assert weights.shape == (triangles.shape[0], GL2_TRI_QUAD.shape[0])
     assert dunavant_points.shape == (triangles.shape[0], 7, 3)
@@ -151,18 +158,26 @@ def test_triangle_mesh_quadrature_points_and_current_density():
         n1 = nodes[i1]
         n2 = nodes[i2]
         area = 0.5 * np.linalg.norm(np.cross(n1 - n0, n2 - n0))
+        expected_centroid = (
+            (1.0 - GL1_TRI_QUAD[:, 1] - GL1_TRI_QUAD[:, 2])[:, None] * n0[None, :]
+            + GL1_TRI_QUAD[:, 1][:, None] * n1[None, :]
+            + GL1_TRI_QUAD[:, 2][:, None] * n2[None, :]
+        )
+        expected_centroid_weights = GL1_TRI_QUAD[:, 0] * area
         expected_points = (
             (1.0 - GL2_TRI_QUAD[:, 1] - GL2_TRI_QUAD[:, 2])[:, None] * n0[None, :]
             + GL2_TRI_QUAD[:, 1][:, None] * n1[None, :]
             + GL2_TRI_QUAD[:, 2][:, None] * n2[None, :]
         )
         expected_weights = GL2_TRI_QUAD[:, 0] * area
+        assert np.allclose(centroid_points[i], expected_centroid, rtol=0.0, atol=1e-13)
+        assert np.allclose(centroid_weights[i], expected_centroid_weights, rtol=0.0, atol=1e-13)
         assert np.allclose(points[i], expected_points, rtol=0.0, atol=1e-13)
         assert np.allclose(weights[i], expected_weights, rtol=0.0, atol=1e-13)
 
 
 @mark.parametrize("par", [True, False])
-@mark.parametrize("quad", ["gl2", "gl3", "dunavant5"])
+@mark.parametrize("quad", ["gl1", "gl2", "gl3", "dunavant5"])
 def test_triangle_mesh_far_field_against_circular_filament(par, quad):
     """Compare far-field triangle-mesh fields against the circular-filament reference."""
     radius = 0.7312345987


### PR DESCRIPTION
## 6.1.0 2026-04-27

### Changed

* Rust
    * Add single-point quadrature option for BEM triangles
* Python
    * Plumb `gl1` single-point quad into bindings and tests
