### PR TITLE
Add direct stress query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     * Reduce boilerplate in bindings
     * Consolidate calculation of stress and strain operators
         * Use synthetic mesh query data for quadrature points
+    * Consolidate validation and matrix scattering
 * Python
     * Plumb new bindings
     * Deduplicate stress queries using new operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 8.2.0 2026-05-01
+
+* Rust
+    * Add stress operator on query points as standalone method
+    * Remove unused dep on `branches`
+* Python
+    * Plumb new bindings
+    * Deduplicate stress queries using new operator
+
 ## 8.1.0 2026-04-30
 
 * Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Rust
     * Add stress operator on query points as standalone method
     * Remove unused dep on `branches`
+    * Reduce boilerplate in bindings
 * Python
     * Plumb new bindings
     * Deduplicate stress queries using new operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
     * Add stress operator on query points as standalone method
     * Remove unused dep on `branches`
     * Reduce boilerplate in bindings
+    * Consolidate calculation of stress and strain operators
+        * Use synthetic mesh query data for quadrature points
 * Python
     * Plumb new bindings
     * Deduplicate stress queries using new operator

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,15 +73,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "branches"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,9 +128,8 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfsem"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
- "branches",
  "criterion",
  "faer",
  "faer-traits",
@@ -1518,15 +1508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,12 +1542,6 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "seq-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfsem"
-version = "8.1.0"
+version = "8.2.0"
 edition = "2024"
 authors = ["Commonwealth Fusion Systems <jlogan@cfs.energy>"]
 license = "MIT"
@@ -22,7 +22,6 @@ nalgebra = "^0.34.2"
 rayon = "^1.12.0"
 libm = "^0.2"
 num-traits = { version = "0.2.19", features = ["libm"] }
-branches = "0.4.4"
 faer = "0.24.0"
 faer-traits = "0.24.0"
 

--- a/cfsem/solenoid_stress/__init__.py
+++ b/cfsem/solenoid_stress/__init__.py
@@ -41,6 +41,7 @@ from .fem2d import (
     orthotropic_plane_strain_thermal_material,
     pack_material_tables_from_tags,
     quad_mesh_interpolation_operator,
+    quad_mesh_stress_operator,
     quad_mesh_strain_operator,
     query_quad_mesh,
 )
@@ -67,6 +68,7 @@ __all__ = [
     "orthotropic_plane_strain_thermal_material",
     "pack_material_tables_from_tags",
     "quad_mesh_interpolation_operator",
+    "quad_mesh_stress_operator",
     "quad_mesh_strain_operator",
     "query_quad_mesh",
     "s_hoop_thick_wall_cylinder",

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -1161,14 +1161,11 @@ def _normalize_materials(
 
 
 def _normalize_thermal_material_table(
-    material_ids: ArrayLike,
     thermal_material_table: ArrayLike | None,
     dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]] | None:
     if thermal_material_table is None:
         return None
-    ids = np.asarray(material_ids, dtype=np.uint64)
-    assert ids.ndim == 1, f"material_ids must have shape (nelem,); got {ids.shape}"
     assert not isinstance(thermal_material_table, Mapping), (
         "thermal_material_table must be a dense array; use pack_material_tables_from_tags(...) "
         "for tagged inputs"
@@ -1428,7 +1425,6 @@ def assemble_structural_2d(
     nodes_arr = _normalize_nodes(nodes, dtype)
     material_ids_arr, material_table_arr = _normalize_materials(material_ids, material_table, dtype)
     thermal_material_table_arr = _normalize_thermal_material_table(
-        material_ids,
         thermal_material_table,
         dtype,
     )

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -64,6 +64,8 @@ _quad_mesh_query_f32 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_query_f32
 _quad_mesh_query_f64 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_query_f64
 _quad_mesh_strain_operator_f32 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_strain_operator_f32
 _quad_mesh_strain_operator_f64 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_strain_operator_f64
+_quad_mesh_stress_operator_f32 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_stress_operator_f32
+_quad_mesh_stress_operator_f64 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_stress_operator_f64
 _isotropic_axisymmetric_material_f32 = _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_material_f32
 _isotropic_axisymmetric_material_f64 = _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_material_f64
 _isotropic_plane_strain_material_f32 = _cfsem_bindings.solenoid_stress_fem_isotropic_plane_strain_material_f32
@@ -805,6 +807,19 @@ def query_quad_mesh(
     recovery operators do not repeat point location. Complexity is
     `O(npoint * (nnode + nelem * max_iterations))`. A point is contained when its
     nearest-element distance is zero to the caller's tolerance.
+
+    Args:
+        nodes: Mesh node coordinates with shape `(nnode, 2)` and units `[length]`.
+        elements: Quad connectivity with shape `(nelem, 4)` for `quad4` or `(nelem, 9)` for
+            `quad9`. Entries are unitless node indices.
+        points: Query point coordinates with shape `(npoint, 2)` and units `[length]`.
+        element_type: Element family, either `"quad4"` or `"quad9"`.
+        max_iterations: Maximum Newton/projection iterations per element. Unitless.
+
+    Returns:
+        Query data with nearest-node, nearest-element, and nearest-face arrays. Coordinate arrays
+        have units `[length]`, distances have units `[length]`, reference coordinates are unitless,
+        and index arrays are unitless.
     """
 
     dtype = _resolve_float_dtype(nodes, points)
@@ -858,6 +873,14 @@ def quad_mesh_interpolation_operator(
     The returned matrix has shape `(npoint, nnode)`. Applying it to a dense `(nnode,)` vector gives
     scalar values at the query points; applying it to `(nnode, ncomponent)` interpolates multiple
     nodal fields with the same operator. The operator always uses the query's nearest element.
+
+    Args:
+        query: Mesh query data from `query_quad_mesh(...)`.
+
+    Returns:
+        Sparse interpolation operator with shape `(npoint, nnode)`. Entries are unitless shape
+        function values, so output values have the same units as the nodal values supplied during
+        matrix multiplication.
     """
 
     dtype = query.nodes.dtype
@@ -888,6 +911,17 @@ def quad_mesh_strain_operator(
 
     The returned matrix has shape `(4 * npoint, 2 * nnode)`. Rows are grouped by query point and
     use the same four-component strain ordering as the structural FEM formulation.
+
+    Args:
+        query: Mesh query data from `query_quad_mesh(...)`.
+        formulation: Symmetry reduction, either `"axisymmetric"` or `"plane_strain"`.
+        thickness: Plane-strain out-of-plane thickness with units `[length]`. Required only for
+            `formulation="plane_strain"`; must be omitted for `formulation="axisymmetric"`.
+
+    Returns:
+        Sparse strain-recovery operator with shape `(4 * npoint, 2 * nnode)`. Entries have units
+        `[1 / length]`, so multiplying by full nodal displacements with shape `(2 * nnode,)` and
+        units `[length]` returns unitless strain samples with shape `(4 * npoint,)`.
     """
 
     normalized_formulation = _normalize_formulation(formulation)
@@ -900,6 +934,72 @@ def quad_mesh_strain_operator(
             query.elements,
             np.asarray(query.nearest_element_indices, dtype=np.uint64),
             query.nearest_element_reference_points,
+            query.element_type,
+            _formulation_code(normalized_formulation),
+            thickness_value,
+        ),
+        dtype,
+    )
+
+
+def quad_mesh_stress_operator(
+    query: QuadMeshQuery,
+    material_ids: ArrayLike,
+    material_table: ArrayLike,
+    *,
+    formulation: str,
+    thickness: float | None = None,
+    material_orientation_angles: ArrayLike | None = None,
+) -> sp.csr_matrix:
+    """Return a sparse operator mapping full nodal displacements to query-point stress.
+
+    The returned matrix has shape `(4 * npoint, 2 * nnode)`. Rows are grouped by query point and
+    use the same four-component stress ordering as the structural FEM formulation. Each query point
+    uses the material row assigned to its nearest element; for points contained by the mesh, that is
+    the containing element. Optional `material_orientation_angles` follow assembly semantics and
+    rotate local anisotropic material axes into the global 2D frame per element.
+
+    Args:
+        query: Mesh query data from `query_quad_mesh(...)`.
+        material_ids: Per-element material row indices with shape `(nelem,)`. Entries are unitless
+            indices into `material_table`.
+        material_table: Elastic stress-strain matrices with shape `(nmat, 4, 4)`. Entries have
+            units `[stress / strain] = [pressure]`.
+        formulation: Symmetry reduction, either `"axisymmetric"` or `"plane_strain"`.
+        thickness: Plane-strain out-of-plane thickness with units `[length]`. Required only for
+            `formulation="plane_strain"`; must be omitted for `formulation="axisymmetric"`.
+        material_orientation_angles: Optional scalar or per-element angles with shape `(nelem,)`,
+            in radians. Angles are unitless and rotate local material axes into the global 2D frame.
+
+    Returns:
+        Sparse stress-recovery operator with shape `(4 * npoint, 2 * nnode)`. Entries have units
+        `[pressure / length]`, so multiplying by full nodal displacements with shape
+        `(2 * nnode,)` and units `[length]` returns stress samples with shape `(4 * npoint,)` and
+        units `[pressure]`.
+    """
+
+    dtype = _resolve_float_dtype(query.nodes, material_table, material_orientation_angles)
+    material_ids_arr, material_table_arr = _normalize_materials(material_ids, material_table, dtype)
+    assert material_ids_arr.shape == (
+        query.elements.shape[0],
+    ), f"material_ids must have shape ({query.elements.shape[0]},); got {material_ids_arr.shape}"
+    material_orientation_angles_arr = _normalize_material_orientation_angles(
+        material_orientation_angles,
+        query.elements.shape[0],
+        dtype,
+    )
+    normalized_formulation = _normalize_formulation(formulation)
+    thickness_value = _normalize_thickness(normalized_formulation, thickness, dtype)
+    binding = _dispatch_pair(dtype, _quad_mesh_stress_operator_f32, _quad_mesh_stress_operator_f64)
+    return _coo_operator_from_binding(
+        binding(
+            np.asarray(query.nodes, dtype=dtype),
+            query.elements,
+            np.asarray(query.nearest_element_indices, dtype=np.uint64),
+            np.asarray(query.nearest_element_reference_points, dtype=dtype),
+            material_ids_arr,
+            material_table_arr,
+            material_orientation_angles_arr,
             query.element_type,
             _formulation_code(normalized_formulation),
             thickness_value,
@@ -941,8 +1041,10 @@ def interpolate_quad_mesh_values(
         max_iterations: Maximum Newton/projection iterations per element.
 
     Returns:
-        QuadMeshInterpolation: interpolated values plus element indices, reference coordinates, and
-        inside flags for the query points.
+        Interpolated values plus element indices, reference coordinates, and inside flags for the
+        query points. `values` has shape `(npoint,)` or `(npoint, ...)` and the same units as
+        `nodal_values`; `element_indices` is unitless with shape `(npoint,)`; `reference_points`
+        is unitless with shape `(npoint, 2)`; `inside` has shape `(npoint,)`.
     """
 
     dtype = _resolve_float_dtype(nodes, nodal_values, points)
@@ -1654,6 +1756,7 @@ __all__ = [
     "orthotropic_plane_strain_thermal_material",
     "pack_material_tables_from_tags",
     "quad_mesh_interpolation_operator",
+    "quad_mesh_stress_operator",
     "quad_mesh_strain_operator",
     "query_quad_mesh",
 ]

--- a/examples/solenoid_stress_axisymmetric_fem.py
+++ b/examples/solenoid_stress_axisymmetric_fem.py
@@ -16,6 +16,7 @@ from cfsem.solenoid_stress.fem2d import (
     cfsem_radial_material,
     infer_quad9_mesh,
     quad_mesh_interpolation_operator,
+    quad_mesh_stress_operator,
     quad_mesh_strain_operator,
     query_quad_mesh,
 )
@@ -410,13 +411,22 @@ def recover_axisymmetric_fields_at_points(
     query = query_quad_mesh(nodes, elements, points, element_type=element_type)
     interpolation_operator = quad_mesh_interpolation_operator(query)
     strain_operator = quad_mesh_strain_operator(query, formulation="axisymmetric")
+    stress_operator = quad_mesh_stress_operator(
+        query,
+        np.zeros(elements.shape[0], dtype=np.uint64),
+        np.asarray([material], dtype=np.float64),
+        formulation="axisymmetric",
+    )
     displacement_2d = np.asarray(displacement, dtype=np.float64).reshape(nodes.shape[0], 2)
     displacement_at_points = np.asarray(interpolation_operator @ displacement_2d, dtype=np.float64)
     strain_at_points = np.asarray(
         strain_operator @ displacement_2d.reshape(-1),
         dtype=np.float64,
     ).reshape(-1, 4)
-    stress_at_points = strain_at_points @ np.asarray(material, dtype=np.float64).T
+    stress_at_points = np.asarray(
+        stress_operator @ displacement_2d.reshape(-1),
+        dtype=np.float64,
+    ).reshape(-1, 4)
     return displacement_at_points, strain_at_points, stress_at_points
 
 

--- a/examples/solenoid_stress_axisymmetric_fem_convergence.py
+++ b/examples/solenoid_stress_axisymmetric_fem_convergence.py
@@ -37,7 +37,7 @@ from cfsem.solenoid_stress.fem2d import (
     cfsem_radial_material,
     infer_quad9_mesh,
     quad_mesh_interpolation_operator,
-    quad_mesh_strain_operator,
+    quad_mesh_stress_operator,
     query_quad_mesh,
 )
 from cfsem.solenoid_stress.solenoid_handcalc import s_long_solenoid
@@ -177,11 +177,18 @@ def recover_axisymmetric_midplane_profile(
     points = np.column_stack([sample_radius, np.full_like(sample_radius, 0.5 * HEIGHT)])
     query = query_quad_mesh(nodes, elements, points, element_type=element_type)
     interpolation_operator = quad_mesh_interpolation_operator(query)
-    strain_operator = quad_mesh_strain_operator(query, formulation="axisymmetric")
+    stress_operator = quad_mesh_stress_operator(
+        query,
+        np.zeros(elements.shape[0], dtype=np.uint64),
+        np.asarray([material], dtype=np.float64),
+        formulation="axisymmetric",
+    )
     displacement_2d = np.asarray(displacement, dtype=np.float64).reshape(nodes.shape[0], 2)
     displacement_at_points = np.asarray(interpolation_operator @ displacement_2d, dtype=np.float64)
-    strain = np.asarray(strain_operator @ displacement_2d.reshape(-1), dtype=np.float64).reshape(-1, 4)
-    stress = strain @ np.asarray(material, dtype=np.float64).T
+    stress = np.asarray(
+        stress_operator @ displacement_2d.reshape(-1),
+        dtype=np.float64,
+    ).reshape(-1, 4)
     return Profile(
         radius=np.asarray(sample_radius, dtype=np.float64),
         u_r=displacement_at_points[:, 0],

--- a/src/mesh/quad2d.rs
+++ b/src/mesh/quad2d.rs
@@ -567,9 +567,10 @@ where
         ));
     }
 
-    let mut rows = Vec::new();
-    let mut cols = Vec::new();
-    let mut vals = Vec::new();
+    let max_nonzeros = element_indices.len() * 4 * DOF_PER_ELEMENT;
+    let mut rows = Vec::with_capacity(max_nonzeros);
+    let mut cols = Vec::with_capacity(max_nonzeros);
+    let mut vals = Vec::with_capacity(max_nonzeros);
 
     for (query_index, (&element_index, &reference)) in
         element_indices.iter().zip(reference_points).enumerate()
@@ -673,9 +674,10 @@ where
         ));
     }
 
-    let mut rows = Vec::new();
-    let mut cols = Vec::new();
-    let mut vals = Vec::new();
+    let max_nonzeros = element_indices.len() * 4 * DOF_PER_ELEMENT;
+    let mut rows = Vec::with_capacity(max_nonzeros);
+    let mut cols = Vec::with_capacity(max_nonzeros);
+    let mut vals = Vec::with_capacity(max_nonzeros);
 
     for (query_index, (&element_index, &reference)) in
         element_indices.iter().zip(reference_points).enumerate()

--- a/src/mesh/quad2d.rs
+++ b/src/mesh/quad2d.rs
@@ -682,9 +682,7 @@ where
     {
         let coords = mesh.element_coords(element_index)?;
         let nodes = mesh.element_nodes(element_index)?;
-        let material_id = *material_ids
-            .get(element_index)
-            .ok_or_else(|| format!("material_ids is missing element {element_index}"))?;
+        let material_id = material_ids[element_index];
         let material = material_table.get(material_id).ok_or_else(|| {
             format!("material_id {material_id} on element {element_index} is out of range")
         })?;

--- a/src/mesh/quad2d.rs
+++ b/src/mesh/quad2d.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use crate::mesh::elements::quad2d::{mapping, quad4, quad9};
 use crate::mesh::{Scalar, cast};
 use crate::physics::solenoid_stress::{
-    DOF_PER_NODE, Real, Structural2dFormulation, build_b_matrix,
+    DOF_PER_NODE, Real, Structural2dFormulation, build_b_matrix, rotate_material_in_plane,
 };
 
 /// Borrowed view of a 2D quadrilateral mesh with fixed nodes per element.
@@ -613,13 +613,140 @@ where
     })
 }
 
+/// Build a sparse stress-recovery operator from query element/reference coordinates.
+///
+/// The operator has shape `(4 * nquery, 2 * nnode)` and maps full nodal displacement values to the
+/// four-component stress vector at each query point. Rows are grouped per query point in the same
+/// component ordering as the structural formulation. Each query point uses the material assigned to
+/// its query element; for contained points this is the containing element.
+///
+/// `mesh.nodes_rz` and `reference_points` define geometry with physical node coordinates in
+/// `[length]` and unitless reference coordinates. `element_indices` and `material_ids` are unitless
+/// indices with lengths `nquery` and `nelem`, respectively. `material_table` has shape
+/// `(nmat, 4, 4)` and units `[stress / strain] = [pressure]`. Optional
+/// `material_orientation_angles` has shape `(nelem,)` and unitless radians. Operator entries have
+/// units `[pressure / length]`, so multiplying by nodal displacements with units `[length]`
+/// returns stresses with units `[pressure]`.
+pub fn quad_mesh_stress_operator<
+    E,
+    F,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    element_indices: &[usize],
+    reference_points: &[[F; 2]],
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+) -> Result<QuadMeshSparseOperator<F>, String>
+where
+    E: QuadReferenceElement<NODES_PER_ELEMENT>,
+    F: Real,
+{
+    const {
+        assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
+    }
+    mesh.validate_connectivity()?;
+    if element_indices.len() != reference_points.len() {
+        return Err(format!(
+            "element_indices has length {}, but reference_points has length {}",
+            element_indices.len(),
+            reference_points.len()
+        ));
+    }
+    if material_ids.len() != mesh.num_elements() {
+        return Err(format!(
+            "material_ids has length {}, but mesh has {} elements",
+            material_ids.len(),
+            mesh.num_elements()
+        ));
+    }
+    if let Some(angles) = material_orientation_angles
+        && angles.len() != mesh.num_elements()
+    {
+        return Err(format!(
+            "material_orientation_angles has length {}, but mesh has {} elements",
+            angles.len(),
+            mesh.num_elements()
+        ));
+    }
+
+    let mut rows = Vec::new();
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+
+    for (query_index, (&element_index, &reference)) in
+        element_indices.iter().zip(reference_points).enumerate()
+    {
+        let coords = mesh.element_coords(element_index)?;
+        let nodes = mesh.element_nodes(element_index)?;
+        let material_id = *material_ids
+            .get(element_index)
+            .ok_or_else(|| format!("material_ids is missing element {element_index}"))?;
+        let material = material_table.get(material_id).ok_or_else(|| {
+            format!("material_id {material_id} on element {element_index} is out of range")
+        })?;
+        let material_storage;
+        let material = if let Some(angles) = material_orientation_angles {
+            material_storage = rotate_material_in_plane(material, angles[element_index]);
+            &material_storage
+        } else {
+            material
+        };
+
+        let shape = E::shape(reference[0], reference[1]);
+        let grad_ref = E::grad_ref(reference[0], reference[1]);
+        let jac = mapping::jacobian(&coords, &grad_ref);
+        let inv_jac = mapping::inv_j(&jac)?;
+        let grad_phys = mapping::grad_phys(&grad_ref, &inv_jac);
+        let point = mapping::map_point(&coords, &shape);
+        let b = build_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            formulation,
+            &shape,
+            &grad_phys,
+            point,
+        )?;
+
+        for component in 0..4 {
+            let row = 4 * query_index + component;
+            for local_node in 0..NODES_PER_ELEMENT {
+                for dof_component in 0..DOF_PER_NODE {
+                    let local_dof = DOF_PER_NODE * local_node + dof_component;
+                    let mut value = F::zero();
+                    for strain_component in 0..4 {
+                        value = value
+                            + material[component][strain_component]
+                                * b[strain_component][local_dof];
+                    }
+                    if value != F::zero() {
+                        rows.push(row);
+                        cols.push(DOF_PER_NODE * nodes[local_node] + dof_component);
+                        vals.push(value);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(QuadMeshSparseOperator {
+        rows,
+        cols,
+        vals,
+        nrow: 4 * element_indices.len(),
+        ncol: DOF_PER_NODE * mesh.num_nodes(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         Quad4ReferenceElement, Quad9ReferenceElement, QuadMeshView2d,
-        quad_mesh_interpolation_operator, query_quad_mesh,
+        quad_mesh_interpolation_operator, quad_mesh_stress_operator, query_quad_mesh,
     };
     use crate::mesh::elements::quad2d::{mapping, quad9};
+    use crate::physics::solenoid_stress::Structural2dFormulation;
 
     #[test]
     fn quad_mesh_query_and_interpolation_operator_handle_quad4() {
@@ -712,5 +839,62 @@ mod tests {
         assert!((query.nearest_element_reference_points[0][0] - reference[0]).abs() < 1.0e-10);
         assert!((query.nearest_element_reference_points[0][1] - reference[1]).abs() < 1.0e-10);
         assert!((interpolated - expected).abs() < 1.0e-10);
+    }
+
+    #[test]
+    fn quad_mesh_stress_operator_uses_query_element_material() {
+        let nodes = [
+            [0.0_f64, 0.0],
+            [1.0, 0.0],
+            [2.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+            [2.0, 1.0],
+        ];
+        let elements = [[0usize, 1, 4, 3], [1, 2, 5, 4]];
+        let mesh = QuadMeshView2d {
+            nodes_rz: &nodes,
+            elements: &elements,
+        };
+        let material_ids = [0usize, 1usize];
+        let material_table = [
+            [
+                [2.0, 0.25, 0.0, 0.0],
+                [0.5, 3.0, 0.0, 0.0],
+                [0.0, 0.0, 5.0, 0.0],
+                [0.0, 0.0, 0.0, 7.0],
+            ],
+            [
+                [11.0, 1.5, 0.0, 0.0],
+                [2.0, 13.0, 0.0, 0.0],
+                [0.0, 0.0, 17.0, 0.0],
+                [0.0, 0.0, 0.0, 19.0],
+            ],
+        ];
+        let query =
+            query_quad_mesh::<Quad4ReferenceElement, _, 4>(mesh, &[[0.25, 0.5], [1.75, 0.5]], 20)
+                .expect("mesh query");
+        let operator = quad_mesh_stress_operator::<Quad4ReferenceElement, _, 4, 8>(
+            mesh,
+            &query.nearest_element_indices,
+            &query.nearest_element_reference_points,
+            &material_ids,
+            &material_table,
+            None,
+            Structural2dFormulation::PlaneStrain { thickness: 1.0 },
+        )
+        .expect("stress operator");
+        let displacement = [
+            0.0_f64, 0.0, 1.0, 0.0, 2.0, 0.0, 0.0, 2.0, 1.0, 2.0, 2.0, 2.0,
+        ];
+        let mut stress = [0.0_f64; 8];
+        for ((&row, &col), &value) in operator.rows.iter().zip(&operator.cols).zip(&operator.vals) {
+            stress[row] += value * displacement[col];
+        }
+
+        let expected = [2.5, 6.5, 0.0, 0.0, 14.0, 28.0, 0.0, 0.0];
+        for (actual, expected) in stress.iter().zip(expected) {
+            assert!((actual - expected).abs() < 1.0e-12);
+        }
     }
 }

--- a/src/mesh/quad2d.rs
+++ b/src/mesh/quad2d.rs
@@ -6,6 +6,7 @@ use crate::mesh::elements::quad2d::{mapping, quad4, quad9};
 use crate::mesh::{Scalar, cast};
 use crate::physics::solenoid_stress::{
     DOF_PER_NODE, Real, Structural2dFormulation, build_b_matrix, rotate_material_in_plane,
+    validate_element_material_inputs,
 };
 
 /// Borrowed view of a 2D quadrilateral mesh with fixed nodes per element.
@@ -657,22 +658,11 @@ where
             reference_points.len()
         ));
     }
-    if material_ids.len() != mesh.num_elements() {
-        return Err(format!(
-            "material_ids has length {}, but mesh has {} elements",
-            material_ids.len(),
-            mesh.num_elements()
-        ));
-    }
-    if let Some(angles) = material_orientation_angles
-        && angles.len() != mesh.num_elements()
-    {
-        return Err(format!(
-            "material_orientation_angles has length {}, but mesh has {} elements",
-            angles.len(),
-            mesh.num_elements()
-        ));
-    }
+    validate_element_material_inputs(
+        mesh.num_elements(),
+        material_ids,
+        material_orientation_angles,
+    )?;
 
     let max_nonzeros = element_indices.len() * 4 * DOF_PER_ELEMENT;
     let mut rows = Vec::with_capacity(max_nonzeros);

--- a/src/physics/solenoid_stress/assembly.rs
+++ b/src/physics/solenoid_stress/assembly.rs
@@ -10,6 +10,7 @@ use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::validate_structural_2d_mesh;
 use crate::physics::solenoid_stress::types::{
     DOF_PER_NODE, Real, StiffnessTriplets, Structural2dFormulation, local_dofs,
+    validate_element_material_inputs,
 };
 
 /// Assemble the full unconstrained stiffness matrix for one quadrilateral family.
@@ -37,22 +38,11 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
-    if material_ids.len() != mesh.num_elements() {
-        return Err(format!(
-            "material_ids has length {}, but mesh has {} elements",
-            material_ids.len(),
-            mesh.num_elements()
-        ));
-    }
-    if let Some(angles) = material_orientation_angles
-        && angles.len() != mesh.num_elements()
-    {
-        return Err(format!(
-            "material_orientation_angles has length {}, but mesh has {} elements",
-            angles.len(),
-            mesh.num_elements()
-        ));
-    }
+    validate_element_material_inputs(
+        mesh.num_elements(),
+        material_ids,
+        material_orientation_angles,
+    )?;
     let mut rows = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
     let mut cols = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
     let mut vals = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT);

--- a/src/physics/solenoid_stress/family.rs
+++ b/src/physics/solenoid_stress/family.rs
@@ -1,6 +1,7 @@
-//! Family-specific quadrilateral sampling and metadata for the axisymmetric FEM backend.
+//! Family-specific quadrilateral sampling and metadata for the structural 2D FEM backend.
 
 use crate::mesh::elements::quad2d::{quad4, quad9};
+use crate::mesh::quad2d::{Quad4ReferenceElement, Quad9ReferenceElement, QuadReferenceElement};
 use crate::mesh::{QuadratureRule, sampling};
 use crate::physics::solenoid_stress::geometry::{FaceSample, VolumeSample};
 use crate::physics::solenoid_stress::model::Structural2dElementType;
@@ -15,6 +16,9 @@ use crate::physics::solenoid_stress::types::Real;
 /// - family-specific face sampling, and
 /// - connectivity flattening for Python-facing metadata export.
 pub(crate) trait QuadElementFamily<const NODES_PER_ELEMENT: usize> {
+    /// Reference-element implementation used by mesh query and recovery operators.
+    type ReferenceElement: QuadReferenceElement<NODES_PER_ELEMENT>;
+
     /// Return the public element-family tag corresponding to this internal family marker.
     fn element_type() -> Structural2dElementType;
 
@@ -45,6 +49,8 @@ pub(crate) trait QuadElementFamily<const NODES_PER_ELEMENT: usize> {
 pub(crate) struct Quad4Family;
 
 impl QuadElementFamily<{ quad4::NODES_PER_ELEMENT }> for Quad4Family {
+    type ReferenceElement = Quad4ReferenceElement;
+
     /// Identify this marker as the public `quad4` family.
     fn element_type() -> Structural2dElementType {
         Structural2dElementType::Quad4
@@ -72,6 +78,8 @@ impl QuadElementFamily<{ quad4::NODES_PER_ELEMENT }> for Quad4Family {
 pub(crate) struct Quad9Family;
 
 impl QuadElementFamily<{ quad9::NODES_PER_ELEMENT }> for Quad9Family {
+    type ReferenceElement = Quad9ReferenceElement;
+
     /// Identify this marker as the public `quad9` family.
     fn element_type() -> Structural2dElementType {
         Structural2dElementType::Quad9

--- a/src/physics/solenoid_stress/loads/body_force.rs
+++ b/src/physics/solenoid_stress/loads/body_force.rs
@@ -2,10 +2,10 @@ use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, local_dofs,
+    DOF_PER_NODE, Real, Structural2dFormulation, local_dofs, scatter_local_matrix,
 };
 
-use super::{SparseOperator, scatter_local_matrix};
+use super::SparseOperator;
 
 /// Build the local dense body-force operator for one element.
 ///

--- a/src/physics/solenoid_stress/loads/mod.rs
+++ b/src/physics/solenoid_stress/loads/mod.rs
@@ -57,44 +57,6 @@ pub struct ThermalLoadOperator<F: Real> {
     pub reference_rhs: Vec<F>,
 }
 
-pub(super) fn scatter_local_vector<F: Real, const NROW: usize>(
-    rows: &mut Vec<usize>,
-    cols: &mut Vec<usize>,
-    vals: &mut Vec<F>,
-    global_rows: &[usize; NROW],
-    global_col: usize,
-    local: &[F; NROW],
-) {
-    for row in 0..NROW {
-        let value = local[row];
-        if value != F::zero() {
-            rows.push(global_rows[row]);
-            cols.push(global_col);
-            vals.push(value);
-        }
-    }
-}
-
-pub(super) fn scatter_local_matrix<F: Real, const NROW: usize, const NCOL: usize>(
-    rows: &mut Vec<usize>,
-    cols: &mut Vec<usize>,
-    vals: &mut Vec<F>,
-    global_rows: &[usize; NROW],
-    global_cols: &[usize; NCOL],
-    local: &[[F; NCOL]; NROW],
-) {
-    for row in 0..NROW {
-        for col in 0..NCOL {
-            let value = local[row][col];
-            if value != F::zero() {
-                rows.push(global_rows[row]);
-                cols.push(global_cols[col]);
-                vals.push(value);
-            }
-        }
-    }
-}
-
 pub(crate) use body_force::body_force_operator_for_family;
 pub(crate) use pressure::pressure_operator_for_family;
 pub(crate) use thermal::temperature_operator_for_family;

--- a/src/physics/solenoid_stress/loads/pressure.rs
+++ b/src/physics/solenoid_stress/loads/pressure.rs
@@ -2,10 +2,10 @@ use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, PressureLoad, Real, Structural2dFormulation, local_dofs,
+    DOF_PER_NODE, PressureLoad, Real, Structural2dFormulation, local_dofs, scatter_local_vector,
 };
 
-use super::{SparseOperator, scatter_local_vector};
+use super::SparseOperator;
 
 /// Build the local dense pressure-load vector for one loaded face.
 ///

--- a/src/physics/solenoid_stress/loads/thermal.rs
+++ b/src/physics/solenoid_stress/loads/thermal.rs
@@ -8,10 +8,11 @@ use crate::physics::solenoid_stress::convenience::{
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, local_dofs,
+    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, local_dofs, scatter_local_matrix,
+    validate_element_material_inputs,
 };
 
-use super::{SparseOperator, ThermalLoadOperator, scatter_local_matrix};
+use super::{SparseOperator, ThermalLoadOperator};
 
 /// Local thermal operator data for one element.
 ///
@@ -119,22 +120,11 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
-    if material_ids.len() != mesh.num_elements() {
-        return Err(format!(
-            "material_ids has length {}, but mesh has {} elements",
-            material_ids.len(),
-            mesh.num_elements()
-        ));
-    }
-    if let Some(angles) = material_orientation_angles
-        && angles.len() != mesh.num_elements()
-    {
-        return Err(format!(
-            "material_orientation_angles has length {}, but mesh has {} elements",
-            angles.len(),
-            mesh.num_elements()
-        ));
-    }
+    validate_element_material_inputs(
+        mesh.num_elements(),
+        material_ids,
+        material_orientation_angles,
+    )?;
     let ndof = mesh.num_nodes() * 2;
     let ncol = mesh.num_nodes();
     let mut rows = Vec::new();

--- a/src/physics/solenoid_stress/loads/traction.rs
+++ b/src/physics/solenoid_stress/loads/traction.rs
@@ -2,10 +2,10 @@ use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, TractionLoad, local_dofs,
+    DOF_PER_NODE, Real, Structural2dFormulation, TractionLoad, local_dofs, scatter_local_matrix,
 };
 
-use super::{SparseOperator, scatter_local_matrix};
+use super::SparseOperator;
 
 /// Build the local dense traction operator for one loaded face.
 ///

--- a/src/physics/solenoid_stress/mod.rs
+++ b/src/physics/solenoid_stress/mod.rs
@@ -509,6 +509,7 @@ pub use model::{
     ReducedRecoveryOperators, Structural2dElementType, Structural2dElements, Structural2dModel,
     assemble_structural_2d,
 };
+pub(crate) use types::validate_element_material_inputs;
 pub use types::{
     DOF_PER_NODE, PressureLoad, Real, Structural2dFormulation, ThermalMaterial, TractionLoad,
     dof_per_element,

--- a/src/physics/solenoid_stress/recovery.rs
+++ b/src/physics/solenoid_stress/recovery.rs
@@ -5,15 +5,18 @@
 //! meridian coordinates `(r, z)` with the element Jacobian. There is no finite-difference
 //! approximation of the displacement field.
 //!
-//! The chain is:
+//! Mechanical strain/stress recovery uses the same query-coordinate sparse operators that serve
+//! arbitrary point probes. Quadrature recovery builds the known element-major
+//! `(element_index, reference_point)` arrays directly, so it reuses that math without doing a
+//! nearest-element search.
+//!
+//! The underlying chain is:
 //! 1. Each element family defines closed-form shape functions `N_i(\xi,\eta)` and closed-form
 //!    reference gradients.
 //! 2. At each quadrature point, those reference gradients are mapped into physical-space
 //!    gradients with the inverse Jacobian according to
 //!    `partial N / partial (r, z) = J^{-T} partial N / partial (\xi, \eta)`.
-//! 3. Those physical derivatives are stored in each [`VolumeSample`] as `grad_phys`.
-//! 4. The axisymmetric strain-displacement matrix `B` is then built from those physical
-//!    derivatives.
+//! 3. The strain-displacement matrix `B` is then built from those physical derivatives.
 //!
 //! In that `B` matrix:
 //! - `e_rr = partial u_r / partial r`,
@@ -25,22 +28,25 @@
 //! - `e_tt = u_r / r`,
 //! so that row uses `N_i / r`, not a spatial derivative.
 //!
-//! 5. Recovery then uses that same `B`:
+//! 4. Recovery then uses that same `B`:
 //!    - strain recovery uses `B`,
 //!    - stress recovery uses `D B`,
 //!    where `D` is the local per-material `4 x 4` matrix for the elastic stress-strain law.
+//!
+//! Thermal recovery remains quadrature-specific because it maps nodal temperatures and material
+//! reference temperatures to thermal strain/stress offsets.
 
+use crate::mesh::elements::quad2d::quadrature::gauss_volume;
+use crate::mesh::quad2d::{quad_mesh_strain_operator, quad_mesh_stress_operator};
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
-use crate::physics::solenoid_stress::axisym::{
-    build_b_matrix, constitutive_times_b, constitutive_times_strain,
-};
+use crate::physics::solenoid_stress::axisym::constitutive_times_strain;
 use crate::physics::solenoid_stress::convenience::{
     rotate_material_in_plane, rotate_thermal_material_in_plane,
 };
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, local_dofs,
+    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial,
 };
 
 /// Sparse quadrature-point recovery operators before reduction into the model-owned CSR form.
@@ -107,21 +113,13 @@ pub struct QuadratureFieldOperators<F: Real> {
     pub ntemp: usize,
 }
 
-/// Dense recovery operators for one quadrature point.
+/// Dense thermal recovery operators for one quadrature point.
 ///
 /// Units:
-/// - `strain`: `[strain / displacement] = [1 / length]`
-/// - `stress`: `[stress / displacement] = [pressure / length]`
 /// - `thermal_strain`: `[strain / temperature]`
 /// - `thermal_stress`: `[stress / temperature]`
 /// - `thermal_*_constant`: `strain` and `stress`, respectively
-struct LocalQuadratureSampleKernel<
-    F: Real,
-    const NODES_PER_ELEMENT: usize,
-    const DOF_PER_ELEMENT: usize,
-> {
-    strain: [[F; DOF_PER_ELEMENT]; 4],
-    stress: [[F; DOF_PER_ELEMENT]; 4],
+struct LocalThermalSampleKernel<F: Real, const NODES_PER_ELEMENT: usize> {
     thermal_strain: [[F; NODES_PER_ELEMENT]; 4],
     thermal_stress: [[F; NODES_PER_ELEMENT]; 4],
     thermal_strain_constant: [F; 4],
@@ -149,64 +147,60 @@ fn scatter_local_matrix<F: Real, const NROW: usize, const NCOL: usize>(
     }
 }
 
-/// Build the dense recovery blocks for one quadrature point.
+/// Build the dense thermal recovery blocks for one quadrature point.
 ///
-/// This helper evaluates the local strain and stress maps with the element's `4 x 4` elastic
-/// stress-strain matrix, and, when thermal data is present, also builds the local thermal
-/// operators and constant offsets associated with the material reference temperature.
-fn quadrature_sample_kernel<
-    F: Real,
-    const NODES_PER_ELEMENT: usize,
-    const DOF_PER_ELEMENT: usize,
->(
+/// This helper builds the local thermal operators and constant offsets associated with the
+/// material reference temperature. Mechanical strain/stress recovery is assembled through the
+/// shared query-coordinate mesh operators.
+fn thermal_sample_kernel<F: Real, const NODES_PER_ELEMENT: usize>(
     sample: &VolumeSample<F, NODES_PER_ELEMENT>,
-    material: &[[F; 4]; 4],
-    thermal_material: Option<&ThermalMaterial<F>>,
-    thermal_stress_unit: Option<&[F; 4]>,
-    formulation: Structural2dFormulation<F>,
-) -> Result<LocalQuadratureSampleKernel<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>, String> {
-    const {
-        assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
-    }
-    // `B` maps nodal displacements `[length]` to strain `[dimensionless]`.
-    let strain = build_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-        formulation,
-        &sample.n,
-        &sample.grad_phys,
-        sample.point,
-    )?;
-    // `D B` maps nodal displacements `[length]` to stress `[pressure]`. The elastic stress-strain
-    // matrix is applied here with the local per-material `4 x 4` matrix; there is no assembled
-    // global stress-strain operator.
-    let stress = constitutive_times_b(material, &strain);
-    let mut local = LocalQuadratureSampleKernel {
-        strain,
-        stress,
+    thermal: &ThermalMaterial<F>,
+    thermal_stress_unit: &[F; 4],
+) -> LocalThermalSampleKernel<F, NODES_PER_ELEMENT> {
+    let mut local = LocalThermalSampleKernel {
         thermal_strain: [[F::zero(); NODES_PER_ELEMENT]; 4],
         thermal_stress: [[F::zero(); NODES_PER_ELEMENT]; 4],
         thermal_strain_constant: [F::zero(); 4],
         thermal_stress_constant: [F::zero(); 4],
     };
 
-    if let Some(thermal) = thermal_material {
-        let thermal_stress_unit = thermal_stress_unit.expect("thermal stress unit");
-        for component in 0..4 {
-            for local_temp_node in 0..NODES_PER_ELEMENT {
-                // These blocks map the nodal temperature field directly to thermal strain/stress
-                // at this quadrature point.
-                local.thermal_strain[component][local_temp_node] =
-                    thermal.alpha[component] * sample.n[local_temp_node];
-                local.thermal_stress[component][local_temp_node] =
-                    thermal_stress_unit[component] * sample.n[local_temp_node];
-            }
-            local.thermal_strain_constant[component] =
-                -thermal.alpha[component] * thermal.reference_temperature;
-            local.thermal_stress_constant[component] =
-                -thermal_stress_unit[component] * thermal.reference_temperature;
+    for component in 0..4 {
+        for local_temp_node in 0..NODES_PER_ELEMENT {
+            // These blocks map the nodal temperature field directly to thermal strain/stress
+            // at this quadrature point.
+            local.thermal_strain[component][local_temp_node] =
+                thermal.alpha[component] * sample.n[local_temp_node];
+            local.thermal_stress[component][local_temp_node] =
+                thermal_stress_unit[component] * sample.n[local_temp_node];
         }
+        local.thermal_strain_constant[component] =
+            -thermal.alpha[component] * thermal.reference_temperature;
+        local.thermal_stress_constant[component] =
+            -thermal_stress_unit[component] * thermal.reference_temperature;
     }
 
-    Ok(local)
+    local
+}
+
+/// Return element-major quadrature-point references without doing a geometric point query.
+///
+/// Quadrature recovery already knows which element owns each point. These arrays have the same
+/// shape expected by the query-coordinate strain/stress operators, but avoid the `O(nquery *
+/// nelem)` nearest-element search that `query_quad_mesh` performs for arbitrary physical points.
+fn element_major_reference_points<F: Real>(
+    nelem: usize,
+    quadrature: QuadratureRule,
+) -> (Vec<usize>, Vec<[F; 2]>) {
+    let references = gauss_volume::<F>(quadrature);
+    let mut element_indices = Vec::with_capacity(nelem * references.len());
+    let mut reference_points = Vec::with_capacity(nelem * references.len());
+    for element_index in 0..nelem {
+        for &(reference, _) in &references {
+            element_indices.push(element_index);
+            reference_points.push(reference);
+        }
+    }
+    (element_indices, reference_points)
 }
 
 /// Assemble quadrature-point strain/stress recovery operators for one quadrilateral family.
@@ -259,13 +253,30 @@ where
 
     let nq_per_element = quadrature.points_per_element();
     let nsamples = mesh.num_elements() * nq_per_element;
+    let (element_indices, reference_points) =
+        element_major_reference_points::<F>(mesh.num_elements(), quadrature);
+    let strain_operator = quad_mesh_strain_operator::<
+        Family::ReferenceElement,
+        F,
+        NODES_PER_ELEMENT,
+        DOF_PER_ELEMENT,
+    >(mesh, &element_indices, &reference_points, formulation)?;
+    let stress_operator = quad_mesh_stress_operator::<
+        Family::ReferenceElement,
+        F,
+        NODES_PER_ELEMENT,
+        DOF_PER_ELEMENT,
+    >(
+        mesh,
+        &element_indices,
+        &reference_points,
+        material_ids,
+        material_table,
+        material_orientation_angles,
+        formulation,
+    )?;
+
     let mut points = Vec::with_capacity(nsamples);
-    let mut strain_rows = Vec::with_capacity(nsamples * (DOF_PER_ELEMENT + 4));
-    let mut strain_cols = Vec::with_capacity(nsamples * (DOF_PER_ELEMENT + 4));
-    let mut strain_vals = Vec::with_capacity(nsamples * (DOF_PER_ELEMENT + 4));
-    let mut stress_rows = Vec::with_capacity(nsamples * (DOF_PER_ELEMENT + 4));
-    let mut stress_cols = Vec::with_capacity(nsamples * (DOF_PER_ELEMENT + 4));
-    let mut stress_vals = Vec::with_capacity(nsamples * (DOF_PER_ELEMENT + 4));
     let mut thermal_strain_rows = Vec::new();
     let mut thermal_strain_cols = Vec::new();
     let mut thermal_strain_vals = Vec::new();
@@ -301,7 +312,6 @@ where
         } else {
             (material, thermal_material_base)
         };
-        let global_dofs = local_dofs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&nodes);
         let thermal_stress_unit =
             thermal_material.map(|thermal| constitutive_times_strain(material, &thermal.alpha));
 
@@ -309,33 +319,13 @@ where
             .into_iter()
             .enumerate()
         {
-            let local = quadrature_sample_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                &sample,
-                material,
-                thermal_material,
-                thermal_stress_unit.as_ref(),
-                formulation,
-            )?;
             let row_base = 4 * (element_index * nq_per_element + q_local);
             let global_rows = [row_base, row_base + 1, row_base + 2, row_base + 3];
             points.push(sample.point);
-            scatter_local_matrix(
-                &mut strain_rows,
-                &mut strain_cols,
-                &mut strain_vals,
-                &global_rows,
-                &global_dofs,
-                &local.strain,
-            );
-            scatter_local_matrix(
-                &mut stress_rows,
-                &mut stress_cols,
-                &mut stress_vals,
-                &global_rows,
-                &global_dofs,
-                &local.stress,
-            );
-            if thermal_material.is_some() {
+            if let (Some(thermal_material), Some(thermal_stress_unit)) =
+                (thermal_material, thermal_stress_unit.as_ref())
+            {
+                let local = thermal_sample_kernel(&sample, thermal_material, thermal_stress_unit);
                 scatter_local_matrix(
                     &mut thermal_strain_rows,
                     &mut thermal_strain_cols,
@@ -364,12 +354,12 @@ where
 
     Ok(QuadratureFieldOperators {
         points,
-        strain_rows,
-        strain_cols,
-        strain_vals,
-        stress_rows,
-        stress_cols,
-        stress_vals,
+        strain_rows: strain_operator.rows,
+        strain_cols: strain_operator.cols,
+        strain_vals: strain_operator.vals,
+        stress_rows: stress_operator.rows,
+        stress_cols: stress_operator.cols,
+        stress_vals: stress_operator.vals,
         thermal_strain_rows,
         thermal_strain_cols,
         thermal_strain_vals,

--- a/src/physics/solenoid_stress/recovery.rs
+++ b/src/physics/solenoid_stress/recovery.rs
@@ -46,7 +46,8 @@ use crate::physics::solenoid_stress::convenience::{
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial,
+    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, scatter_local_matrix,
+    validate_element_material_inputs,
 };
 
 /// Sparse quadrature-point recovery operators before reduction into the model-owned CSR form.
@@ -124,27 +125,6 @@ struct LocalThermalSampleKernel<F: Real, const NODES_PER_ELEMENT: usize> {
     thermal_stress: [[F; NODES_PER_ELEMENT]; 4],
     thermal_strain_constant: [F; 4],
     thermal_stress_constant: [F; 4],
-}
-
-/// Scatter one dense local block into triplet storage for a sparse recovery operator.
-fn scatter_local_matrix<F: Real, const NROW: usize, const NCOL: usize>(
-    rows: &mut Vec<usize>,
-    cols: &mut Vec<usize>,
-    vals: &mut Vec<F>,
-    global_rows: &[usize; NROW],
-    global_cols: &[usize; NCOL],
-    local: &[[F; NCOL]; NROW],
-) {
-    for row in 0..NROW {
-        for col in 0..NCOL {
-            let value = local[row][col];
-            if value != F::zero() {
-                rows.push(global_rows[row]);
-                cols.push(global_cols[col]);
-                vals.push(value);
-            }
-        }
-    }
 }
 
 /// Build the dense thermal recovery blocks for one quadrature point.
@@ -234,22 +214,11 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
-    if material_ids.len() != mesh.num_elements() {
-        return Err(format!(
-            "material_ids has length {}, but mesh has {} elements",
-            material_ids.len(),
-            mesh.num_elements()
-        ));
-    }
-    if let Some(angles) = material_orientation_angles
-        && angles.len() != mesh.num_elements()
-    {
-        return Err(format!(
-            "material_orientation_angles has length {}, but mesh has {} elements",
-            angles.len(),
-            mesh.num_elements()
-        ));
-    }
+    validate_element_material_inputs(
+        mesh.num_elements(),
+        material_ids,
+        material_orientation_angles,
+    )?;
 
     let nq_per_element = quadrature.points_per_element();
     let nsamples = mesh.num_elements() * nq_per_element;

--- a/src/physics/solenoid_stress/types.rs
+++ b/src/physics/solenoid_stress/types.rs
@@ -124,6 +124,71 @@ pub fn local_dofs<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
     local_dofs
 }
 
+/// Validate per-element material-index arrays shared by assembly and recovery code.
+pub(crate) fn validate_element_material_inputs<F: Real>(
+    nelem: usize,
+    material_ids: &[usize],
+    material_orientation_angles: Option<&[F]>,
+) -> Result<(), String> {
+    if material_ids.len() != nelem {
+        return Err(format!(
+            "material_ids has length {}, but mesh has {} elements",
+            material_ids.len(),
+            nelem
+        ));
+    }
+    if let Some(angles) = material_orientation_angles
+        && angles.len() != nelem
+    {
+        return Err(format!(
+            "material_orientation_angles has length {}, but mesh has {} elements",
+            angles.len(),
+            nelem
+        ));
+    }
+    Ok(())
+}
+
+/// Scatter one local vector into sparse triplet storage.
+pub(crate) fn scatter_local_vector<F: Real, const NROW: usize>(
+    rows: &mut Vec<usize>,
+    cols: &mut Vec<usize>,
+    vals: &mut Vec<F>,
+    global_rows: &[usize; NROW],
+    global_col: usize,
+    local: &[F; NROW],
+) {
+    for row in 0..NROW {
+        let value = local[row];
+        if value != F::zero() {
+            rows.push(global_rows[row]);
+            cols.push(global_col);
+            vals.push(value);
+        }
+    }
+}
+
+/// Scatter one local dense block into sparse triplet storage.
+pub(crate) fn scatter_local_matrix<F: Real, const NROW: usize, const NCOL: usize>(
+    rows: &mut Vec<usize>,
+    cols: &mut Vec<usize>,
+    vals: &mut Vec<F>,
+    global_rows: &[usize; NROW],
+    global_cols: &[usize; NCOL],
+    local: &[[F; NCOL]; NROW],
+) {
+    for row in 0..NROW {
+        for col in 0..NCOL {
+            let value = local[row][col];
+            if value != F::zero() {
+                rows.push(global_rows[row]);
+                cols.push(global_cols[col]);
+                vals.push(value);
+            }
+        }
+    }
+}
+
 /// One scalar normal-pressure load topology entry for one element face.
 ///
 /// The pressure amplitude is supplied later at `build_rhs(...)` time, not stored here.

--- a/src/python.rs
+++ b/src/python.rs
@@ -255,6 +255,31 @@ fn flatten_sparse_operator<F: mesh::Scalar>(
     )
 }
 
+type SparseOperatorPyResult<'py, F> = PyResult<(
+    Py<PyArray1<F>>,
+    Py<PyArray1<u64>>,
+    Py<PyArray1<u64>>,
+    u64,
+    u64,
+)>;
+
+fn sparse_operator_to_py<'py, F>(
+    py: Python<'py>,
+    operator: mesh::quad2d::QuadMeshSparseOperator<F>,
+) -> SparseOperatorPyResult<'py, F>
+where
+    F: mesh::Scalar + NumpyElement,
+{
+    let (vals, rows, cols, nrow, ncol) = flatten_sparse_operator(operator);
+    Ok((
+        PyArray1::from_vec(py, vals).unbind(),
+        PyArray1::from_vec(py, rows).unbind(),
+        PyArray1::from_vec(py, cols).unbind(),
+        nrow,
+        ncol,
+    ))
+}
+
 fn read_axisym_pressure_faces(
     pressure_faces: PyReadonlyArray2<'_, u64>,
 ) -> PyResult<Vec<physics::solenoid_stress::PressureLoad>> {
@@ -1486,6 +1511,159 @@ fn solenoid_stress_fem_quad_mesh_query_f32<'py>(
     Ok(dict.unbind())
 }
 
+fn unsupported_quad_element_type(element_type: &str) -> String {
+    format!("unsupported element_type {element_type:?}; use 'quad4' or 'quad9'")
+}
+
+fn quad_mesh_interpolation_operator_for_element_type<F>(
+    nodes: &[[F; 2]],
+    elements: PyReadonlyArray2<'_, u64>,
+    element_indices: &[usize],
+    reference_points: &[[F; 2]],
+    element_type: &str,
+) -> PyResult<mesh::quad2d::QuadMeshSparseOperator<F>>
+where
+    F: physics::solenoid_stress::Real + NumpyElement,
+{
+    match element_type {
+        "quad4" => {
+            let elements = read_axisym_elements::<4>("elements", elements)?;
+            mesh::quad2d::quad_mesh_interpolation_operator::<
+                mesh::quad2d::Quad4ReferenceElement,
+                _,
+                4,
+            >(
+                mesh::QuadMeshView2d {
+                    nodes_rz: nodes,
+                    elements: &elements,
+                },
+                element_indices,
+                reference_points,
+            )
+            .map_err(|msg| PyInteropError::ValueError { msg }.into())
+        }
+        "quad9" => {
+            let elements = read_axisym_elements::<9>("elements", elements)?;
+            mesh::quad2d::quad_mesh_interpolation_operator::<
+                mesh::quad2d::Quad9ReferenceElement,
+                _,
+                9,
+            >(
+                mesh::QuadMeshView2d {
+                    nodes_rz: nodes,
+                    elements: &elements,
+                },
+                element_indices,
+                reference_points,
+            )
+            .map_err(|msg| PyInteropError::ValueError { msg }.into())
+        }
+        _ => Err(PyInteropError::ValueError {
+            msg: unsupported_quad_element_type(element_type),
+        }
+        .into()),
+    }
+}
+
+fn quad_mesh_strain_operator_for_element_type<F>(
+    nodes: &[[F; 2]],
+    elements: PyReadonlyArray2<'_, u64>,
+    element_indices: &[usize],
+    reference_points: &[[F; 2]],
+    element_type: &str,
+    formulation: physics::solenoid_stress::Structural2dFormulation<F>,
+) -> PyResult<mesh::quad2d::QuadMeshSparseOperator<F>>
+where
+    F: physics::solenoid_stress::Real + NumpyElement,
+{
+    match element_type {
+        "quad4" => {
+            let elements = read_axisym_elements::<4>("elements", elements)?;
+            mesh::quad2d::quad_mesh_strain_operator::<mesh::quad2d::Quad4ReferenceElement, _, 4, 8>(
+                mesh::QuadMeshView2d {
+                    nodes_rz: nodes,
+                    elements: &elements,
+                },
+                element_indices,
+                reference_points,
+                formulation,
+            )
+            .map_err(|msg| PyInteropError::ValueError { msg }.into())
+        }
+        "quad9" => {
+            let elements = read_axisym_elements::<9>("elements", elements)?;
+            mesh::quad2d::quad_mesh_strain_operator::<mesh::quad2d::Quad9ReferenceElement, _, 9, 18>(
+                mesh::QuadMeshView2d {
+                    nodes_rz: nodes,
+                    elements: &elements,
+                },
+                element_indices,
+                reference_points,
+                formulation,
+            )
+            .map_err(|msg| PyInteropError::ValueError { msg }.into())
+        }
+        _ => Err(PyInteropError::ValueError {
+            msg: unsupported_quad_element_type(element_type),
+        }
+        .into()),
+    }
+}
+
+fn quad_mesh_stress_operator_for_element_type<F>(
+    nodes: &[[F; 2]],
+    elements: PyReadonlyArray2<'_, u64>,
+    element_indices: &[usize],
+    reference_points: &[[F; 2]],
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    material_orientation_angles: Option<&[F]>,
+    element_type: &str,
+    formulation: physics::solenoid_stress::Structural2dFormulation<F>,
+) -> PyResult<mesh::quad2d::QuadMeshSparseOperator<F>>
+where
+    F: physics::solenoid_stress::Real + NumpyElement,
+{
+    match element_type {
+        "quad4" => {
+            let elements = read_axisym_elements::<4>("elements", elements)?;
+            mesh::quad2d::quad_mesh_stress_operator::<mesh::quad2d::Quad4ReferenceElement, _, 4, 8>(
+                mesh::QuadMeshView2d {
+                    nodes_rz: nodes,
+                    elements: &elements,
+                },
+                element_indices,
+                reference_points,
+                material_ids,
+                material_table,
+                material_orientation_angles,
+                formulation,
+            )
+            .map_err(|msg| PyInteropError::ValueError { msg }.into())
+        }
+        "quad9" => {
+            let elements = read_axisym_elements::<9>("elements", elements)?;
+            mesh::quad2d::quad_mesh_stress_operator::<mesh::quad2d::Quad9ReferenceElement, _, 9, 18>(
+                mesh::QuadMeshView2d {
+                    nodes_rz: nodes,
+                    elements: &elements,
+                },
+                element_indices,
+                reference_points,
+                material_ids,
+                material_table,
+                material_orientation_angles,
+                formulation,
+            )
+            .map_err(|msg| PyInteropError::ValueError { msg }.into())
+        }
+        _ => Err(PyInteropError::ValueError {
+            msg: unsupported_quad_element_type(element_type),
+        }
+        .into()),
+    }
+}
+
 /// Low-level binding for scalar interpolation operators from query element/reference data.
 #[pyfunction]
 fn solenoid_stress_fem_quad_mesh_interpolation_operator_f64<'py>(
@@ -1505,50 +1683,14 @@ fn solenoid_stress_fem_quad_mesh_interpolation_operator_f64<'py>(
     let nodes = read_axisym_nodes("nodes", nodes)?;
     let element_indices = read_axisym_material_ids("element_indices", element_indices)?;
     let reference_points = read_axisym_nodes("reference_points", reference_points)?;
-    let operator = match element_type {
-        "quad4" => {
-            let elements = read_axisym_elements::<4>("elements", elements)?;
-            mesh::quad2d::quad_mesh_interpolation_operator::<
-                mesh::quad2d::Quad4ReferenceElement,
-                _,
-                4,
-            >(
-                mesh::QuadMeshView2d {
-                    nodes_rz: &nodes,
-                    elements: &elements,
-                },
-                &element_indices,
-                &reference_points,
-            )
-        }
-        "quad9" => {
-            let elements = read_axisym_elements::<9>("elements", elements)?;
-            mesh::quad2d::quad_mesh_interpolation_operator::<
-                mesh::quad2d::Quad9ReferenceElement,
-                _,
-                9,
-            >(
-                mesh::QuadMeshView2d {
-                    nodes_rz: &nodes,
-                    elements: &elements,
-                },
-                &element_indices,
-                &reference_points,
-            )
-        }
-        _ => Err(format!(
-            "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
-        )),
-    }
-    .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let (vals, rows, cols, nrow, ncol) = flatten_sparse_operator(operator);
-    Ok((
-        PyArray1::from_vec(py, vals).unbind(),
-        PyArray1::from_vec(py, rows).unbind(),
-        PyArray1::from_vec(py, cols).unbind(),
-        nrow,
-        ncol,
-    ))
+    let operator = quad_mesh_interpolation_operator_for_element_type(
+        &nodes,
+        elements,
+        &element_indices,
+        &reference_points,
+        element_type,
+    )?;
+    sparse_operator_to_py(py, operator)
 }
 
 /// Low-level binding for scalar interpolation operators from query element/reference data.
@@ -1570,50 +1712,14 @@ fn solenoid_stress_fem_quad_mesh_interpolation_operator_f32<'py>(
     let nodes = read_axisym_nodes("nodes", nodes)?;
     let element_indices = read_axisym_material_ids("element_indices", element_indices)?;
     let reference_points = read_axisym_nodes("reference_points", reference_points)?;
-    let operator = match element_type {
-        "quad4" => {
-            let elements = read_axisym_elements::<4>("elements", elements)?;
-            mesh::quad2d::quad_mesh_interpolation_operator::<
-                mesh::quad2d::Quad4ReferenceElement,
-                _,
-                4,
-            >(
-                mesh::QuadMeshView2d {
-                    nodes_rz: &nodes,
-                    elements: &elements,
-                },
-                &element_indices,
-                &reference_points,
-            )
-        }
-        "quad9" => {
-            let elements = read_axisym_elements::<9>("elements", elements)?;
-            mesh::quad2d::quad_mesh_interpolation_operator::<
-                mesh::quad2d::Quad9ReferenceElement,
-                _,
-                9,
-            >(
-                mesh::QuadMeshView2d {
-                    nodes_rz: &nodes,
-                    elements: &elements,
-                },
-                &element_indices,
-                &reference_points,
-            )
-        }
-        _ => Err(format!(
-            "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
-        )),
-    }
-    .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let (vals, rows, cols, nrow, ncol) = flatten_sparse_operator(operator);
-    Ok((
-        PyArray1::from_vec(py, vals).unbind(),
-        PyArray1::from_vec(py, rows).unbind(),
-        PyArray1::from_vec(py, cols).unbind(),
-        nrow,
-        ncol,
-    ))
+    let operator = quad_mesh_interpolation_operator_for_element_type(
+        &nodes,
+        elements,
+        &element_indices,
+        &reference_points,
+        element_type,
+    )?;
+    sparse_operator_to_py(py, operator)
 }
 
 /// Low-level binding for strain-recovery operators from query element/reference data.
@@ -1640,55 +1746,15 @@ fn solenoid_stress_fem_quad_mesh_strain_operator_f64<'py>(
     let formulation =
         physics::solenoid_stress::Structural2dFormulation::from_code(formulation, thickness)
             .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let operator =
-        match element_type {
-            "quad4" => {
-                let elements = read_axisym_elements::<4>("elements", elements)?;
-                mesh::quad2d::quad_mesh_strain_operator::<
-                    mesh::quad2d::Quad4ReferenceElement,
-                    _,
-                    4,
-                    8,
-                >(
-                    mesh::QuadMeshView2d {
-                        nodes_rz: &nodes,
-                        elements: &elements,
-                    },
-                    &element_indices,
-                    &reference_points,
-                    formulation,
-                )
-            }
-            "quad9" => {
-                let elements = read_axisym_elements::<9>("elements", elements)?;
-                mesh::quad2d::quad_mesh_strain_operator::<
-                    mesh::quad2d::Quad9ReferenceElement,
-                    _,
-                    9,
-                    18,
-                >(
-                    mesh::QuadMeshView2d {
-                        nodes_rz: &nodes,
-                        elements: &elements,
-                    },
-                    &element_indices,
-                    &reference_points,
-                    formulation,
-                )
-            }
-            _ => Err(format!(
-                "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
-            )),
-        }
-        .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let (vals, rows, cols, nrow, ncol) = flatten_sparse_operator(operator);
-    Ok((
-        PyArray1::from_vec(py, vals).unbind(),
-        PyArray1::from_vec(py, rows).unbind(),
-        PyArray1::from_vec(py, cols).unbind(),
-        nrow,
-        ncol,
-    ))
+    let operator = quad_mesh_strain_operator_for_element_type(
+        &nodes,
+        elements,
+        &element_indices,
+        &reference_points,
+        element_type,
+        formulation,
+    )?;
+    sparse_operator_to_py(py, operator)
 }
 
 /// Low-level binding for strain-recovery operators from query element/reference data.
@@ -1715,55 +1781,15 @@ fn solenoid_stress_fem_quad_mesh_strain_operator_f32<'py>(
     let formulation =
         physics::solenoid_stress::Structural2dFormulation::from_code(formulation, thickness)
             .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let operator =
-        match element_type {
-            "quad4" => {
-                let elements = read_axisym_elements::<4>("elements", elements)?;
-                mesh::quad2d::quad_mesh_strain_operator::<
-                    mesh::quad2d::Quad4ReferenceElement,
-                    _,
-                    4,
-                    8,
-                >(
-                    mesh::QuadMeshView2d {
-                        nodes_rz: &nodes,
-                        elements: &elements,
-                    },
-                    &element_indices,
-                    &reference_points,
-                    formulation,
-                )
-            }
-            "quad9" => {
-                let elements = read_axisym_elements::<9>("elements", elements)?;
-                mesh::quad2d::quad_mesh_strain_operator::<
-                    mesh::quad2d::Quad9ReferenceElement,
-                    _,
-                    9,
-                    18,
-                >(
-                    mesh::QuadMeshView2d {
-                        nodes_rz: &nodes,
-                        elements: &elements,
-                    },
-                    &element_indices,
-                    &reference_points,
-                    formulation,
-                )
-            }
-            _ => Err(format!(
-                "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
-            )),
-        }
-        .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let (vals, rows, cols, nrow, ncol) = flatten_sparse_operator(operator);
-    Ok((
-        PyArray1::from_vec(py, vals).unbind(),
-        PyArray1::from_vec(py, rows).unbind(),
-        PyArray1::from_vec(py, cols).unbind(),
-        nrow,
-        ncol,
-    ))
+    let operator = quad_mesh_strain_operator_for_element_type(
+        &nodes,
+        elements,
+        &element_indices,
+        &reference_points,
+        element_type,
+        formulation,
+    )?;
+    sparse_operator_to_py(py, operator)
 }
 
 /// Low-level binding for stress-recovery operators from query element/reference data.
@@ -1801,61 +1827,18 @@ fn solenoid_stress_fem_quad_mesh_stress_operator_f64<'py>(
     let formulation =
         physics::solenoid_stress::Structural2dFormulation::from_code(formulation, thickness)
             .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let operator =
-        match element_type {
-            "quad4" => {
-                let elements = read_axisym_elements::<4>("elements", elements)?;
-                mesh::quad2d::quad_mesh_stress_operator::<
-                    mesh::quad2d::Quad4ReferenceElement,
-                    _,
-                    4,
-                    8,
-                >(
-                    mesh::QuadMeshView2d {
-                        nodes_rz: &nodes,
-                        elements: &elements,
-                    },
-                    &element_indices,
-                    &reference_points,
-                    &material_ids,
-                    &material_table,
-                    material_orientation_angles,
-                    formulation,
-                )
-            }
-            "quad9" => {
-                let elements = read_axisym_elements::<9>("elements", elements)?;
-                mesh::quad2d::quad_mesh_stress_operator::<
-                    mesh::quad2d::Quad9ReferenceElement,
-                    _,
-                    9,
-                    18,
-                >(
-                    mesh::QuadMeshView2d {
-                        nodes_rz: &nodes,
-                        elements: &elements,
-                    },
-                    &element_indices,
-                    &reference_points,
-                    &material_ids,
-                    &material_table,
-                    material_orientation_angles,
-                    formulation,
-                )
-            }
-            _ => Err(format!(
-                "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
-            )),
-        }
-        .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let (vals, rows, cols, nrow, ncol) = flatten_sparse_operator(operator);
-    Ok((
-        PyArray1::from_vec(py, vals).unbind(),
-        PyArray1::from_vec(py, rows).unbind(),
-        PyArray1::from_vec(py, cols).unbind(),
-        nrow,
-        ncol,
-    ))
+    let operator = quad_mesh_stress_operator_for_element_type(
+        &nodes,
+        elements,
+        &element_indices,
+        &reference_points,
+        &material_ids,
+        &material_table,
+        material_orientation_angles,
+        element_type,
+        formulation,
+    )?;
+    sparse_operator_to_py(py, operator)
 }
 
 /// Low-level binding for stress-recovery operators from query element/reference data.
@@ -1893,61 +1876,18 @@ fn solenoid_stress_fem_quad_mesh_stress_operator_f32<'py>(
     let formulation =
         physics::solenoid_stress::Structural2dFormulation::from_code(formulation, thickness)
             .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let operator =
-        match element_type {
-            "quad4" => {
-                let elements = read_axisym_elements::<4>("elements", elements)?;
-                mesh::quad2d::quad_mesh_stress_operator::<
-                    mesh::quad2d::Quad4ReferenceElement,
-                    _,
-                    4,
-                    8,
-                >(
-                    mesh::QuadMeshView2d {
-                        nodes_rz: &nodes,
-                        elements: &elements,
-                    },
-                    &element_indices,
-                    &reference_points,
-                    &material_ids,
-                    &material_table,
-                    material_orientation_angles,
-                    formulation,
-                )
-            }
-            "quad9" => {
-                let elements = read_axisym_elements::<9>("elements", elements)?;
-                mesh::quad2d::quad_mesh_stress_operator::<
-                    mesh::quad2d::Quad9ReferenceElement,
-                    _,
-                    9,
-                    18,
-                >(
-                    mesh::QuadMeshView2d {
-                        nodes_rz: &nodes,
-                        elements: &elements,
-                    },
-                    &element_indices,
-                    &reference_points,
-                    &material_ids,
-                    &material_table,
-                    material_orientation_angles,
-                    formulation,
-                )
-            }
-            _ => Err(format!(
-                "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
-            )),
-        }
-        .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let (vals, rows, cols, nrow, ncol) = flatten_sparse_operator(operator);
-    Ok((
-        PyArray1::from_vec(py, vals).unbind(),
-        PyArray1::from_vec(py, rows).unbind(),
-        PyArray1::from_vec(py, cols).unbind(),
-        nrow,
-        ncol,
-    ))
+    let operator = quad_mesh_stress_operator_for_element_type(
+        &nodes,
+        elements,
+        &element_indices,
+        &reference_points,
+        &material_ids,
+        &material_table,
+        material_orientation_angles,
+        element_type,
+        formulation,
+    )?;
+    sparse_operator_to_py(py, operator)
 }
 
 #[pyfunction]

--- a/src/python.rs
+++ b/src/python.rs
@@ -1263,27 +1263,25 @@ fn solenoid_stress_fem_infer_quad9_mesh_f32<'py>(
     ))
 }
 
-/// Low-level binding for one-pass quad mesh queries.
-#[pyfunction]
-fn solenoid_stress_fem_quad_mesh_query_f64<'py>(
-    py: Python<'py>,
-    nodes: PyReadonlyArray2<'_, f64>,
+fn quad_mesh_query_for_element_type<F>(
+    nodes: &[[F; 2]],
     elements: PyReadonlyArray2<'_, u64>,
-    points: PyReadonlyArray2<'_, f64>,
+    points: &[[F; 2]],
     element_type: &str,
     max_iterations: usize,
-) -> PyResult<Py<PyDict>> {
-    let nodes = read_axisym_nodes("nodes", nodes)?;
-    let points = read_axisym_nodes("points", points)?;
-    let query = match element_type {
+) -> PyResult<mesh::quad2d::QuadMeshQueryResult<F>>
+where
+    F: physics::solenoid_stress::Real + NumpyElement,
+{
+    match element_type {
         "quad4" => {
             let elements = read_axisym_elements::<4>("elements", elements)?;
             mesh::quad2d::query_quad_mesh::<mesh::quad2d::Quad4ReferenceElement, _, 4>(
                 mesh::QuadMeshView2d {
-                    nodes_rz: &nodes,
+                    nodes_rz: nodes,
                     elements: &elements,
                 },
-                &points,
+                points,
                 max_iterations,
             )
         }
@@ -1291,10 +1289,10 @@ fn solenoid_stress_fem_quad_mesh_query_f64<'py>(
             let elements = read_axisym_elements::<9>("elements", elements)?;
             mesh::quad2d::query_quad_mesh::<mesh::quad2d::Quad9ReferenceElement, _, 9>(
                 mesh::QuadMeshView2d {
-                    nodes_rz: &nodes,
+                    nodes_rz: nodes,
                     elements: &elements,
                 },
-                &points,
+                points,
                 max_iterations,
             )
         }
@@ -1302,7 +1300,16 @@ fn solenoid_stress_fem_quad_mesh_query_f64<'py>(
             "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
         )),
     }
-    .map_err(|msg| PyInteropError::ValueError { msg })?;
+    .map_err(|msg| PyInteropError::ValueError { msg }.into())
+}
+
+fn quad_mesh_query_to_py<'py, F>(
+    py: Python<'py>,
+    query: mesh::quad2d::QuadMeshQueryResult<F>,
+) -> PyResult<Py<PyDict>>
+where
+    F: mesh::Scalar + NumpyElement,
+{
     let dict = PyDict::new(py);
     dict.set_item(
         "nearest_node_indices",
@@ -1388,6 +1395,23 @@ fn solenoid_stress_fem_quad_mesh_query_f64<'py>(
 
 /// Low-level binding for one-pass quad mesh queries.
 #[pyfunction]
+fn solenoid_stress_fem_quad_mesh_query_f64<'py>(
+    py: Python<'py>,
+    nodes: PyReadonlyArray2<'_, f64>,
+    elements: PyReadonlyArray2<'_, u64>,
+    points: PyReadonlyArray2<'_, f64>,
+    element_type: &str,
+    max_iterations: usize,
+) -> PyResult<Py<PyDict>> {
+    let nodes = read_axisym_nodes("nodes", nodes)?;
+    let points = read_axisym_nodes("points", points)?;
+    let query =
+        quad_mesh_query_for_element_type(&nodes, elements, &points, element_type, max_iterations)?;
+    quad_mesh_query_to_py(py, query)
+}
+
+/// Low-level binding for one-pass quad mesh queries.
+#[pyfunction]
 fn solenoid_stress_fem_quad_mesh_query_f32<'py>(
     py: Python<'py>,
     nodes: PyReadonlyArray2<'_, f32>,
@@ -1398,115 +1422,9 @@ fn solenoid_stress_fem_quad_mesh_query_f32<'py>(
 ) -> PyResult<Py<PyDict>> {
     let nodes = read_axisym_nodes("nodes", nodes)?;
     let points = read_axisym_nodes("points", points)?;
-    let query = match element_type {
-        "quad4" => {
-            let elements = read_axisym_elements::<4>("elements", elements)?;
-            mesh::quad2d::query_quad_mesh::<mesh::quad2d::Quad4ReferenceElement, _, 4>(
-                mesh::QuadMeshView2d {
-                    nodes_rz: &nodes,
-                    elements: &elements,
-                },
-                &points,
-                max_iterations,
-            )
-        }
-        "quad9" => {
-            let elements = read_axisym_elements::<9>("elements", elements)?;
-            mesh::quad2d::query_quad_mesh::<mesh::quad2d::Quad9ReferenceElement, _, 9>(
-                mesh::QuadMeshView2d {
-                    nodes_rz: &nodes,
-                    elements: &elements,
-                },
-                &points,
-                max_iterations,
-            )
-        }
-        _ => Err(format!(
-            "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
-        )),
-    }
-    .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let dict = PyDict::new(py);
-    dict.set_item(
-        "nearest_node_indices",
-        PyArray1::from_vec(
-            py,
-            query
-                .nearest_node_indices
-                .into_iter()
-                .map(|index| index as u64)
-                .collect(),
-        ),
-    )?;
-    dict.set_item(
-        "nearest_node_points",
-        PyArray1::from_vec(py, flatten_quad_points(query.nearest_node_points)),
-    )?;
-    dict.set_item(
-        "nearest_node_distances",
-        PyArray1::from_vec(py, query.nearest_node_distances),
-    )?;
-    dict.set_item(
-        "nearest_element_indices",
-        PyArray1::from_vec(
-            py,
-            query
-                .nearest_element_indices
-                .into_iter()
-                .map(|index| index as u64)
-                .collect(),
-        ),
-    )?;
-    dict.set_item(
-        "nearest_element_reference_points",
-        PyArray1::from_vec(
-            py,
-            flatten_quad_points(query.nearest_element_reference_points),
-        ),
-    )?;
-    dict.set_item(
-        "nearest_element_points",
-        PyArray1::from_vec(py, flatten_quad_points(query.nearest_element_points)),
-    )?;
-    dict.set_item(
-        "nearest_element_distances",
-        PyArray1::from_vec(py, query.nearest_element_distances),
-    )?;
-    dict.set_item(
-        "nearest_face_element_indices",
-        PyArray1::from_vec(
-            py,
-            query
-                .nearest_face_element_indices
-                .into_iter()
-                .map(|index| index as u64)
-                .collect(),
-        ),
-    )?;
-    dict.set_item(
-        "nearest_face_local_faces",
-        PyArray1::from_vec(
-            py,
-            query
-                .nearest_face_local_faces
-                .into_iter()
-                .map(u64::from)
-                .collect(),
-        ),
-    )?;
-    dict.set_item(
-        "nearest_face_reference_coordinates",
-        PyArray1::from_vec(py, query.nearest_face_reference_coordinates),
-    )?;
-    dict.set_item(
-        "nearest_face_points",
-        PyArray1::from_vec(py, flatten_quad_points(query.nearest_face_points)),
-    )?;
-    dict.set_item(
-        "nearest_face_distances",
-        PyArray1::from_vec(py, query.nearest_face_distances),
-    )?;
-    Ok(dict.unbind())
+    let query =
+        quad_mesh_query_for_element_type(&nodes, elements, &points, element_type, max_iterations)?;
+    quad_mesh_query_to_py(py, query)
 }
 
 fn quad_mesh_interpolation_operator_for_element_type<F>(

--- a/src/python.rs
+++ b/src/python.rs
@@ -255,18 +255,16 @@ fn flatten_sparse_operator<F: mesh::Scalar>(
     )
 }
 
-type SparseOperatorPyResult<'py, F> = PyResult<(
+fn sparse_operator_to_py<'py, F>(
+    py: Python<'py>,
+    operator: mesh::quad2d::QuadMeshSparseOperator<F>,
+) -> PyResult<(
     Py<PyArray1<F>>,
     Py<PyArray1<u64>>,
     Py<PyArray1<u64>>,
     u64,
     u64,
-)>;
-
-fn sparse_operator_to_py<'py, F>(
-    py: Python<'py>,
-    operator: mesh::quad2d::QuadMeshSparseOperator<F>,
-) -> SparseOperatorPyResult<'py, F>
+)>
 where
     F: mesh::Scalar + NumpyElement,
 {
@@ -1511,10 +1509,6 @@ fn solenoid_stress_fem_quad_mesh_query_f32<'py>(
     Ok(dict.unbind())
 }
 
-fn unsupported_quad_element_type(element_type: &str) -> String {
-    format!("unsupported element_type {element_type:?}; use 'quad4' or 'quad9'")
-}
-
 fn quad_mesh_interpolation_operator_for_element_type<F>(
     nodes: &[[F; 2]],
     elements: PyReadonlyArray2<'_, u64>,
@@ -1559,7 +1553,7 @@ where
             .map_err(|msg| PyInteropError::ValueError { msg }.into())
         }
         _ => Err(PyInteropError::ValueError {
-            msg: unsupported_quad_element_type(element_type),
+            msg: format!("unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"),
         }
         .into()),
     }
@@ -1604,7 +1598,7 @@ where
             .map_err(|msg| PyInteropError::ValueError { msg }.into())
         }
         _ => Err(PyInteropError::ValueError {
-            msg: unsupported_quad_element_type(element_type),
+            msg: format!("unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"),
         }
         .into()),
     }
@@ -1658,7 +1652,7 @@ where
             .map_err(|msg| PyInteropError::ValueError { msg }.into())
         }
         _ => Err(PyInteropError::ValueError {
-            msg: unsupported_quad_element_type(element_type),
+            msg: format!("unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"),
         }
         .into()),
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -1766,6 +1766,190 @@ fn solenoid_stress_fem_quad_mesh_strain_operator_f32<'py>(
     ))
 }
 
+/// Low-level binding for stress-recovery operators from query element/reference data.
+#[pyfunction]
+fn solenoid_stress_fem_quad_mesh_stress_operator_f64<'py>(
+    py: Python<'py>,
+    nodes: PyReadonlyArray2<'_, f64>,
+    elements: PyReadonlyArray2<'_, u64>,
+    element_indices: PyReadonlyArray1<'_, u64>,
+    reference_points: PyReadonlyArray2<'_, f64>,
+    material_ids: PyReadonlyArray1<'_, u64>,
+    material_table: PyReadonlyArray3<'_, f64>,
+    material_orientation_angles: PyReadonlyArray1<'_, f64>,
+    element_type: &str,
+    formulation: u8,
+    thickness: f64,
+) -> PyResult<(
+    Py<PyArray1<f64>>,
+    Py<PyArray1<u64>>,
+    Py<PyArray1<u64>>,
+    u64,
+    u64,
+)> {
+    let nodes = read_axisym_nodes("nodes", nodes)?;
+    let element_indices = read_axisym_material_ids("element_indices", element_indices)?;
+    let reference_points = read_axisym_nodes("reference_points", reference_points)?;
+    let material_ids = read_axisym_material_ids("material_ids", material_ids)?;
+    let material_table = read_axisym_material_table("material_table", material_table)?;
+    let material_orientation_angles = read_axisym_material_orientation_angles(
+        "material_orientation_angles",
+        material_orientation_angles,
+    )?;
+    let material_orientation_angles =
+        (!material_orientation_angles.is_empty()).then_some(material_orientation_angles.as_slice());
+    let formulation =
+        physics::solenoid_stress::Structural2dFormulation::from_code(formulation, thickness)
+            .map_err(|msg| PyInteropError::ValueError { msg })?;
+    let operator =
+        match element_type {
+            "quad4" => {
+                let elements = read_axisym_elements::<4>("elements", elements)?;
+                mesh::quad2d::quad_mesh_stress_operator::<
+                    mesh::quad2d::Quad4ReferenceElement,
+                    _,
+                    4,
+                    8,
+                >(
+                    mesh::QuadMeshView2d {
+                        nodes_rz: &nodes,
+                        elements: &elements,
+                    },
+                    &element_indices,
+                    &reference_points,
+                    &material_ids,
+                    &material_table,
+                    material_orientation_angles,
+                    formulation,
+                )
+            }
+            "quad9" => {
+                let elements = read_axisym_elements::<9>("elements", elements)?;
+                mesh::quad2d::quad_mesh_stress_operator::<
+                    mesh::quad2d::Quad9ReferenceElement,
+                    _,
+                    9,
+                    18,
+                >(
+                    mesh::QuadMeshView2d {
+                        nodes_rz: &nodes,
+                        elements: &elements,
+                    },
+                    &element_indices,
+                    &reference_points,
+                    &material_ids,
+                    &material_table,
+                    material_orientation_angles,
+                    formulation,
+                )
+            }
+            _ => Err(format!(
+                "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
+            )),
+        }
+        .map_err(|msg| PyInteropError::ValueError { msg })?;
+    let (vals, rows, cols, nrow, ncol) = flatten_sparse_operator(operator);
+    Ok((
+        PyArray1::from_vec(py, vals).unbind(),
+        PyArray1::from_vec(py, rows).unbind(),
+        PyArray1::from_vec(py, cols).unbind(),
+        nrow,
+        ncol,
+    ))
+}
+
+/// Low-level binding for stress-recovery operators from query element/reference data.
+#[pyfunction]
+fn solenoid_stress_fem_quad_mesh_stress_operator_f32<'py>(
+    py: Python<'py>,
+    nodes: PyReadonlyArray2<'_, f32>,
+    elements: PyReadonlyArray2<'_, u64>,
+    element_indices: PyReadonlyArray1<'_, u64>,
+    reference_points: PyReadonlyArray2<'_, f32>,
+    material_ids: PyReadonlyArray1<'_, u64>,
+    material_table: PyReadonlyArray3<'_, f32>,
+    material_orientation_angles: PyReadonlyArray1<'_, f32>,
+    element_type: &str,
+    formulation: u8,
+    thickness: f32,
+) -> PyResult<(
+    Py<PyArray1<f32>>,
+    Py<PyArray1<u64>>,
+    Py<PyArray1<u64>>,
+    u64,
+    u64,
+)> {
+    let nodes = read_axisym_nodes("nodes", nodes)?;
+    let element_indices = read_axisym_material_ids("element_indices", element_indices)?;
+    let reference_points = read_axisym_nodes("reference_points", reference_points)?;
+    let material_ids = read_axisym_material_ids("material_ids", material_ids)?;
+    let material_table = read_axisym_material_table("material_table", material_table)?;
+    let material_orientation_angles = read_axisym_material_orientation_angles(
+        "material_orientation_angles",
+        material_orientation_angles,
+    )?;
+    let material_orientation_angles =
+        (!material_orientation_angles.is_empty()).then_some(material_orientation_angles.as_slice());
+    let formulation =
+        physics::solenoid_stress::Structural2dFormulation::from_code(formulation, thickness)
+            .map_err(|msg| PyInteropError::ValueError { msg })?;
+    let operator =
+        match element_type {
+            "quad4" => {
+                let elements = read_axisym_elements::<4>("elements", elements)?;
+                mesh::quad2d::quad_mesh_stress_operator::<
+                    mesh::quad2d::Quad4ReferenceElement,
+                    _,
+                    4,
+                    8,
+                >(
+                    mesh::QuadMeshView2d {
+                        nodes_rz: &nodes,
+                        elements: &elements,
+                    },
+                    &element_indices,
+                    &reference_points,
+                    &material_ids,
+                    &material_table,
+                    material_orientation_angles,
+                    formulation,
+                )
+            }
+            "quad9" => {
+                let elements = read_axisym_elements::<9>("elements", elements)?;
+                mesh::quad2d::quad_mesh_stress_operator::<
+                    mesh::quad2d::Quad9ReferenceElement,
+                    _,
+                    9,
+                    18,
+                >(
+                    mesh::QuadMeshView2d {
+                        nodes_rz: &nodes,
+                        elements: &elements,
+                    },
+                    &element_indices,
+                    &reference_points,
+                    &material_ids,
+                    &material_table,
+                    material_orientation_angles,
+                    formulation,
+                )
+            }
+            _ => Err(format!(
+                "unsupported element_type {element_type:?}; use 'quad4' or 'quad9'"
+            )),
+        }
+        .map_err(|msg| PyInteropError::ValueError { msg })?;
+    let (vals, rows, cols, nrow, ncol) = flatten_sparse_operator(operator);
+    Ok((
+        PyArray1::from_vec(py, vals).unbind(),
+        PyArray1::from_vec(py, rows).unbind(),
+        PyArray1::from_vec(py, cols).unbind(),
+        nrow,
+        ncol,
+    ))
+}
+
 #[pyfunction]
 fn filament_helix_path(
     path: (
@@ -3690,6 +3874,14 @@ fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
     )?)?;
     m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_quad_mesh_strain_operator_f32,
+        m.clone()
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        solenoid_stress_fem_quad_mesh_stress_operator_f64,
+        m.clone()
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        solenoid_stress_fem_quad_mesh_stress_operator_f32,
         m.clone()
     )?)?;
     Ok(())

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -115,6 +115,101 @@ def test_quad_mesh_query_and_interpolation_helpers_for_quad4():
     assert np.isnan(outside.values[0])
 
 
+def test_quad_mesh_stress_operator_selects_material_by_query_element() -> None:
+    """Query-point stress recovery should use the material assigned to each containing element."""
+
+    nodes = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [2.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+            [2.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    elements = np.array([[0, 1, 4, 3], [1, 2, 5, 4]], dtype=np.uint64)
+    material_ids = np.array([0, 1], dtype=np.uint64)
+    material_table = np.array(
+        [
+            [
+                [2.0, 0.25, 0.0, 0.0],
+                [0.5, 3.0, 0.0, 0.0],
+                [0.0, 0.0, 5.0, 0.0],
+                [0.0, 0.0, 0.0, 7.0],
+            ],
+            [
+                [11.0, 1.5, 0.0, 0.0],
+                [2.0, 13.0, 0.0, 0.0],
+                [0.0, 0.0, 17.0, 0.0],
+                [0.0, 0.0, 0.0, 19.0],
+            ],
+        ],
+        dtype=np.float64,
+    )
+    query = fem.query_quad_mesh(nodes, elements, [[0.25, 0.5], [1.75, 0.5]])
+    displacement = np.column_stack([nodes[:, 0], 2.0 * nodes[:, 1]]).reshape(-1)
+
+    stress_operator = fem.quad_mesh_stress_operator(
+        query,
+        material_ids,
+        material_table,
+        formulation="plane_strain",
+        thickness=1.0,
+    )
+    stress = np.asarray(stress_operator @ displacement).reshape(-1, 4)
+
+    strain = np.asarray([1.0, 2.0, 0.0, 0.0])
+    expected = np.vstack([material_table[0] @ strain, material_table[1] @ strain])
+    np.testing.assert_allclose(stress, expected, atol=1.0e-12)
+
+
+def test_quad_mesh_stress_operator_applies_material_orientation() -> None:
+    """Material orientation should rotate local anisotropic stiffness before stress recovery."""
+
+    nodes = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 1.0],
+            [0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    elements = np.array([[0, 1, 2, 3]], dtype=np.uint64)
+    material_ids = np.array([0], dtype=np.uint64)
+    material_table = np.diag([10.0, 20.0, 30.0, 40.0]).reshape(1, 4, 4)
+    query = fem.query_quad_mesh(nodes, elements, [[0.5, 0.5]])
+    displacement = np.column_stack([nodes[:, 0], np.zeros(nodes.shape[0])]).reshape(-1)
+
+    unrotated_operator = fem.quad_mesh_stress_operator(
+        query,
+        material_ids,
+        material_table,
+        formulation="plane_strain",
+        thickness=1.0,
+    )
+    rotated_operator = fem.quad_mesh_stress_operator(
+        query,
+        material_ids,
+        material_table,
+        formulation="plane_strain",
+        thickness=1.0,
+        material_orientation_angles=np.pi / 2.0,
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(unrotated_operator @ displacement).reshape(-1, 4),
+        [[10.0, 0.0, 0.0, 0.0]],
+    )
+    np.testing.assert_allclose(
+        np.asarray(rotated_operator @ displacement).reshape(-1, 4),
+        [[20.0, 0.0, 0.0, 0.0]],
+        atol=1.0e-12,
+    )
+
+
 def test_quad_mesh_interpolation_outside_policy_errors():
     """Check interpolation policy errors for points outside the nearest-element tolerance."""
 
@@ -2332,12 +2427,14 @@ def test_plane_strain_circular_hole_matches_kirsch_stress_concentration(
         points,
         element_type=element_type,
     )
-    strain_operator = fem.quad_mesh_strain_operator(
+    stress_operator = fem.quad_mesh_stress_operator(
         query,
+        np.zeros(model.analysis_elements.shape[0], dtype=np.uint64),
+        np.asarray([material], dtype=dtype),
         formulation="plane_strain",
         thickness=1.0,
     )
-    stress = np.asarray(strain_operator @ displacement, dtype=dtype).reshape(-1, 4) @ material.T
+    stress = np.asarray(stress_operator @ displacement, dtype=dtype).reshape(-1, 4)
 
     # The Kirsch stress concentration is a boundary value at r = a, theta = pi/2.
     hoop = hoop_stress_from_cartesian(stress, points) / remote_stress


### PR DESCRIPTION
## 8.2.0 2026-05-01

* Rust
    * Add stress operator on query points as standalone method
    * Remove unused dep on `branches`
    * Reduce boilerplate in bindings
    * Consolidate calculation of stress and strain operators
        * Use synthetic mesh query data for quadrature points
    * Consolidate validation and matrix scattering
* Python
    * Plumb new bindings
    * Deduplicate stress queries using new operator
