### PR TITLE
Replace triangle Gauss-Legendre quad sets with Dunavant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 8.0.0 2026-04-28
+
+* Rust
+    * !Replace triangle Gauss-Legendre quadrature point sets with Dunavant variants of order 1-4
+* Python
+    * Plumb new quadrature variants through bindings
+
 ## 7.0.0 2026-04-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfsem"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "branches",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfsem"
-version = "7.0.0"
+version = "8.0.0"
 edition = "2024"
 authors = ["Commonwealth Fusion Systems <jlogan@cfs.energy>"]
 license = "MIT"

--- a/cfsem/bindings.py
+++ b/cfsem/bindings.py
@@ -378,7 +378,7 @@ def flux_density_triangle_mesh(
     triangles: NDArray[int64],
     s: NDArray[float64],
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> Array3xN:
     """
     Biot-Savart law calculation for B-field contribution from a triangle mesh
@@ -390,7 +390,7 @@ def flux_density_triangle_mesh(
         triangles: node indices with shape `(ntri, 3)`
         s: [A] nodal stream-function values with shape `(nnode,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [T] (Bx, By, Bz) magnetic flux density at observation points
@@ -408,7 +408,7 @@ def vector_potential_triangle_mesh(
     triangles: NDArray[int64],
     s: NDArray[float64],
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> Array3xN:
     """
     Vector potential calculation for A-field contribution from a triangle mesh
@@ -420,7 +420,7 @@ def vector_potential_triangle_mesh(
         triangles: node indices with shape `(ntri, 3)`
         s: [A] nodal stream-function values with shape `(nnode,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [Wb/m] or [V-s/m] (Ax, Ay, Az) magnetic vector potential at observation points
@@ -437,7 +437,7 @@ def flux_density_triangle_mesh_mapping(
     nodes: NDArray[float64],
     triangles: NDArray[int64],
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> tuple[NDArray[float64], NDArray[float64], NDArray[float64]]:
     """
     Assemble the dense source-node to target-point B-field mapping for a triangle mesh.
@@ -447,7 +447,7 @@ def flux_density_triangle_mesh_mapping(
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [T/A] `(bx_map, by_map, bz_map)` with shape `(nobs, nnode)`
@@ -470,7 +470,7 @@ def vector_potential_triangle_mesh_mapping(
     nodes: NDArray[float64],
     triangles: NDArray[int64],
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> tuple[NDArray[float64], NDArray[float64], NDArray[float64]]:
     """
     Assemble the dense source-node to target-point A-field mapping for a triangle mesh.
@@ -480,7 +480,7 @@ def vector_potential_triangle_mesh_mapping(
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [V*s/(m*A)] `(ax_map, ay_map, az_map)` with shape `(nobs, nnode)`
@@ -524,7 +524,7 @@ def triangle_mesh_current_density(
 def triangle_mesh_quadrature_points(
     nodes: NDArray[float64],
     triangles: NDArray[int64],
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> tuple[NDArray[float64], NDArray[float64]]:
     """
     Extract physical quadrature-point coordinates and area weights for each triangle.
@@ -532,7 +532,7 @@ def triangle_mesh_quadrature_points(
     Args:
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         points: [m] quadrature-point coordinates with shape `(ntri, nqp, 3)`
@@ -551,7 +551,7 @@ def triangle_mesh_inductance_matrix(
     nodes: NDArray[float64],
     triangles: NDArray[int64],
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> NDArray[float64]:
     """
     Assemble the dense nodal inductance matrix for a triangle stream-function mesh.
@@ -563,7 +563,7 @@ def triangle_mesh_inductance_matrix(
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [H] dense nodal inductance matrix with shape `(nnode, nnode)`
@@ -582,7 +582,7 @@ def triangle_mesh_inductance_mapping_from_linear_filaments(
     triangles_tgt: NDArray[int64],
     wire_radius: float | NDArray[float64] = 0.0,
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> NDArray[float64]:
     """
     Assemble the source-current to target-node inductance mapping from linear filaments.
@@ -594,7 +594,7 @@ def triangle_mesh_inductance_mapping_from_linear_filaments(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         wire_radius: [m] filament radius, scalar or array of length `nfil`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [H] mapping matrix with shape `(nnode_tgt, nfil)`
@@ -618,7 +618,7 @@ def triangle_mesh_inductance_mapping_from_circular_filaments(
     nodes_tgt: NDArray[float64],
     triangles_tgt: NDArray[int64],
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> NDArray[float64]:
     """
     Assemble the source-current to target-node inductance mapping from circular filaments.
@@ -629,7 +629,7 @@ def triangle_mesh_inductance_mapping_from_circular_filaments(
         nodes_tgt: [m] target mesh node coordinates with shape `(nnode_tgt, 3)`
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [H] mapping matrix with shape `(nnode_tgt, nfil)`
@@ -651,7 +651,7 @@ def triangle_mesh_flux_linkage_mapping_from_dipoles(
     triangles_tgt: NDArray[int64],
     outer_radius: float | NDArray[float64] = 0.0,
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> NDArray[float64]:
     """
     Assemble the source-amplitude to target-node flux-linkage mapping from dipoles.
@@ -663,7 +663,7 @@ def triangle_mesh_flux_linkage_mapping_from_dipoles(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         outer_radius: [m] dipole finite-core radius, scalar or array of length `ndip`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         mapping matrix with shape `(nnode_tgt, ndip)`
@@ -688,7 +688,7 @@ def triangle_mesh_force_mapping(
     triangles_tgt: NDArray[int64],
     s_tgt: NDArray[float64],
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> tuple[NDArray[float64], NDArray[float64], NDArray[float64]]:
     """
     Assemble the frozen-target source-node to target-triangle force mapping between two meshes.
@@ -700,7 +700,7 @@ def triangle_mesh_force_mapping(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, nnode_src)`
@@ -727,7 +727,7 @@ def triangle_mesh_self_force_mapping(
     triangles: NDArray[int64],
     s: NDArray[float64],
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> tuple[NDArray[float64], NDArray[float64], NDArray[float64]]:
     """
     Assemble the self-excluded frozen-target source-node to target-triangle force mapping.
@@ -737,7 +737,7 @@ def triangle_mesh_self_force_mapping(
         triangles: node indices with shape `(ntri, 3)`
         s: [A] fixed nodal current-potential values with shape `(nnode,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri, nnode)`
@@ -763,7 +763,7 @@ def triangle_mesh_force_mapping_from_linear_filaments(
     s_tgt: NDArray[float64],
     wire_radius: float | NDArray[float64] = 0.0,
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> tuple[NDArray[float64], NDArray[float64], NDArray[float64]]:
     """
     Assemble the frozen-target source-current to target-triangle force mapping from linear filaments.
@@ -776,7 +776,7 @@ def triangle_mesh_force_mapping_from_linear_filaments(
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         wire_radius: [m] filament radius, scalar or array of length `nfil`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, nfil)`
@@ -808,7 +808,7 @@ def triangle_mesh_force_mapping_from_circular_filaments(
     triangles_tgt: NDArray[int64],
     s_tgt: NDArray[float64],
     par: bool = True,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> tuple[NDArray[float64], NDArray[float64], NDArray[float64]]:
     """
     Assemble the frozen-target source-current to target-triangle force mapping from circular filaments.
@@ -820,7 +820,7 @@ def triangle_mesh_force_mapping_from_circular_filaments(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, nfil)`
@@ -850,7 +850,7 @@ def triangle_mesh_force_mapping_from_dipoles(
     s_tgt: NDArray[float64],
     par: bool = True,
     outer_radius: NDArray[float64] | None = None,
-    quad: str = "gl3",
+    quad: str = "dunavant3",
 ) -> tuple[NDArray[float64], NDArray[float64], NDArray[float64]]:
     """
     Assemble the frozen-target source-amplitude to target-triangle force mapping from dipoles.
@@ -863,7 +863,7 @@ def triangle_mesh_force_mapping_from_dipoles(
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         par: Whether to use CPU parallelism
         outer_radius: [m] radius inside which to defer to magnetized sphere calc. Defaults to zeroes.
-        quad: Triangle quadrature rule, one of `"gl1"`, `"gl2"`, `"gl3"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/source_amplitude] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, ndip)`

--- a/cfsem/bindings.py
+++ b/cfsem/bindings.py
@@ -390,7 +390,8 @@ def flux_density_triangle_mesh(
         triangles: node indices with shape `(ntri, 3)`
         s: [A] nodal stream-function values with shape `(nnode,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [T] (Bx, By, Bz) magnetic flux density at observation points
@@ -420,7 +421,8 @@ def vector_potential_triangle_mesh(
         triangles: node indices with shape `(ntri, 3)`
         s: [A] nodal stream-function values with shape `(nnode,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [Wb/m] or [V-s/m] (Ax, Ay, Az) magnetic vector potential at observation points
@@ -447,7 +449,8 @@ def flux_density_triangle_mesh_mapping(
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [T/A] `(bx_map, by_map, bz_map)` with shape `(nobs, nnode)`
@@ -480,7 +483,8 @@ def vector_potential_triangle_mesh_mapping(
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [V*s/(m*A)] `(ax_map, ay_map, az_map)` with shape `(nobs, nnode)`
@@ -532,7 +536,8 @@ def triangle_mesh_quadrature_points(
     Args:
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         points: [m] quadrature-point coordinates with shape `(ntri, nqp, 3)`
@@ -563,7 +568,8 @@ def triangle_mesh_inductance_matrix(
         nodes: [m] mesh node coordinates with shape `(nnode, 3)`
         triangles: node indices with shape `(ntri, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [H] dense nodal inductance matrix with shape `(nnode, nnode)`
@@ -594,7 +600,8 @@ def triangle_mesh_inductance_mapping_from_linear_filaments(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         wire_radius: [m] filament radius, scalar or array of length `nfil`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [H] mapping matrix with shape `(nnode_tgt, nfil)`
@@ -629,7 +636,8 @@ def triangle_mesh_inductance_mapping_from_circular_filaments(
         nodes_tgt: [m] target mesh node coordinates with shape `(nnode_tgt, 3)`
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [H] mapping matrix with shape `(nnode_tgt, nfil)`
@@ -663,7 +671,8 @@ def triangle_mesh_flux_linkage_mapping_from_dipoles(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         outer_radius: [m] dipole finite-core radius, scalar or array of length `ndip`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         mapping matrix with shape `(nnode_tgt, ndip)`
@@ -700,7 +709,8 @@ def triangle_mesh_force_mapping(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, nnode_src)`
@@ -737,7 +747,8 @@ def triangle_mesh_self_force_mapping(
         triangles: node indices with shape `(ntri, 3)`
         s: [A] fixed nodal current-potential values with shape `(nnode,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri, nnode)`
@@ -776,7 +787,8 @@ def triangle_mesh_force_mapping_from_linear_filaments(
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         wire_radius: [m] filament radius, scalar or array of length `nfil`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, nfil)`
@@ -820,7 +832,8 @@ def triangle_mesh_force_mapping_from_circular_filaments(
         triangles_tgt: target node indices with shape `(ntri_tgt, 3)`
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         par: Whether to use CPU parallelism
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/A] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, nfil)`
@@ -863,7 +876,8 @@ def triangle_mesh_force_mapping_from_dipoles(
         s_tgt: [A] fixed target nodal current-potential values with shape `(nnode_tgt,)`
         par: Whether to use CPU parallelism
         outer_radius: [m] radius inside which to defer to magnetized sphere calc. Defaults to zeroes.
-        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`, `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
+        quad: Triangle quadrature rule, one of `"dunavant1"`, `"dunavant2"`,
+            `"dunavant3"`, `"dunavant4"`, or `"dunavant5"`
 
     Returns:
         [N/source_amplitude] `(fx, fy, fz)` force mappings, each with shape `(ntri_tgt, ndip)`

--- a/examples/field_explorer.py
+++ b/examples/field_explorer.py
@@ -25,7 +25,8 @@ DEFAULT_BOUNDARY_ELEMENT_LENGTH_NODES = 4
 MAX_BOUNDARY_ELEMENT_LENGTH_NODES = 20
 DEFAULT_BOUNDARY_ELEMENT_STRIP_COUNT = 1
 MAX_BOUNDARY_ELEMENT_STRIP_COUNT = 10
-DEFAULT_BOUNDARY_ELEMENT_QUAD = "gl3"
+BOUNDARY_ELEMENT_QUADS = ("dunavant1", "dunavant2", "dunavant3", "dunavant4", "dunavant5")
+DEFAULT_BOUNDARY_ELEMENT_QUAD = "dunavant3"
 BOUNDARY_COMPARE_GRID_SIZE = 17 if os.getenv("CFSEM_TESTING") else 101
 DOCS_FIELD_EXPLORER_SVG = (
     Path(__file__).resolve().parents[1] / "docs/python/example_outputs/field_explorer.svg"
@@ -116,7 +117,7 @@ def normalize_boundary_element_strip_count(n_strip_count: int) -> int:
 
 
 def normalize_boundary_element_quadrature(quad: str | None) -> str:
-    return quad if quad in ("gl1", "gl2", "gl3", "dunavant5") else DEFAULT_BOUNDARY_ELEMENT_QUAD
+    return quad if quad in BOUNDARY_ELEMENT_QUADS else DEFAULT_BOUNDARY_ELEMENT_QUAD
 
 
 def finite_positive_max(values: np.ndarray) -> float | None:
@@ -2098,9 +2099,10 @@ def create_app():
                                     dcc.Dropdown(
                                         id="boundary-element-quad",
                                         options=[
-                                            {"label": "Gauss-Legendre 1", "value": "gl1"},
-                                            {"label": "Gauss-Legendre 2", "value": "gl2"},
-                                            {"label": "Gauss-Legendre 3", "value": "gl3"},
+                                            {"label": "Dunavant 1", "value": "dunavant1"},
+                                            {"label": "Dunavant 2", "value": "dunavant2"},
+                                            {"label": "Dunavant 3", "value": "dunavant3"},
+                                            {"label": "Dunavant 4", "value": "dunavant4"},
                                             {"label": "Dunavant 5", "value": "dunavant5"},
                                         ],
                                         value=DEFAULT_BOUNDARY_ELEMENT_QUAD,

--- a/src/mesh/elements/tri/quadrature.rs
+++ b/src/mesh/elements/tri/quadrature.rs
@@ -1,30 +1,35 @@
 //! Reference-triangle quadrature rules used by the boundary-element triangle kernels.
 
-/// One-point centroid quadrature rule on a triangle.
+/// Dunavant's one-point degree-1 centroid quadrature rule on a triangle.
 /// Format is `[weight, u, v]`.
-const TABLE_GAUSS_LEGENDRE_1: [[f64; 3]; 1] = [[0.5, 1.0 / 3.0, 1.0 / 3.0]];
+const TABLE_DUNAVANT_1: [[f64; 3]; 1] = [[0.5, 1.0 / 3.0, 1.0 / 3.0]];
 
-/// Second-order quadrature integration weights on a triangular surface.
+/// Dunavant's 3-point degree-2 symmetric quadrature rule on a triangle.
 /// Format is `[weight, u, v]`.
-const TABLE_GAUSS_LEGENDRE_2: [[f64; 3]; 4] = [
-    [0.5283121635e-01, 0.1666666667e+00, 0.7886751346e+00],
-    [0.1971687836e+00, 0.6220084679e+00, 0.2113248654e+00],
-    [0.5283121635e-01, 0.4465819874e-01, 0.7886751346e+00],
-    [0.1971687836e+00, 0.1666666667e+00, 0.2113248654e+00],
+const TABLE_DUNAVANT_2: [[f64; 3]; 3] = [
+    [1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0],
+    [1.0 / 6.0, 2.0 / 3.0, 1.0 / 6.0],
+    [1.0 / 6.0, 1.0 / 6.0, 2.0 / 3.0],
 ];
 
-/// Third-order quadrature integration weights on a triangular surface.
+/// Dunavant's 4-point degree-3 symmetric quadrature rule on a triangle.
 /// Format is `[weight, u, v]`.
-const TABLE_GAUSS_LEGENDRE_3: [[f64; 3]; 9] = [
-    [0.9876542474e-01, 0.2500000000e+00, 0.5000000000e+00],
-    [0.1391378575e-01, 0.5635083269e-01, 0.8872983346e+00],
-    [0.1095430035e+00, 0.4436491673e+00, 0.1127016654e+00],
-    [0.6172839460e-01, 0.4436491673e+00, 0.5000000000e+00],
-    [0.8696116674e-02, 0.1000000000e+00, 0.8872983346e+00],
-    [0.6846438175e-01, 0.7872983346e+00, 0.1127016654e+00],
-    [0.6172839460e-01, 0.5635083269e-01, 0.5000000000e+00],
-    [0.8696116674e-02, 0.1270166538e-01, 0.8872983346e+00],
-    [0.6846438175e-01, 0.1000000000e+00, 0.1127016654e+00],
+const TABLE_DUNAVANT_3: [[f64; 3]; 4] = [
+    [-27.0 / 96.0, 1.0 / 3.0, 1.0 / 3.0],
+    [25.0 / 96.0, 0.2, 0.2],
+    [25.0 / 96.0, 0.6, 0.2],
+    [25.0 / 96.0, 0.2, 0.6],
+];
+
+/// Dunavant's 6-point degree-4 symmetric quadrature rule on a triangle.
+/// Format is `[weight, u, v]`.
+const TABLE_DUNAVANT_4: [[f64; 3]; 6] = [
+    [0.1116907948390055, 0.445948490915965, 0.445948490915965],
+    [0.1116907948390055, 0.108103018168070, 0.445948490915965],
+    [0.1116907948390055, 0.445948490915965, 0.108103018168070],
+    [0.054975871827661, 0.091576213509771, 0.091576213509771],
+    [0.054975871827661, 0.816847572980459, 0.091576213509771],
+    [0.054975871827661, 0.091576213509771, 0.816847572980459],
 ];
 
 /// Dunavant's 7-point degree-5 symmetric quadrature rule on a triangle.
@@ -40,26 +45,36 @@ const TABLE_DUNAVANT_5: [[f64; 3]; 7] = [
 ];
 
 /// Maximum number of quadrature points among the supported triangle rules.
-pub const TRIANGLE_MAX_QUADRATURE_POINTS: usize = TABLE_GAUSS_LEGENDRE_3.len();
+pub const TRIANGLE_MAX_QUADRATURE_POINTS: usize = TABLE_DUNAVANT_5.len();
 
+/// Supported reference-triangle quadrature rules for boundary-element kernels.
 #[derive(Clone, Copy)]
 pub enum QuadratureKind {
-    GaussLegendre1,
-    GaussLegendre2,
-    GaussLegendre3,
+    /// One-point Dunavant rule, exact through total polynomial degree 1.
+    Dunavant1,
+    /// Three-point Dunavant rule, exact through total polynomial degree 2.
+    Dunavant2,
+    /// Four-point Dunavant rule, exact through total polynomial degree 3.
+    Dunavant3,
+    /// Six-point Dunavant rule, exact through total polynomial degree 4.
+    Dunavant4,
+    /// Seven-point Dunavant rule, exact through total polynomial degree 5.
     Dunavant5,
 }
 
+/// Return the reference-triangle quadrature table for the requested rule.
 #[inline]
 pub fn triangle_quadrature_points(quad_kind: QuadratureKind) -> &'static [[f64; 3]] {
     match quad_kind {
-        QuadratureKind::GaussLegendre1 => &TABLE_GAUSS_LEGENDRE_1,
-        QuadratureKind::GaussLegendre2 => &TABLE_GAUSS_LEGENDRE_2,
-        QuadratureKind::GaussLegendre3 => &TABLE_GAUSS_LEGENDRE_3,
+        QuadratureKind::Dunavant1 => &TABLE_DUNAVANT_1,
+        QuadratureKind::Dunavant2 => &TABLE_DUNAVANT_2,
+        QuadratureKind::Dunavant3 => &TABLE_DUNAVANT_3,
+        QuadratureKind::Dunavant4 => &TABLE_DUNAVANT_4,
         QuadratureKind::Dunavant5 => &TABLE_DUNAVANT_5,
     }
 }
 
+/// Return the number of reference-triangle quadrature points for the requested rule.
 #[inline]
 pub fn triangle_quadrature_count(quad_kind: QuadratureKind) -> usize {
     triangle_quadrature_points(quad_kind).len()

--- a/src/physics/boundary_element/test.rs
+++ b/src/physics/boundary_element/test.rs
@@ -51,6 +51,71 @@ struct TriangleMeshData {
     s: Vec<f64>,
 }
 
+fn permute_triangle_patch(tri: TrianglePatch, order: [usize; 3]) -> TrianglePatch {
+    TrianglePatch {
+        nodes: order.map(|i| tri.nodes[i]),
+        s: order.map(|i| tri.s[i]),
+    }
+}
+
+fn mesh_node(mesh: &TriangleMeshData, idx: usize) -> [f64; 3] {
+    [mesh.nodes.0[idx], mesh.nodes.1[idx], mesh.nodes.2[idx]]
+}
+
+fn node_permutation_by_coordinates(
+    reference: &TriangleMeshData,
+    candidate: &TriangleMeshData,
+) -> Vec<usize> {
+    (0..reference.nodes.0.len())
+        .map(|iref| {
+            let node = mesh_node(reference, iref);
+            (0..candidate.nodes.0.len())
+                .find(|&icand| mesh_node(candidate, icand) == node)
+                .unwrap_or_else(|| panic!("candidate mesh is missing reference node {node:?}"))
+        })
+        .collect()
+}
+
+fn explicit_patch_inductance_matrix(
+    patches: &[TrianglePatch],
+    mesh: &TriangleMeshData,
+) -> Vec<f64> {
+    let nnode = mesh.nodes.0.len();
+    let mut out = vec![0.0; nnode * nnode];
+
+    for (isrc, src) in patches.iter().enumerate() {
+        let src_idx = [
+            mesh.triangles.0[isrc],
+            mesh.triangles.1[isrc],
+            mesh.triangles.2[isrc],
+        ];
+        for (itgt, tgt) in patches.iter().enumerate() {
+            let tgt_idx = [
+                mesh.triangles.0[itgt],
+                mesh.triangles.1[itgt],
+                mesh.triangles.2[itgt],
+            ];
+            let block = triangle_basis_mutual_inductance_block(
+                src.nodes[0],
+                src.nodes[1],
+                src.nodes[2],
+                tgt.nodes[0],
+                tgt.nodes[1],
+                tgt.nodes[2],
+                QuadratureKind::Dunavant3,
+            );
+
+            for i in 0..3 {
+                for j in 0..3 {
+                    out[src_idx[i] * nnode + tgt_idx[j]] += block[i][j];
+                }
+            }
+        }
+    }
+
+    out
+}
+
 fn mesh_view(mesh: &TriangleMeshData) -> TriangleMeshView<'_> {
     TriangleMeshView::new(
         (&mesh.nodes.0, &mesh.nodes.1, &mesh.nodes.2),
@@ -133,7 +198,7 @@ fn strip_flux_density(tris: &[TrianglePatch], obs: [f64; 3]) -> [f64; 3] {
             tri.nodes[2],
             tri.s,
             obs,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
         );
         out[0] += contrib[0];
         out[1] += contrib[1];
@@ -151,7 +216,7 @@ fn strip_vector_potential(tris: &[TrianglePatch], obs: [f64; 3]) -> [f64; 3] {
             tri.nodes[2],
             tri.s,
             obs,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
         );
         out[0] += contrib[0];
         out[1] += contrib[1];
@@ -228,14 +293,14 @@ fn mesh_flux_density(mesh: &TriangleMeshData, obs: &[[f64; 3]], par: bool) -> Ve
             (&obs_xyz.0, &obs_xyz.1, &obs_xyz.2),
             &view,
             &mesh.s,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut bx, &mut by, &mut bz),
         ),
         false => flux_density_triangle_mesh(
             (&obs_xyz.0, &obs_xyz.1, &obs_xyz.2),
             &view,
             &mesh.s,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut bx, &mut by, &mut bz),
         ),
     };
@@ -256,14 +321,14 @@ fn mesh_vector_potential(mesh: &TriangleMeshData, obs: &[[f64; 3]], par: bool) -
             (&obs_xyz.0, &obs_xyz.1, &obs_xyz.2),
             &view,
             &mesh.s,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut ax, &mut ay, &mut az),
         ),
         false => vector_potential_triangle_mesh(
             (&obs_xyz.0, &obs_xyz.1, &obs_xyz.2),
             &view,
             &mesh.s,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut ax, &mut ay, &mut az),
         ),
     };
@@ -277,10 +342,8 @@ fn mesh_inductance_matrix(mesh: &TriangleMeshData, par: bool) -> Vec<f64> {
     let mut out = vec![0.0; nnode * nnode];
     let view = mesh_view(mesh);
     let result = match par {
-        true => {
-            triangle_mesh_inductance_matrix_par(&view, QuadratureKind::GaussLegendre3, &mut out)
-        }
-        false => triangle_mesh_inductance_matrix(&view, QuadratureKind::GaussLegendre3, &mut out),
+        true => triangle_mesh_inductance_matrix_par(&view, QuadratureKind::Dunavant3, &mut out),
+        false => triangle_mesh_inductance_matrix(&view, QuadratureKind::Dunavant3, &mut out),
     };
     result.unwrap();
     out
@@ -312,7 +375,7 @@ where
         let tri_area = calc_tri_area(tri_nodes[0], tri_nodes[1], tri_nodes[2]);
         let ktgt = triangle_basis_current_densities(tri_nodes[0], tri_nodes[1], tri_nodes[2]);
 
-        for qp in triangle_quadrature_points(QuadratureKind::GaussLegendre3) {
+        for qp in triangle_quadrature_points(QuadratureKind::Dunavant3) {
             let obs = map_tri_uv(tri_nodes[0], tri_nodes[1], tri_nodes[2], [qp[1], qp[2]]);
             let a = eval_a(obs);
             let w = qp[0] * tri_area;
@@ -349,7 +412,7 @@ fn mesh_inductance_mapping_from_linear_filaments(
             dlxyzfil,
             wire_radius,
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             &mut out,
         ),
         false => triangle_mesh_inductance_mapping_from_linear_filaments(
@@ -357,7 +420,7 @@ fn mesh_inductance_mapping_from_linear_filaments(
             dlxyzfil,
             wire_radius,
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             &mut out,
         ),
     };
@@ -380,14 +443,14 @@ fn mesh_inductance_mapping_from_circular_filaments(
             rfil,
             zfil,
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             &mut out,
         ),
         false => triangle_mesh_inductance_mapping_from_circular_filaments(
             rfil,
             zfil,
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             &mut out,
         ),
     };
@@ -412,7 +475,7 @@ fn mesh_flux_linkage_mapping_from_dipoles(
             moment_dir,
             outer_radius,
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             &mut out,
         ),
         false => triangle_mesh_flux_linkage_mapping_from_dipoles(
@@ -420,7 +483,7 @@ fn mesh_flux_linkage_mapping_from_dipoles(
             moment_dir,
             outer_radius,
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             &mut out,
         ),
     };
@@ -443,13 +506,13 @@ fn mesh_flux_density_mapping(
         true => flux_density_triangle_mesh_mapping_par(
             (&obs_xyz.0, &obs_xyz.1, &obs_xyz.2),
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut bx, &mut by, &mut bz),
         ),
         false => flux_density_triangle_mesh_mapping(
             (&obs_xyz.0, &obs_xyz.1, &obs_xyz.2),
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut bx, &mut by, &mut bz),
         ),
     };
@@ -473,13 +536,13 @@ fn mesh_vector_potential_mapping(
         true => vector_potential_triangle_mesh_mapping_par(
             (&obs_xyz.0, &obs_xyz.1, &obs_xyz.2),
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut ax, &mut ay, &mut az),
         ),
         false => vector_potential_triangle_mesh_mapping(
             (&obs_xyz.0, &obs_xyz.1, &obs_xyz.2),
             &view,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut ax, &mut ay, &mut az),
         ),
     };
@@ -505,14 +568,14 @@ fn mesh_force_mapping(
             &view_src,
             &view_tgt,
             &mesh_tgt.s,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut fx, &mut fy, &mut fz),
         ),
         false => triangle_mesh_force_mapping(
             &view_src,
             &view_tgt,
             &mesh_tgt.s,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut fx, &mut fy, &mut fz),
         ),
     };
@@ -532,13 +595,13 @@ fn mesh_self_force_mapping(mesh: &TriangleMeshData, par: bool) -> (Vec<f64>, Vec
         true => triangle_mesh_self_force_mapping_par(
             &view,
             &mesh.s,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut fx, &mut fy, &mut fz),
         ),
         false => triangle_mesh_self_force_mapping(
             &view,
             &mesh.s,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut fx, &mut fy, &mut fz),
         ),
     };
@@ -556,7 +619,7 @@ fn explicit_force_on_target_triangle_from_source_mesh(
     let k_tgt = triangle_current_density(tri_nodes[0], tri_nodes[1], tri_nodes[2], tri_s);
     let mut out = [0.0; 3];
     let view = mesh_view(mesh_src);
-    for qp in triangle_quadrature_points(QuadratureKind::GaussLegendre3) {
+    for qp in triangle_quadrature_points(QuadratureKind::Dunavant3) {
         let obs = map_tri_uv(tri_nodes[0], tri_nodes[1], tri_nodes[2], [qp[1], qp[2]]);
         let mut bx = [0.0];
         let mut by = [0.0];
@@ -565,7 +628,7 @@ fn explicit_force_on_target_triangle_from_source_mesh(
             (&[obs[0]], &[obs[1]], &[obs[2]]),
             &view,
             &mesh_src.s,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
             (&mut bx, &mut by, &mut bz),
         )
         .unwrap();
@@ -671,7 +734,7 @@ fn strip_mutual_inductance(src: &[TrianglePatch], tgt: &[TrianglePatch]) -> f64 
                 target.nodes[0],
                 target.nodes[1],
                 target.nodes[2],
-                QuadratureKind::GaussLegendre3,
+                QuadratureKind::Dunavant3,
             );
             out += triangle_inductance_from_potential_vectors(block, source.s, target.s);
         }
@@ -765,7 +828,7 @@ fn test_triangle_mesh_collection_matches_single_triangle_kernels() {
             tri.nodes[2],
             tri.s,
             *point,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
         );
         let a_direct = vector_potential_triangle(
             tri.nodes[0],
@@ -773,7 +836,7 @@ fn test_triangle_mesh_collection_matches_single_triangle_kernels() {
             tri.nodes[2],
             tri.s,
             *point,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
         );
 
         for axis in 0..3 {
@@ -962,7 +1025,7 @@ fn test_triangle_mesh_field_mappings_match_collection_fields() {
 fn test_triangle_basis_fields_match_current_element_quadrature_sum() {
     let tri = [[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [0.2, 0.8, 0.1]];
     let obs = [0.35, -0.22, 1.15];
-    let quad_kind = QuadratureKind::GaussLegendre3;
+    let quad_kind = QuadratureKind::Dunavant3;
 
     let (tri_area, jref) = triangle_basis_current_density(tri[0], tri[1], tri[2]);
     let mut b_via_elements = [0.0; 3];
@@ -1030,7 +1093,7 @@ fn test_single_triangle_basis_contributions_cancel_for_constant_potential() {
                 tri[2],
                 s_basis,
                 obs,
-                QuadratureKind::GaussLegendre3,
+                QuadratureKind::Dunavant3,
             );
             let a = vector_potential_triangle(
                 tri[0],
@@ -1038,7 +1101,7 @@ fn test_single_triangle_basis_contributions_cancel_for_constant_potential() {
                 tri[2],
                 s_basis,
                 obs,
-                QuadratureKind::GaussLegendre3,
+                QuadratureKind::Dunavant3,
             );
             for axis in 0..3 {
                 b_sum[axis] += b[axis];
@@ -1081,7 +1144,7 @@ fn test_single_triangle_basis_contributions_cancel_for_constant_potential() {
 fn test_triangle_mesh_quadrature_points_and_current_density_extractors() {
     let tris = circular_strip_triangles(0.73, 7.3e-4, 1.7, 24);
     let mesh = triangle_patches_to_mesh(&tris);
-    let quad_kind = QuadratureKind::GaussLegendre2;
+    let quad_kind = QuadratureKind::Dunavant2;
     let ntri = mesh.triangles.0.len();
     let nqp = triangle_quadrature_count(quad_kind);
 
@@ -1133,16 +1196,19 @@ fn test_triangle_mesh_quadrature_points_and_current_density_extractors() {
     }
 }
 
-/// Checks that the single-point rule is the reference-triangle centroid rule.
-#[test]
-fn test_single_point_triangle_quadrature_rule() {
-    let quad_points = triangle_quadrature_points(QuadratureKind::GaussLegendre1);
+fn assert_triangle_rule_integrates_monomials(
+    name: &str,
+    quad_kind: QuadratureKind,
+    degree: usize,
+    npoints: usize,
+) {
+    let quad_points = triangle_quadrature_points(quad_kind);
 
-    assert_eq!(quad_points, &[[0.5, 1.0 / 3.0, 1.0 / 3.0]]);
-    assert_eq!(triangle_quadrature_count(QuadratureKind::GaussLegendre1), 1);
+    assert_eq!(quad_points.len(), npoints);
+    assert_eq!(triangle_quadrature_count(quad_kind), npoints);
 
-    for p in 0..=1 {
-        for q in 0..=(1 - p) {
+    for p in 0..=degree {
+        for q in 0..=(degree - p) {
             let approx_int = quad_points
                 .iter()
                 .map(|qp| qp[0] * qp[1].powi(p as i32) * qp[2].powi(q as i32))
@@ -1150,32 +1216,20 @@ fn test_single_point_triangle_quadrature_rule() {
             let exact_int = reference_triangle_monomial_integral(p, q);
             assert!(
                 approx(approx_int, exact_int, 0.0, 1e-14),
-                "single-point rule failed for u^{p} v^{q}: approx={approx_int:.16e}, exact={exact_int:.16e}"
+                "{name} failed for u^{p} v^{q}: approx={approx_int:.16e}, exact={exact_int:.16e}"
             );
         }
     }
 }
 
-/// Checks that the Dunavant rule integrates reference-triangle monomials through degree five.
+/// Checks that the Dunavant rules integrate reference-triangle monomials to their exact degree.
 #[test]
-fn test_dunavant_rule_integrates_reference_triangle_monomials_to_degree_five() {
-    let quad_points = triangle_quadrature_points(QuadratureKind::Dunavant5);
-
-    assert_eq!(quad_points.len(), 7);
-
-    for p in 0..=5 {
-        for q in 0..=(5 - p) {
-            let approx_int = quad_points
-                .iter()
-                .map(|qp| qp[0] * qp[1].powi(p as i32) * qp[2].powi(q as i32))
-                .sum::<f64>();
-            let exact_int = reference_triangle_monomial_integral(p, q);
-            assert!(
-                approx(approx_int, exact_int, 0.0, 1e-14),
-                "Dunavant rule failed for u^{p} v^{q}: approx={approx_int:.16e}, exact={exact_int:.16e}"
-            );
-        }
-    }
+fn test_dunavant_rules_integrate_reference_triangle_monomials_to_expected_degree() {
+    assert_triangle_rule_integrates_monomials("Dunavant1", QuadratureKind::Dunavant1, 1, 1);
+    assert_triangle_rule_integrates_monomials("Dunavant2", QuadratureKind::Dunavant2, 2, 3);
+    assert_triangle_rule_integrates_monomials("Dunavant3", QuadratureKind::Dunavant3, 3, 4);
+    assert_triangle_rule_integrates_monomials("Dunavant4", QuadratureKind::Dunavant4, 4, 6);
+    assert_triangle_rule_integrates_monomials("Dunavant5", QuadratureKind::Dunavant5, 5, 7);
 }
 
 /// Checks disjoint-triangle inductance blocks against vector-potential contraction.
@@ -1183,7 +1237,7 @@ fn test_dunavant_rule_integrates_reference_triangle_monomials_to_degree_five() {
 fn test_triangle_basis_mutual_inductance_block_matches_vector_potential_for_disjoint_triangles() {
     let src = [[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [0.2, 0.8, 0.0]];
     let tgt = [[0.3, -0.2, 1.1], [1.1, 0.1, 1.4], [0.2, 0.9, 1.2]];
-    let quad_kind = QuadratureKind::GaussLegendre3;
+    let quad_kind = QuadratureKind::Dunavant3;
 
     let block = triangle_basis_mutual_inductance_block(
         src[0], src[1], src[2], tgt[0], tgt[1], tgt[2], quad_kind,
@@ -1232,42 +1286,85 @@ fn test_triangle_basis_mutual_inductance_block_matches_vector_potential_for_disj
     }
 }
 
-/// Checks a one-triangle mesh inductance matrix against the direct single-triangle block.
+/// Checks a shared-edge two-triangle inductance matrix against direct triangle blocks
+/// and verifies that permuting triangle node order preserves the physical result.
 #[test]
-fn test_triangle_mesh_inductance_matrix_matches_single_triangle_block() {
-    let tri = TrianglePatch {
-        nodes: [[0.0, 0.0, 0.0], [0.9, 0.1, 0.0], [0.2, 0.8, 0.1]],
-        s: [1.2, -0.4, 0.7],
-    };
-    let mesh = triangle_patches_to_mesh(&[tri]);
-    let block = triangle_basis_mutual_inductance_block(
-        tri.nodes[0],
-        tri.nodes[1],
-        tri.nodes[2],
-        tri.nodes[0],
-        tri.nodes[1],
-        tri.nodes[2],
-        QuadratureKind::GaussLegendre3,
-    );
-    let lmat = mesh_inductance_matrix(&mesh, false);
-    let lmat_par = mesh_inductance_matrix(&mesh, true);
+fn test_triangle_mesh_inductance_matrix_is_invariant_to_shared_edge_triangle_node_order() {
+    let p0 = [0.0, 0.0, 0.0];
+    let p1 = [0.9, 0.1, 0.0];
+    let p2 = [0.2, 0.8, 0.1];
+    let p3 = [1.1, 1.0, -0.03];
+    let base_patches = [
+        TrianglePatch {
+            nodes: [p0, p1, p2],
+            s: [1.2, -0.4, 0.7],
+        },
+        TrianglePatch {
+            nodes: [p1, p3, p2],
+            s: [-0.4, -1.1, 0.7],
+        },
+    ];
+    let base_mesh = triangle_patches_to_mesh(&base_patches);
+    let base_lmat = mesh_inductance_matrix(&base_mesh, false);
+    let base_bilinear =
+        triangle_mesh_inductance_from_potential_vectors(&base_lmat, &base_mesh.s, &base_mesh.s)
+            .unwrap();
 
-    for i in 0..3 {
-        for j in 0..3 {
-            let idx = i * 3 + j;
+    for (case_name, orders) in [
+        ("unpermuted", [[0, 1, 2], [0, 1, 2]]),
+        ("permuted", [[1, 2, 0], [1, 2, 0]]),
+    ] {
+        let patches = [
+            permute_triangle_patch(base_patches[0], orders[0]),
+            permute_triangle_patch(base_patches[1], orders[1]),
+        ];
+        let mesh = triangle_patches_to_mesh(&patches);
+        let direct_lmat = explicit_patch_inductance_matrix(&patches, &mesh);
+        let lmat = mesh_inductance_matrix(&mesh, false);
+        let lmat_par = mesh_inductance_matrix(&mesh, true);
+        let base_to_case = node_permutation_by_coordinates(&base_mesh, &mesh);
+        assert_eq!(mesh.nodes.0.len(), base_mesh.nodes.0.len());
+        let nnode = base_mesh.nodes.0.len();
+
+        for i in 0..nnode {
             assert!(
-                approx(lmat[idx], block[i][j], 1e-12, 1e-14),
-                "single-triangle nodal matrix mismatch at ({i},{j}): matrix={:.16e}, block={:.16e}",
-                lmat[idx],
-                block[i][j],
+                approx(mesh.s[base_to_case[i]], base_mesh.s[i], 0.0, 1e-14),
+                "nodal stream function changed under {case_name} node order at node {i}: value={:.16e}, expected={:.16e}",
+                mesh.s[base_to_case[i]],
+                base_mesh.s[i],
             );
-            assert!(
-                approx(lmat_par[idx], block[i][j], 1e-12, 1e-14),
-                "single-triangle parallel nodal matrix mismatch at ({i},{j}): matrix={:.16e}, block={:.16e}",
-                lmat_par[idx],
-                block[i][j],
-            );
+            for j in 0..nnode {
+                let idx = i * nnode + j;
+                let case_idx = base_to_case[i] * nnode + base_to_case[j];
+                assert!(
+                    approx(lmat[idx], direct_lmat[idx], 1e-12, 1e-14),
+                    "shared-edge nodal matrix mismatch for {case_name} node order at ({i},{j}): matrix={:.16e}, direct={:.16e}",
+                    lmat[idx],
+                    direct_lmat[idx],
+                );
+                assert!(
+                    approx(lmat_par[idx], direct_lmat[idx], 1e-12, 1e-14),
+                    "shared-edge parallel nodal matrix mismatch for {case_name} node order at ({i},{j}): matrix={:.16e}, direct={:.16e}",
+                    lmat_par[idx],
+                    direct_lmat[idx],
+                );
+                assert!(
+                    approx(lmat[case_idx], base_lmat[idx], 1e-12, 1e-14),
+                    "shared-edge nodal matrix changed under {case_name} node order at base nodes ({i},{j}): matrix={:.16e}, expected={:.16e}",
+                    lmat[case_idx],
+                    base_lmat[idx],
+                );
+            }
         }
+
+        let bilinear =
+            triangle_mesh_inductance_from_potential_vectors(&lmat, &mesh.s, &mesh.s).unwrap();
+        assert!(
+            approx(bilinear, base_bilinear, 1e-12, 1e-14),
+            "shared-edge inductance changed under {case_name} node order: matrix={:.16e}, expected={:.16e}",
+            bilinear,
+            base_bilinear,
+        );
     }
 }
 
@@ -1282,7 +1379,7 @@ fn test_triangle_basis_self_inductance_block_is_symmetric_and_finite() {
         tri[0],
         tri[1],
         tri[2],
-        QuadratureKind::GaussLegendre3,
+        QuadratureKind::Dunavant3,
     );
 
     let mut max_entry: f64 = 0.0;
@@ -1649,7 +1746,7 @@ fn test_triangle_basis_mutual_inductance_touching_pairs_are_finite_and_reciproca
             other[0],
             other[1],
             other[2],
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
         );
         let block21 = triangle_basis_mutual_inductance_block(
             other[0],
@@ -1658,7 +1755,7 @@ fn test_triangle_basis_mutual_inductance_touching_pairs_are_finite_and_reciproca
             tri0[0],
             tri0[1],
             tri0[2],
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
         );
 
         for i in 0..3 {
@@ -1756,16 +1853,16 @@ fn test_triangle_basis_force_block_matches_direct_contraction() {
         tgt0,
         tgt1,
         tgt2,
-        QuadratureKind::GaussLegendre3,
+        QuadratureKind::Dunavant3,
     );
     let via_block = triangle_force_from_potential_vectors(block, s_src, s_tgt);
 
     let tri_area = calc_tri_area(tgt0, tgt1, tgt2);
     let k_tgt = triangle_current_density(tgt0, tgt1, tgt2, s_tgt);
     let mut direct = [0.0; 3];
-    for qp in triangle_quadrature_points(QuadratureKind::GaussLegendre3) {
+    for qp in triangle_quadrature_points(QuadratureKind::Dunavant3) {
         let obs = map_tri_uv(tgt0, tgt1, tgt2, [qp[1], qp[2]]);
-        let b = flux_density_triangle(src0, src1, src2, s_src, obs, QuadratureKind::GaussLegendre3);
+        let b = flux_density_triangle(src0, src1, src2, s_src, obs, QuadratureKind::Dunavant3);
         let jf = cross3(k_tgt[0], k_tgt[1], k_tgt[2], b[0], b[1], b[2]);
         let w = qp[0] * tri_area;
         direct[0] += jf.0 * w;
@@ -2041,7 +2138,7 @@ fn test_triangle_fields_are_finite_on_and_very_near_triangle_surface() {
             tri.nodes[2],
             tri.s,
             *point,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
         );
         let a_direct = vector_potential_triangle(
             tri.nodes[0],
@@ -2049,7 +2146,7 @@ fn test_triangle_fields_are_finite_on_and_very_near_triangle_surface() {
             tri.nodes[2],
             tri.s,
             *point,
-            QuadratureKind::GaussLegendre3,
+            QuadratureKind::Dunavant3,
         );
 
         for axis in 0..3 {

--- a/src/python.rs
+++ b/src/python.rs
@@ -90,9 +90,10 @@ fn split_triangle_index_array2(
 
 fn parse_triangle_quadrature(quad: &str) -> PyResult<physics::boundary_element::QuadratureKind> {
     match quad {
-        "gl1" => Ok(physics::boundary_element::QuadratureKind::GaussLegendre1),
-        "gl2" => Ok(physics::boundary_element::QuadratureKind::GaussLegendre2),
-        "gl3" => Ok(physics::boundary_element::QuadratureKind::GaussLegendre3),
+        "dunavant1" => Ok(physics::boundary_element::QuadratureKind::Dunavant1),
+        "dunavant2" => Ok(physics::boundary_element::QuadratureKind::Dunavant2),
+        "dunavant3" => Ok(physics::boundary_element::QuadratureKind::Dunavant3),
+        "dunavant4" => Ok(physics::boundary_element::QuadratureKind::Dunavant4),
         "dunavant5" => Ok(physics::boundary_element::QuadratureKind::Dunavant5),
         _ => Err(PyInteropError::ValueError {
             msg: format!("Unsupported triangle quadrature rule: {quad}"),
@@ -2246,7 +2247,7 @@ fn triangle_mesh_view<'a>(
     })
 }
 
-#[pyfunction(signature = (obs, nodes, triangles, s, par=true, quad="gl3"))]
+#[pyfunction(signature = (obs, nodes, triangles, s, par=true, quad="dunavant3"))]
 fn flux_density_triangle_mesh(
     obs: PyReadonlyArray2<f64>,
     nodes: PyReadonlyArray2<f64>,
@@ -2286,7 +2287,7 @@ fn flux_density_triangle_mesh(
     _3tup_ret!((bx, f64), (by, f64), (bz, f64))
 }
 
-#[pyfunction(signature = (obs, nodes, triangles, s, par=true, quad="gl3"))]
+#[pyfunction(signature = (obs, nodes, triangles, s, par=true, quad="dunavant3"))]
 fn vector_potential_triangle_mesh(
     obs: PyReadonlyArray2<f64>,
     nodes: PyReadonlyArray2<f64>,
@@ -2326,7 +2327,7 @@ fn vector_potential_triangle_mesh(
     _3tup_ret!((ax, f64), (ay, f64), (az, f64))
 }
 
-#[pyfunction(signature = (obs, nodes, triangles, par=true, quad="gl3"))]
+#[pyfunction(signature = (obs, nodes, triangles, par=true, quad="dunavant3"))]
 fn flux_density_triangle_mesh_mapping(
     obs: PyReadonlyArray2<f64>,
     nodes: PyReadonlyArray2<f64>,
@@ -2369,7 +2370,7 @@ fn flux_density_triangle_mesh_mapping(
     _3tup_ret!((bx, f64), (by, f64), (bz, f64))
 }
 
-#[pyfunction(signature = (obs, nodes, triangles, par=true, quad="gl3"))]
+#[pyfunction(signature = (obs, nodes, triangles, par=true, quad="dunavant3"))]
 fn vector_potential_triangle_mesh_mapping(
     obs: PyReadonlyArray2<f64>,
     nodes: PyReadonlyArray2<f64>,
@@ -2441,7 +2442,7 @@ fn triangle_mesh_current_density(
     _3tup_ret!((jx, f64), (jy, f64), (jz, f64))
 }
 
-#[pyfunction(signature = (nodes, triangles, quad="gl3"))]
+#[pyfunction(signature = (nodes, triangles, quad="dunavant3"))]
 fn triangle_mesh_quadrature_points(
     nodes: PyReadonlyArray2<f64>,
     triangles: PyReadonlyArray2<i64>,
@@ -2492,7 +2493,7 @@ fn triangle_mesh_quadrature_points(
     })
 }
 
-#[pyfunction(signature = (nodes, triangles, par=true, quad="gl3"))]
+#[pyfunction(signature = (nodes, triangles, par=true, quad="dunavant3"))]
 fn triangle_mesh_inductance_matrix(
     nodes: PyReadonlyArray2<f64>,
     triangles: PyReadonlyArray2<i64>,
@@ -2527,7 +2528,7 @@ fn triangle_mesh_inductance_matrix(
     Python::attach(|py| Ok(PyArray1::from_vec(py, out).unbind()))
 }
 
-#[pyfunction(signature = (xyzfil, dlxyzfil, wire_radius, nodes_tgt, triangles_tgt, par=true, quad="gl3"))]
+#[pyfunction(signature = (xyzfil, dlxyzfil, wire_radius, nodes_tgt, triangles_tgt, par=true, quad="dunavant3"))]
 fn triangle_mesh_inductance_mapping_from_linear_filaments(
     xyzfil: (
         PyReadonlyArray1<f64>,
@@ -2577,7 +2578,7 @@ fn triangle_mesh_inductance_mapping_from_linear_filaments(
     Python::attach(|py| Ok(PyArray1::from_vec(py, out).unbind()))
 }
 
-#[pyfunction(signature = (rfil, zfil, nodes_tgt, triangles_tgt, par=true, quad="gl3"))]
+#[pyfunction(signature = (rfil, zfil, nodes_tgt, triangles_tgt, par=true, quad="dunavant3"))]
 fn triangle_mesh_inductance_mapping_from_circular_filaments(
     rfil: PyReadonlyArray1<f64>,
     zfil: PyReadonlyArray1<f64>,
@@ -2621,7 +2622,7 @@ fn triangle_mesh_inductance_mapping_from_circular_filaments(
     Python::attach(|py| Ok(PyArray1::from_vec(py, out).unbind()))
 }
 
-#[pyfunction(signature = (loc, moment_dir, outer_radius, nodes_tgt, triangles_tgt, par=true, quad="gl3"))]
+#[pyfunction(signature = (loc, moment_dir, outer_radius, nodes_tgt, triangles_tgt, par=true, quad="dunavant3"))]
 fn triangle_mesh_flux_linkage_mapping_from_dipoles(
     loc: (
         PyReadonlyArray1<f64>,
@@ -2671,7 +2672,7 @@ fn triangle_mesh_flux_linkage_mapping_from_dipoles(
     Python::attach(|py| Ok(PyArray1::from_vec(py, out).unbind()))
 }
 
-#[pyfunction(signature = (nodes_src, triangles_src, nodes_tgt, triangles_tgt, s_tgt, par=true, quad="gl3"))]
+#[pyfunction(signature = (nodes_src, triangles_src, nodes_tgt, triangles_tgt, s_tgt, par=true, quad="dunavant3"))]
 fn triangle_mesh_force_mapping(
     nodes_src: PyReadonlyArray2<f64>,
     triangles_src: PyReadonlyArray2<i64>,
@@ -2720,7 +2721,7 @@ fn triangle_mesh_force_mapping(
     _3tup_ret!((fx, f64), (fy, f64), (fz, f64))
 }
 
-#[pyfunction(signature = (nodes, triangles, s, par=true, quad="gl3"))]
+#[pyfunction(signature = (nodes, triangles, s, par=true, quad="dunavant3"))]
 fn triangle_mesh_self_force_mapping(
     nodes: PyReadonlyArray2<f64>,
     triangles: PyReadonlyArray2<i64>,
@@ -2758,7 +2759,7 @@ fn triangle_mesh_self_force_mapping(
     _3tup_ret!((fx, f64), (fy, f64), (fz, f64))
 }
 
-#[pyfunction(signature = (xyzfil, dlxyzfil, wire_radius, nodes_tgt, triangles_tgt, s_tgt, par=true, quad="gl3"))]
+#[pyfunction(signature = (xyzfil, dlxyzfil, wire_radius, nodes_tgt, triangles_tgt, s_tgt, par=true, quad="dunavant3"))]
 fn triangle_mesh_force_mapping_from_linear_filaments(
     xyzfil: (
         PyReadonlyArray1<f64>,
@@ -2818,7 +2819,7 @@ fn triangle_mesh_force_mapping_from_linear_filaments(
     _3tup_ret!((fx, f64), (fy, f64), (fz, f64))
 }
 
-#[pyfunction(signature = (rfil, zfil, nodes_tgt, triangles_tgt, s_tgt, par=true, quad="gl3"))]
+#[pyfunction(signature = (rfil, zfil, nodes_tgt, triangles_tgt, s_tgt, par=true, quad="dunavant3"))]
 fn triangle_mesh_force_mapping_from_circular_filaments(
     rfil: PyReadonlyArray1<f64>,
     zfil: PyReadonlyArray1<f64>,
@@ -2867,7 +2868,7 @@ fn triangle_mesh_force_mapping_from_circular_filaments(
     _3tup_ret!((fx, f64), (fy, f64), (fz, f64))
 }
 
-#[pyfunction(signature = (loc, moment_dir, outer_radius, nodes_tgt, triangles_tgt, s_tgt, par=true, quad="gl3"))]
+#[pyfunction(signature = (loc, moment_dir, outer_radius, nodes_tgt, triangles_tgt, s_tgt, par=true, quad="dunavant3"))]
 fn triangle_mesh_force_mapping_from_dipoles(
     loc: (
         PyReadonlyArray1<f64>,

--- a/test/test_boundary_element.py
+++ b/test/test_boundary_element.py
@@ -5,6 +5,8 @@ from pytest import approx, mark, raises
 
 import cfsem
 
+TRIANGLE_QUADRATURES = ["dunavant1", "dunavant2", "dunavant3", "dunavant4", "dunavant5"]
+
 DUNAVANT1_TRI_QUAD = np.array([[0.5, 1.0 / 3.0, 1.0 / 3.0]], dtype=np.float64)
 
 DUNAVANT2_TRI_QUAD = np.array(
@@ -12,6 +14,16 @@ DUNAVANT2_TRI_QUAD = np.array(
         [1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0],
         [1.0 / 6.0, 2.0 / 3.0, 1.0 / 6.0],
         [1.0 / 6.0, 1.0 / 6.0, 2.0 / 3.0],
+    ],
+    dtype=np.float64,
+)
+
+DUNAVANT3_TRI_QUAD = np.array(
+    [
+        [-27.0 / 96.0, 1.0 / 3.0, 1.0 / 3.0],
+        [25.0 / 96.0, 0.2, 0.2],
+        [25.0 / 96.0, 0.6, 0.2],
+        [25.0 / 96.0, 0.2, 0.6],
     ],
     dtype=np.float64,
 )
@@ -27,6 +39,27 @@ DUNAVANT4_TRI_QUAD = np.array(
     ],
     dtype=np.float64,
 )
+
+DUNAVANT5_TRI_QUAD = np.array(
+    [
+        [0.112500000000000, 0.333333333333333, 0.333333333333333],
+        [0.066197076394253, 0.470142064105115, 0.470142064105115],
+        [0.066197076394253, 0.059715871789770, 0.470142064105115],
+        [0.066197076394253, 0.470142064105115, 0.059715871789770],
+        [0.062969590272414, 0.101286507323456, 0.101286507323456],
+        [0.062969590272414, 0.797426985353087, 0.101286507323456],
+        [0.062969590272414, 0.101286507323456, 0.797426985353087],
+    ],
+    dtype=np.float64,
+)
+
+TRIANGLE_QUADRATURE_TABLES = {
+    "dunavant1": DUNAVANT1_TRI_QUAD,
+    "dunavant2": DUNAVANT2_TRI_QUAD,
+    "dunavant3": DUNAVANT3_TRI_QUAD,
+    "dunavant4": DUNAVANT4_TRI_QUAD,
+    "dunavant5": DUNAVANT5_TRI_QUAD,
+}
 
 
 def _triangle_strip_mesh(
@@ -141,32 +174,19 @@ def _linear_filament_loop(
     return ((x[:-1], y[:-1], zvals[:-1]), (dx, dy, dz))
 
 
-def test_triangle_mesh_quadrature_points_and_current_density():
+@mark.parametrize("quad", TRIANGLE_QUADRATURES)
+def test_triangle_mesh_quadrature_points_and_current_density(quad):
     """Check quadrature-point extraction and current-density reconstruction on a strip mesh."""
     nodes, triangles, s = _triangle_strip_mesh(0.73, 7.3e-4, 1.7, nphi=32)
+    tri_quad = TRIANGLE_QUADRATURE_TABLES[quad]
 
     j = cfsem.triangle_mesh_current_density(nodes, triangles, s)
     j_ref = _triangle_current_density_reference(nodes, triangles, s)
-    centroid_points, centroid_weights = cfsem.triangle_mesh_quadrature_points(
-        nodes, triangles, quad="dunavant1"
-    )
-    points, weights = cfsem.triangle_mesh_quadrature_points(nodes, triangles, quad="dunavant2")
-    dunavant4_points, dunavant4_weights = cfsem.triangle_mesh_quadrature_points(
-        nodes, triangles, quad="dunavant4"
-    )
-    dunavant_points, dunavant_weights = cfsem.triangle_mesh_quadrature_points(
-        nodes, triangles, quad="dunavant5"
-    )
+    points, weights = cfsem.triangle_mesh_quadrature_points(nodes, triangles, quad=quad)
 
     assert j.shape == (triangles.shape[0], 3)
-    assert centroid_points.shape == (triangles.shape[0], DUNAVANT1_TRI_QUAD.shape[0], 3)
-    assert centroid_weights.shape == (triangles.shape[0], DUNAVANT1_TRI_QUAD.shape[0])
-    assert points.shape == (triangles.shape[0], DUNAVANT2_TRI_QUAD.shape[0], 3)
-    assert weights.shape == (triangles.shape[0], DUNAVANT2_TRI_QUAD.shape[0])
-    assert dunavant4_points.shape == (triangles.shape[0], DUNAVANT4_TRI_QUAD.shape[0], 3)
-    assert dunavant4_weights.shape == (triangles.shape[0], DUNAVANT4_TRI_QUAD.shape[0])
-    assert dunavant_points.shape == (triangles.shape[0], 7, 3)
-    assert dunavant_weights.shape == (triangles.shape[0], 7)
+    assert points.shape == (triangles.shape[0], tri_quad.shape[0], 3)
+    assert weights.shape == (triangles.shape[0], tri_quad.shape[0])
     assert np.allclose(j, j_ref, rtol=1e-13, atol=1e-13)
 
     for i, (i0, i1, i2) in enumerate(triangles):
@@ -174,34 +194,18 @@ def test_triangle_mesh_quadrature_points_and_current_density():
         n1 = nodes[i1]
         n2 = nodes[i2]
         area = 0.5 * np.linalg.norm(np.cross(n1 - n0, n2 - n0))
-        expected_centroid = (
-            (1.0 - DUNAVANT1_TRI_QUAD[:, 1] - DUNAVANT1_TRI_QUAD[:, 2])[:, None] * n0[None, :]
-            + DUNAVANT1_TRI_QUAD[:, 1][:, None] * n1[None, :]
-            + DUNAVANT1_TRI_QUAD[:, 2][:, None] * n2[None, :]
-        )
-        expected_centroid_weights = DUNAVANT1_TRI_QUAD[:, 0] * area
         expected_points = (
-            (1.0 - DUNAVANT2_TRI_QUAD[:, 1] - DUNAVANT2_TRI_QUAD[:, 2])[:, None] * n0[None, :]
-            + DUNAVANT2_TRI_QUAD[:, 1][:, None] * n1[None, :]
-            + DUNAVANT2_TRI_QUAD[:, 2][:, None] * n2[None, :]
+            (1.0 - tri_quad[:, 1] - tri_quad[:, 2])[:, None] * n0[None, :]
+            + tri_quad[:, 1][:, None] * n1[None, :]
+            + tri_quad[:, 2][:, None] * n2[None, :]
         )
-        expected_weights = DUNAVANT2_TRI_QUAD[:, 0] * area
-        expected_dunavant4_points = (
-            (1.0 - DUNAVANT4_TRI_QUAD[:, 1] - DUNAVANT4_TRI_QUAD[:, 2])[:, None] * n0[None, :]
-            + DUNAVANT4_TRI_QUAD[:, 1][:, None] * n1[None, :]
-            + DUNAVANT4_TRI_QUAD[:, 2][:, None] * n2[None, :]
-        )
-        expected_dunavant4_weights = DUNAVANT4_TRI_QUAD[:, 0] * area
-        assert np.allclose(centroid_points[i], expected_centroid, rtol=0.0, atol=1e-13)
-        assert np.allclose(centroid_weights[i], expected_centroid_weights, rtol=0.0, atol=1e-13)
+        expected_weights = tri_quad[:, 0] * area
         assert np.allclose(points[i], expected_points, rtol=0.0, atol=1e-13)
         assert np.allclose(weights[i], expected_weights, rtol=0.0, atol=1e-13)
-        assert np.allclose(dunavant4_points[i], expected_dunavant4_points, rtol=0.0, atol=1e-13)
-        assert np.allclose(dunavant4_weights[i], expected_dunavant4_weights, rtol=0.0, atol=1e-13)
 
 
 @mark.parametrize("par", [True, False])
-@mark.parametrize("quad", ["dunavant1", "dunavant2", "dunavant3", "dunavant4", "dunavant5"])
+@mark.parametrize("quad", TRIANGLE_QUADRATURES)
 def test_triangle_mesh_far_field_against_circular_filament(par, quad):
     """Compare far-field triangle-mesh fields against the circular-filament reference."""
     radius = 0.7312345987
@@ -242,7 +246,8 @@ def test_triangle_mesh_far_field_against_circular_filament(par, quad):
     assert np.allclose(a, a_ref, rtol=1e-3, atol=a_atol)
 
 
-def test_triangle_mesh_serial_vs_parallel():
+@mark.parametrize("quad", TRIANGLE_QUADRATURES)
+def test_triangle_mesh_serial_vs_parallel(quad):
     """Check that serial and parallel triangle-mesh field evaluations agree."""
     radius = 0.7312345987
     height = radius * 1e-3
@@ -258,17 +263,18 @@ def test_triangle_mesh_serial_vs_parallel():
         dtype=np.float64,
     )
 
-    b_serial = np.column_stack(cfsem.flux_density_triangle_mesh(obs, nodes, triangles, s, par=False))
-    b_parallel = np.column_stack(cfsem.flux_density_triangle_mesh(obs, nodes, triangles, s, par=True))
-    a_serial = np.column_stack(cfsem.vector_potential_triangle_mesh(obs, nodes, triangles, s, par=False))
-    a_parallel = np.column_stack(cfsem.vector_potential_triangle_mesh(obs, nodes, triangles, s, par=True))
+    b_serial = np.column_stack(cfsem.flux_density_triangle_mesh(obs, nodes, triangles, s, par=False, quad=quad))
+    b_parallel = np.column_stack(cfsem.flux_density_triangle_mesh(obs, nodes, triangles, s, par=True, quad=quad))
+    a_serial = np.column_stack(cfsem.vector_potential_triangle_mesh(obs, nodes, triangles, s, par=False, quad=quad))
+    a_parallel = np.column_stack(cfsem.vector_potential_triangle_mesh(obs, nodes, triangles, s, par=True, quad=quad))
 
     assert np.allclose(b_serial, b_parallel, rtol=1e-12, atol=1e-12)
     assert np.allclose(a_serial, a_parallel, rtol=1e-12, atol=1e-12)
 
 
 @mark.parametrize("par", [True, False])
-def test_triangle_mesh_field_mappings_contract_to_collection_fields(par):
+@mark.parametrize("quad", TRIANGLE_QUADRATURES)
+def test_triangle_mesh_field_mappings_contract_to_collection_fields(par, quad):
     """Check field mapping contractions against direct triangle-mesh field evaluation."""
     radius = 0.7312345987
     height = radius * 1e-3
@@ -285,22 +291,22 @@ def test_triangle_mesh_field_mappings_contract_to_collection_fields(par):
     )
 
     bx_map, by_map, bz_map = cfsem.flux_density_triangle_mesh_mapping(
-        obs, nodes, triangles, par=par, quad="dunavant3"
+        obs, nodes, triangles, par=par, quad=quad
     )
     ax_map, ay_map, az_map = cfsem.vector_potential_triangle_mesh_mapping(
-        obs, nodes, triangles, par=par, quad="dunavant3"
+        obs, nodes, triangles, par=par, quad=quad
     )
     bx_map_ref, by_map_ref, bz_map_ref = cfsem.flux_density_triangle_mesh_mapping(
-        obs, nodes, triangles, par=not par, quad="dunavant3"
+        obs, nodes, triangles, par=not par, quad=quad
     )
     ax_map_ref, ay_map_ref, az_map_ref = cfsem.vector_potential_triangle_mesh_mapping(
-        obs, nodes, triangles, par=not par, quad="dunavant3"
+        obs, nodes, triangles, par=not par, quad=quad
     )
 
     b_from_map = np.column_stack((bx_map @ s, by_map @ s, bz_map @ s))
     a_from_map = np.column_stack((ax_map @ s, ay_map @ s, az_map @ s))
-    b_direct = np.column_stack(cfsem.flux_density_triangle_mesh(obs, nodes, triangles, s, par=False))
-    a_direct = np.column_stack(cfsem.vector_potential_triangle_mesh(obs, nodes, triangles, s, par=False))
+    b_direct = np.column_stack(cfsem.flux_density_triangle_mesh(obs, nodes, triangles, s, par=False, quad=quad))
+    a_direct = np.column_stack(cfsem.vector_potential_triangle_mesh(obs, nodes, triangles, s, par=False, quad=quad))
 
     assert bx_map.shape == (obs.shape[0], nodes.shape[0])
     assert by_map.shape == (obs.shape[0], nodes.shape[0])
@@ -583,17 +589,18 @@ def test_triangle_mesh_force_mapping_against_direct_target_quadrature(par):
 
 
 @mark.parametrize("par", [True, False])
-def test_triangle_mesh_self_force_mapping_shapes_and_serial_parallel_agree(par):
+@mark.parametrize("quad", TRIANGLE_QUADRATURES)
+def test_triangle_mesh_self_force_mapping_shapes_and_serial_parallel_agree(par, quad):
     """Check self-force mapping shapes and serial/parallel agreement."""
     radius = 0.71
     height = radius * 1e-3
     nodes, triangles, s = _triangle_strip_mesh(radius, height, 1.0, nphi=32)
 
-    fx, fy, fz = cfsem.triangle_mesh_self_force_mapping(nodes, triangles, s, par=par, quad="dunavant3")
+    fx, fy, fz = cfsem.triangle_mesh_self_force_mapping(nodes, triangles, s, par=par, quad=quad)
     tri_forces = _contract_force_mapping(fx, fy, fz, s)
     total_force = np.sum(tri_forces, axis=0)
     fx_ref, fy_ref, fz_ref = cfsem.triangle_mesh_self_force_mapping(
-        nodes, triangles, s, par=not par, quad="dunavant3"
+        nodes, triangles, s, par=not par, quad=quad
     )
     tri_forces_ref = _contract_force_mapping(fx_ref, fy_ref, fz_ref, s)
 

--- a/test/test_boundary_element.py
+++ b/test/test_boundary_element.py
@@ -5,14 +5,25 @@ from pytest import approx, mark, raises
 
 import cfsem
 
-GL1_TRI_QUAD = np.array([[0.5, 1.0 / 3.0, 1.0 / 3.0]], dtype=np.float64)
+DUNAVANT1_TRI_QUAD = np.array([[0.5, 1.0 / 3.0, 1.0 / 3.0]], dtype=np.float64)
 
-GL2_TRI_QUAD = np.array(
+DUNAVANT2_TRI_QUAD = np.array(
     [
-        [0.05283121635, 0.1666666667, 0.7886751346],
-        [0.1971687836, 0.6220084679, 0.2113248654],
-        [0.05283121635, 0.04465819874, 0.7886751346],
-        [0.1971687836, 0.1666666667, 0.2113248654],
+        [1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0],
+        [1.0 / 6.0, 2.0 / 3.0, 1.0 / 6.0],
+        [1.0 / 6.0, 1.0 / 6.0, 2.0 / 3.0],
+    ],
+    dtype=np.float64,
+)
+
+DUNAVANT4_TRI_QUAD = np.array(
+    [
+        [0.1116907948390055, 0.445948490915965, 0.445948490915965],
+        [0.1116907948390055, 0.108103018168070, 0.445948490915965],
+        [0.1116907948390055, 0.445948490915965, 0.108103018168070],
+        [0.054975871827661, 0.091576213509771, 0.091576213509771],
+        [0.054975871827661, 0.816847572980459, 0.091576213509771],
+        [0.054975871827661, 0.091576213509771, 0.816847572980459],
     ],
     dtype=np.float64,
 )
@@ -137,18 +148,23 @@ def test_triangle_mesh_quadrature_points_and_current_density():
     j = cfsem.triangle_mesh_current_density(nodes, triangles, s)
     j_ref = _triangle_current_density_reference(nodes, triangles, s)
     centroid_points, centroid_weights = cfsem.triangle_mesh_quadrature_points(
-        nodes, triangles, quad="gl1"
+        nodes, triangles, quad="dunavant1"
     )
-    points, weights = cfsem.triangle_mesh_quadrature_points(nodes, triangles, quad="gl2")
+    points, weights = cfsem.triangle_mesh_quadrature_points(nodes, triangles, quad="dunavant2")
+    dunavant4_points, dunavant4_weights = cfsem.triangle_mesh_quadrature_points(
+        nodes, triangles, quad="dunavant4"
+    )
     dunavant_points, dunavant_weights = cfsem.triangle_mesh_quadrature_points(
         nodes, triangles, quad="dunavant5"
     )
 
     assert j.shape == (triangles.shape[0], 3)
-    assert centroid_points.shape == (triangles.shape[0], GL1_TRI_QUAD.shape[0], 3)
-    assert centroid_weights.shape == (triangles.shape[0], GL1_TRI_QUAD.shape[0])
-    assert points.shape == (triangles.shape[0], GL2_TRI_QUAD.shape[0], 3)
-    assert weights.shape == (triangles.shape[0], GL2_TRI_QUAD.shape[0])
+    assert centroid_points.shape == (triangles.shape[0], DUNAVANT1_TRI_QUAD.shape[0], 3)
+    assert centroid_weights.shape == (triangles.shape[0], DUNAVANT1_TRI_QUAD.shape[0])
+    assert points.shape == (triangles.shape[0], DUNAVANT2_TRI_QUAD.shape[0], 3)
+    assert weights.shape == (triangles.shape[0], DUNAVANT2_TRI_QUAD.shape[0])
+    assert dunavant4_points.shape == (triangles.shape[0], DUNAVANT4_TRI_QUAD.shape[0], 3)
+    assert dunavant4_weights.shape == (triangles.shape[0], DUNAVANT4_TRI_QUAD.shape[0])
     assert dunavant_points.shape == (triangles.shape[0], 7, 3)
     assert dunavant_weights.shape == (triangles.shape[0], 7)
     assert np.allclose(j, j_ref, rtol=1e-13, atol=1e-13)
@@ -159,25 +175,33 @@ def test_triangle_mesh_quadrature_points_and_current_density():
         n2 = nodes[i2]
         area = 0.5 * np.linalg.norm(np.cross(n1 - n0, n2 - n0))
         expected_centroid = (
-            (1.0 - GL1_TRI_QUAD[:, 1] - GL1_TRI_QUAD[:, 2])[:, None] * n0[None, :]
-            + GL1_TRI_QUAD[:, 1][:, None] * n1[None, :]
-            + GL1_TRI_QUAD[:, 2][:, None] * n2[None, :]
+            (1.0 - DUNAVANT1_TRI_QUAD[:, 1] - DUNAVANT1_TRI_QUAD[:, 2])[:, None] * n0[None, :]
+            + DUNAVANT1_TRI_QUAD[:, 1][:, None] * n1[None, :]
+            + DUNAVANT1_TRI_QUAD[:, 2][:, None] * n2[None, :]
         )
-        expected_centroid_weights = GL1_TRI_QUAD[:, 0] * area
+        expected_centroid_weights = DUNAVANT1_TRI_QUAD[:, 0] * area
         expected_points = (
-            (1.0 - GL2_TRI_QUAD[:, 1] - GL2_TRI_QUAD[:, 2])[:, None] * n0[None, :]
-            + GL2_TRI_QUAD[:, 1][:, None] * n1[None, :]
-            + GL2_TRI_QUAD[:, 2][:, None] * n2[None, :]
+            (1.0 - DUNAVANT2_TRI_QUAD[:, 1] - DUNAVANT2_TRI_QUAD[:, 2])[:, None] * n0[None, :]
+            + DUNAVANT2_TRI_QUAD[:, 1][:, None] * n1[None, :]
+            + DUNAVANT2_TRI_QUAD[:, 2][:, None] * n2[None, :]
         )
-        expected_weights = GL2_TRI_QUAD[:, 0] * area
+        expected_weights = DUNAVANT2_TRI_QUAD[:, 0] * area
+        expected_dunavant4_points = (
+            (1.0 - DUNAVANT4_TRI_QUAD[:, 1] - DUNAVANT4_TRI_QUAD[:, 2])[:, None] * n0[None, :]
+            + DUNAVANT4_TRI_QUAD[:, 1][:, None] * n1[None, :]
+            + DUNAVANT4_TRI_QUAD[:, 2][:, None] * n2[None, :]
+        )
+        expected_dunavant4_weights = DUNAVANT4_TRI_QUAD[:, 0] * area
         assert np.allclose(centroid_points[i], expected_centroid, rtol=0.0, atol=1e-13)
         assert np.allclose(centroid_weights[i], expected_centroid_weights, rtol=0.0, atol=1e-13)
         assert np.allclose(points[i], expected_points, rtol=0.0, atol=1e-13)
         assert np.allclose(weights[i], expected_weights, rtol=0.0, atol=1e-13)
+        assert np.allclose(dunavant4_points[i], expected_dunavant4_points, rtol=0.0, atol=1e-13)
+        assert np.allclose(dunavant4_weights[i], expected_dunavant4_weights, rtol=0.0, atol=1e-13)
 
 
 @mark.parametrize("par", [True, False])
-@mark.parametrize("quad", ["gl1", "gl2", "gl3", "dunavant5"])
+@mark.parametrize("quad", ["dunavant1", "dunavant2", "dunavant3", "dunavant4", "dunavant5"])
 def test_triangle_mesh_far_field_against_circular_filament(par, quad):
     """Compare far-field triangle-mesh fields against the circular-filament reference."""
     radius = 0.7312345987
@@ -261,16 +285,16 @@ def test_triangle_mesh_field_mappings_contract_to_collection_fields(par):
     )
 
     bx_map, by_map, bz_map = cfsem.flux_density_triangle_mesh_mapping(
-        obs, nodes, triangles, par=par, quad="gl3"
+        obs, nodes, triangles, par=par, quad="dunavant3"
     )
     ax_map, ay_map, az_map = cfsem.vector_potential_triangle_mesh_mapping(
-        obs, nodes, triangles, par=par, quad="gl3"
+        obs, nodes, triangles, par=par, quad="dunavant3"
     )
     bx_map_ref, by_map_ref, bz_map_ref = cfsem.flux_density_triangle_mesh_mapping(
-        obs, nodes, triangles, par=not par, quad="gl3"
+        obs, nodes, triangles, par=not par, quad="dunavant3"
     )
     ax_map_ref, ay_map_ref, az_map_ref = cfsem.vector_potential_triangle_mesh_mapping(
-        obs, nodes, triangles, par=not par, quad="gl3"
+        obs, nodes, triangles, par=not par, quad="dunavant3"
     )
 
     b_from_map = np.column_stack((bx_map @ s, by_map @ s, bz_map @ s))
@@ -304,7 +328,7 @@ def test_triangle_mesh_inductance_matrix_strip_self_inductance_against_wien_and_
     target_current = 3.7  # [A]
 
     # Calculate full-mesh nodal mutual inductance matrix
-    lmat = cfsem.triangle_mesh_inductance_matrix(nodes, triangles, par=False, quad="gl3")  # [H]
+    lmat = cfsem.triangle_mesh_inductance_matrix(nodes, triangles, par=False, quad="dunavant3")  # [H]
 
     # Total self-inductance is 2 * stored energy per amp^2,
     # so we can calculate the self-inductance by taking 2 times the stored energy at unit current.
@@ -345,7 +369,7 @@ def test_triangle_mesh_inductance_mappings_from_other_source_models(par):
     radius = 0.58
     height = radius * 1e-3
     nodes_tgt, triangles_tgt, s_tgt = _triangle_strip_mesh(radius, height, 0.9, nphi=20, z_center=0.14)
-    points, weights = cfsem.triangle_mesh_quadrature_points(nodes_tgt, triangles_tgt, quad="gl3")
+    points, weights = cfsem.triangle_mesh_quadrature_points(nodes_tgt, triangles_tgt, quad="dunavant3")
     j_tgt = cfsem.triangle_mesh_current_density(nodes_tgt, triangles_tgt, s_tgt)
     xyzp = (points[..., 0].ravel(), points[..., 1].ravel(), points[..., 2].ravel())
 
@@ -369,7 +393,7 @@ def test_triangle_mesh_inductance_mappings_from_other_source_models(par):
         triangles_tgt,
         wire_radius=wire_radius,
         par=par,
-        quad="gl3",
+        quad="dunavant3",
     )
     m_lin_ref = cfsem.triangle_mesh_inductance_mapping_from_linear_filaments(
         xyzfil,
@@ -378,7 +402,7 @@ def test_triangle_mesh_inductance_mappings_from_other_source_models(par):
         triangles_tgt,
         wire_radius=wire_radius,
         par=not par,
-        quad="gl3",
+        quad="dunavant3",
     )
     energy_lin = float(s_tgt @ (m_lin @ ifil))
     a_lin = np.column_stack(
@@ -392,10 +416,10 @@ def test_triangle_mesh_inductance_mappings_from_other_source_models(par):
     zfil = np.array([-0.16, 0.29], dtype=np.float64)
     icirc = np.array([0.8, -1.1], dtype=np.float64)
     m_circ = cfsem.triangle_mesh_inductance_mapping_from_circular_filaments(
-        rfil, zfil, nodes_tgt, triangles_tgt, par=par, quad="gl3"
+        rfil, zfil, nodes_tgt, triangles_tgt, par=par, quad="dunavant3"
     )
     m_circ_ref = cfsem.triangle_mesh_inductance_mapping_from_circular_filaments(
-        rfil, zfil, nodes_tgt, triangles_tgt, par=not par, quad="gl3"
+        rfil, zfil, nodes_tgt, triangles_tgt, par=not par, quad="dunavant3"
     )
     energy_circ = float(s_tgt @ (m_circ @ icirc))
     r_qp = np.sqrt(points[..., 0] ** 2 + points[..., 1] ** 2)
@@ -433,7 +457,7 @@ def test_triangle_mesh_inductance_mappings_from_other_source_models(par):
         triangles_tgt,
         outer_radius=outer_radius,
         par=par,
-        quad="gl3",
+        quad="dunavant3",
     )
     m_dip_ref = cfsem.triangle_mesh_flux_linkage_mapping_from_dipoles(
         loc,
@@ -442,7 +466,7 @@ def test_triangle_mesh_inductance_mappings_from_other_source_models(par):
         triangles_tgt,
         outer_radius=outer_radius,
         par=not par,
-        quad="gl3",
+        quad="dunavant3",
     )
     energy_dip = float(s_tgt @ (m_dip @ dip_amp))
     moment = tuple(dip_amp * comp for comp in moment_dir)
@@ -493,7 +517,7 @@ def test_triangle_mesh_inductance_mappings_scalar_source_thickness_inputs():
         triangles_tgt,
         wire_radius=wire_radius_scalar,
         par=False,
-        quad="gl3",
+        quad="dunavant3",
     )
 
     loc = (
@@ -515,7 +539,7 @@ def test_triangle_mesh_inductance_mappings_scalar_source_thickness_inputs():
         triangles_tgt,
         outer_radius=outer_radius_scalar,
         par=False,
-        quad="gl3",
+        quad="dunavant3",
     )
 
     assert m_lin.shape == (nodes_tgt.shape[0], 2)
@@ -539,15 +563,15 @@ def test_triangle_mesh_force_mapping_against_direct_target_quadrature(par):
         triangles_tgt,
         s_tgt,
         par=par,
-        quad="gl3",
+        quad="dunavant3",
     )
     tri_forces = _contract_force_mapping(fx, fy, fz, s_src)
 
-    points, weights = cfsem.triangle_mesh_quadrature_points(nodes_tgt, triangles_tgt, quad="gl3")
+    points, weights = cfsem.triangle_mesh_quadrature_points(nodes_tgt, triangles_tgt, quad="dunavant3")
     j_tgt = cfsem.triangle_mesh_current_density(nodes_tgt, triangles_tgt, s_tgt)
     b_qp = np.column_stack(
         cfsem.flux_density_triangle_mesh(
-            points.reshape(-1, 3), nodes_src, triangles_src, s_src, par=False, quad="gl3"
+            points.reshape(-1, 3), nodes_src, triangles_src, s_src, par=False, quad="dunavant3"
         )
     ).reshape(points.shape)
     tri_forces_ref = _force_from_bfield_on_target(points, weights, j_tgt, b_qp)
@@ -565,11 +589,11 @@ def test_triangle_mesh_self_force_mapping_shapes_and_serial_parallel_agree(par):
     height = radius * 1e-3
     nodes, triangles, s = _triangle_strip_mesh(radius, height, 1.0, nphi=32)
 
-    fx, fy, fz = cfsem.triangle_mesh_self_force_mapping(nodes, triangles, s, par=par, quad="gl3")
+    fx, fy, fz = cfsem.triangle_mesh_self_force_mapping(nodes, triangles, s, par=par, quad="dunavant3")
     tri_forces = _contract_force_mapping(fx, fy, fz, s)
     total_force = np.sum(tri_forces, axis=0)
     fx_ref, fy_ref, fz_ref = cfsem.triangle_mesh_self_force_mapping(
-        nodes, triangles, s, par=not par, quad="gl3"
+        nodes, triangles, s, par=not par, quad="dunavant3"
     )
     tri_forces_ref = _contract_force_mapping(fx_ref, fy_ref, fz_ref, s)
 
@@ -586,7 +610,7 @@ def test_triangle_mesh_force_mappings_from_other_source_models(par):
     radius = 0.58
     height = radius * 1e-3
     nodes_tgt, triangles_tgt, s_tgt = _triangle_strip_mesh(radius, height, 0.9, nphi=20, z_center=0.14)
-    points, weights = cfsem.triangle_mesh_quadrature_points(nodes_tgt, triangles_tgt, quad="gl3")
+    points, weights = cfsem.triangle_mesh_quadrature_points(nodes_tgt, triangles_tgt, quad="dunavant3")
     j_tgt = cfsem.triangle_mesh_current_density(nodes_tgt, triangles_tgt, s_tgt)
     xyzp = (points[..., 0].ravel(), points[..., 1].ravel(), points[..., 2].ravel())
 
@@ -611,7 +635,7 @@ def test_triangle_mesh_force_mappings_from_other_source_models(par):
         s_tgt,
         wire_radius=wire_radius,
         par=par,
-        quad="gl3",
+        quad="dunavant3",
     )
     tri_forces_lin = _contract_force_mapping(fx_lin, fy_lin, fz_lin, ifil)
     b_lin = np.column_stack(
@@ -623,7 +647,7 @@ def test_triangle_mesh_force_mappings_from_other_source_models(par):
     zfil = np.array([-0.16, 0.29], dtype=np.float64)
     icirc = np.array([0.8, -1.1], dtype=np.float64)
     fx_circ, fy_circ, fz_circ = cfsem.triangle_mesh_force_mapping_from_circular_filaments(
-        rfil, zfil, nodes_tgt, triangles_tgt, s_tgt, par=par, quad="gl3"
+        rfil, zfil, nodes_tgt, triangles_tgt, s_tgt, par=par, quad="dunavant3"
     )
     tri_forces_circ = _contract_force_mapping(fx_circ, fy_circ, fz_circ, icirc)
     b_circ = np.column_stack(
@@ -657,7 +681,7 @@ def test_triangle_mesh_force_mappings_from_other_source_models(par):
         s_tgt,
         par=par,
         outer_radius=outer_radius,
-        quad="gl3",
+        quad="dunavant3",
     )
     tri_forces_dip = _contract_force_mapping(fx_dip, fy_dip, fz_dip, dip_amp)
     moment = tuple(dip_amp * comp for comp in moment_dir)
@@ -709,11 +733,11 @@ def test_triangle_mesh_force_on_strip_against_linear_filament_loop(par):
         s_tgt,
         wire_radius=0.0,
         par=par,
-        quad="gl3",
+        quad="dunavant3",
     )
     tri_forces = _contract_force_mapping(fx, fy, fz, ifil)
 
-    points, weights = cfsem.triangle_mesh_quadrature_points(nodes_tgt, triangles_tgt, quad="gl3")
+    points, weights = cfsem.triangle_mesh_quadrature_points(nodes_tgt, triangles_tgt, quad="dunavant3")
     j_tgt = cfsem.triangle_mesh_current_density(nodes_tgt, triangles_tgt, s_tgt)
     j_qp = np.repeat(j_tgt[:, None, :], points.shape[1], axis=1).reshape(-1, 3)
     fx_ref, fy_ref, fz_ref = cfsem.body_force_density_linear_filament(
@@ -762,7 +786,7 @@ def test_triangle_mesh_invalid_inputs():
         cfsem.triangle_mesh_current_density(nodes, degenerate_triangles, s)
 
     with raises(ValueError, match="zero area"):
-        cfsem.triangle_mesh_quadrature_points(nodes, degenerate_triangles, quad="gl3")
+        cfsem.triangle_mesh_quadrature_points(nodes, degenerate_triangles, quad="dunavant3")
 
     with raises(ValueError, match="Unsupported triangle quadrature rule") as excinfo:
         cfsem.vector_potential_triangle_mesh(obs, nodes, triangles, s, quad="bad")


### PR DESCRIPTION
## 8.0.0 2026-04-28

* Rust
    * !Replace triangle Gauss-Legendre quadrature point sets with Dunavant variants of order 1-4
* Python
    * Plumb new quadrature variants through bindings
