### PR TITLE
Implement parallel assembly for 2D FEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 8.4.0 2026-06-05
+
+* Rust
+    * Add thread-parallel stiffness matrix assembly for 2D FEM solver
+* Python
+    * Plumb parallel option into 2D FEM interface
+
 ## 8.3.0 2026-05-04
 
 * Rust

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -1379,6 +1379,7 @@ def assemble_structural_2d(
     prescribed: Mapping[int, float] | None = None,
     quadrature: str | int = "gl3",
     element_type: str = "quad4",
+    par: bool = True,
 ) -> Structural2DFEMModel:
     """Assemble the reusable 2D structural FEM model.
 
@@ -1410,6 +1411,7 @@ def assemble_structural_2d(
             value. Displacement units are `[length]`.
         quadrature: Quadrature rule selector, either `gl3`, `gl4`, `3`, or `4`.
         element_type: Analysis element family, either `quad4` or `quad9`.
+        par: Whether to assemble the stiffness matrix using threaded element batches.
 
     Returns:
         Structural2DFEMModel: Reusable model storing the reduced stiffness matrix, sparse load
@@ -1462,7 +1464,11 @@ def assemble_structural_2d(
         material_table_arr,
         pressure_faces_arr,
         traction_faces_arr,
-        np.zeros((0, 5), dtype=dtype) if thermal_material_table_arr is None else thermal_material_table_arr,
+        (
+            thermal_material_table_arr
+            if thermal_material_table_arr is not None
+            else np.zeros((0, 5), dtype=dtype)
+        ),
         material_orientation_angles_arr,
         prescribed_dofs,
         prescribed_values,
@@ -1470,6 +1476,7 @@ def assemble_structural_2d(
         _formulation_code(normalized_formulation),
         thickness_value,
         quadrature_code,
+        par,
     )
 
     stiffness = _csc_matrix_from_binding(backend.stiffness_csc(), dtype)

--- a/docs/python/solenoid_stress.md
+++ b/docs/python/solenoid_stress.md
@@ -24,6 +24,7 @@ The FEM path supports:
 - `quad4`, inferred `quad9`, and explicit `quad9` elements,
 - `gl3` and `gl4` quadrature,
 - optional per-element in-plane material orientation angles,
+- optional threaded stiffness assembly with `par=True`,
 - reusable reduced-space operators for body force, pressure, traction, and nodal-temperature thermal strain,
 - reduced quadrature-point recovery operators for strain and stress,
 - model-owned Dirichlet constraints applied during assembly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub(crate) fn chunksize(nelem: usize) -> usize {
         .unwrap_or(NonZeroUsize::MIN)
         .get();
 
-    let ncores = ncores / 2; // Heuristic for physical cores
+    let ncores = (ncores / 2).max(1); // Heuristic for physical cores
 
     (nelem / ncores).max(1)
 }

--- a/src/physics/solenoid_stress/assembly.rs
+++ b/src/physics/solenoid_stress/assembly.rs
@@ -3,6 +3,9 @@
 //! The element system matrix is assembled in Galerkin form
 //! `K_e = integral(B^T D B 2*pi*r dA)`.
 
+use rayon::prelude::*;
+
+use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::axisym::{accumulate_stiffness, build_b_matrix};
 use crate::physics::solenoid_stress::convenience::rotate_material_in_plane;
@@ -34,6 +37,94 @@ pub(crate) fn assemble_stiffness_for_family<
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
+    validate_stiffness_inputs::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        mesh,
+        material_ids,
+        material_orientation_angles,
+        formulation,
+    )?;
+    assemble_stiffness_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        mesh,
+        material_ids,
+        material_table,
+        material_orientation_angles,
+        formulation,
+        quadrature,
+        0,
+        mesh.num_elements(),
+    )
+}
+
+/// Assemble full-space stiffness triplets with element ranges split across Rayon workers.
+///
+/// Each worker owns an independent triplet buffer, so the element kernel has no shared mutable
+/// state.  The per-range triplets are concatenated in element order before the existing
+/// constrained-system reduction and sparse compression stages consume them.
+pub(crate) fn assemble_stiffness_for_family_par<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+) -> Result<StiffnessTriplets<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    validate_stiffness_inputs::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        mesh,
+        material_ids,
+        material_orientation_angles,
+        formulation,
+    )?;
+    let nelem = mesh.num_elements();
+    let chunk = chunksize(nelem);
+    let mut ranges = Vec::with_capacity(nelem.div_ceil(chunk));
+    let mut start = 0;
+    while start < nelem {
+        let end = (start + chunk).min(nelem);
+        ranges.push((start, end));
+        start = end;
+    }
+
+    let chunks = ranges
+        .into_par_iter()
+        .map(|(start, end)| {
+            assemble_stiffness_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                material_ids,
+                material_table,
+                material_orientation_angles,
+                formulation,
+                quadrature,
+                start,
+                end,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(concat_stiffness_triplets(
+        chunks,
+        nelem * DOF_PER_ELEMENT * DOF_PER_ELEMENT,
+    ))
+}
+
+/// Validate shape and material inputs shared by serial and threaded stiffness assembly.
+fn validate_stiffness_inputs<
+    F: Real,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+) -> Result<(), String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
@@ -42,12 +133,35 @@ where
         mesh.num_elements(),
         material_ids,
         material_orientation_angles,
-    )?;
-    let mut rows = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
-    let mut cols = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
-    let mut vals = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
+    )
+}
 
-    for element_index in 0..mesh.num_elements() {
+#[allow(clippy::too_many_arguments)]
+/// Assemble the contribution from a contiguous element range into an independent triplet buffer.
+fn assemble_stiffness_range_for_family<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+    element_start: usize,
+    element_end: usize,
+) -> Result<StiffnessTriplets<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    let nelem = element_end - element_start;
+    let mut rows = Vec::with_capacity(nelem * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
+    let mut cols = Vec::with_capacity(nelem * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
+    let mut vals = Vec::with_capacity(nelem * DOF_PER_ELEMENT * DOF_PER_ELEMENT);
+
+    for element_index in element_start..element_end {
         let coords = mesh.element_coords(element_index)?;
         let nodes = mesh.element_nodes(element_index)?;
         let material_id = material_ids[element_index];
@@ -88,9 +202,27 @@ where
     Ok(StiffnessTriplets { rows, cols, vals })
 }
 
+/// Concatenate independently assembled triplet chunks without changing element order.
+fn concat_stiffness_triplets<F: Real>(
+    chunks: Vec<StiffnessTriplets<F>>,
+    capacity: usize,
+) -> StiffnessTriplets<F> {
+    let mut rows = Vec::with_capacity(capacity);
+    let mut cols = Vec::with_capacity(capacity);
+    let mut vals = Vec::with_capacity(capacity);
+
+    for chunk in chunks {
+        rows.extend(chunk.rows);
+        cols.extend(chunk.cols);
+        vals.extend(chunk.vals);
+    }
+
+    StiffnessTriplets { rows, cols, vals }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::assemble_stiffness_for_family;
+    use super::{assemble_stiffness_for_family, assemble_stiffness_for_family_par};
     use crate::mesh::QuadratureRule;
     use crate::physics::solenoid_stress::convenience::isotropic_axisymmetric_material;
     use crate::physics::solenoid_stress::family::Quad4Family;
@@ -123,5 +255,36 @@ mod tests {
                 assert!((dense[row][col] - dense[col][row]).abs() / scale < 1.0e-12);
             }
         }
+    }
+
+    #[test]
+    /// Check that threaded assembly matches serial assembly exactly for the same element stream.
+    fn parallel_stiffness_matches_serial_stiffness() {
+        let mesh = single_element_quad4_mesh();
+        let material_ids = [0usize];
+        let material_table = [isotropic_axisymmetric_material(200.0e9, 0.27)];
+        let serial = assemble_stiffness_for_family::<f64, Quad4Family, 4, { dof_per_element(4) }>(
+            mesh,
+            &material_ids,
+            &material_table,
+            None,
+            crate::physics::solenoid_stress::types::Structural2dFormulation::Axisymmetric,
+            QuadratureRule::GaussLegendre3,
+        )
+        .expect("serial assembly should succeed");
+        let parallel =
+            assemble_stiffness_for_family_par::<f64, Quad4Family, 4, { dof_per_element(4) }>(
+                mesh,
+                &material_ids,
+                &material_table,
+                None,
+                crate::physics::solenoid_stress::types::Structural2dFormulation::Axisymmetric,
+                QuadratureRule::GaussLegendre3,
+            )
+            .expect("parallel assembly should succeed");
+
+        assert_eq!(serial.rows, parallel.rows);
+        assert_eq!(serial.cols, parallel.cols);
+        assert_eq!(serial.vals, parallel.vals);
     }
 }

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -7,7 +7,9 @@ use faer::sparse::{SparseColMat, SparseRowMat, Triplet};
 
 use crate::mesh::elements::quad2d::{quad4, quad9};
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
-use crate::physics::solenoid_stress::assembly::assemble_stiffness_for_family;
+use crate::physics::solenoid_stress::assembly::{
+    assemble_stiffness_for_family, assemble_stiffness_for_family_par,
+};
 use crate::physics::solenoid_stress::convenience::{
     QuadratureFieldSamples, Structural2dElementMeasures, Structural2dElementQuadrature,
 };
@@ -490,6 +492,7 @@ pub fn assemble_structural_2d<F: Real>(
     prescribed: &[(usize, F)],
     formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
+    par: bool,
 ) -> Result<Structural2dModel<F>, String> {
     match elements {
         Structural2dElements::Quad4(elements) => build_model_for_family::<
@@ -509,6 +512,7 @@ pub fn assemble_structural_2d<F: Real>(
             prescribed,
             formulation,
             quadrature,
+            par,
         ),
         Structural2dElements::Quad9(elements) => build_model_for_family::<
             F,
@@ -527,6 +531,7 @@ pub fn assemble_structural_2d<F: Real>(
             prescribed,
             formulation,
             quadrature,
+            par,
         ),
     }
 }
@@ -564,6 +569,7 @@ fn build_model_for_family<
     prescribed: &[(usize, F)],
     formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
+    par: bool,
 ) -> Result<Structural2dModel<F>, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
@@ -581,7 +587,16 @@ where
     // Assemble stiffness in the full displacement space first, then apply Dirichlet reduction.
     // This keeps the element kernels simple and pushes all constraint handling into the common
     // reduction helpers below.
-    let stiffness_full =
+    let stiffness_full = if par {
+        assemble_stiffness_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            material_ids,
+            material_table,
+            material_orientation_angles,
+            formulation,
+            quadrature,
+        )?
+    } else {
         assemble_stiffness_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             material_ids,
@@ -589,7 +604,8 @@ where
             material_orientation_angles,
             formulation,
             quadrature,
-        )?;
+        )?
+    };
     let mut constant_rhs = vec![F::zero(); ndof_reduced];
     let stiffness_reduced = reduce_square_triplets(
         &stiffness_full.rows,

--- a/src/python.rs
+++ b/src/python.rs
@@ -830,6 +830,7 @@ fn assemble_structural_2d_model_low_level<F: physics::solenoid_stress::Real + Nu
     formulation: u8,
     thickness: F,
     quadrature: u8,
+    par: bool,
 ) -> PyResult<physics::solenoid_stress::Structural2dModel<F>> {
     let quadrature = parse_solenoid_fem_quadrature(quadrature)?;
     let element_type = physics::solenoid_stress::Structural2dElementType::from_code(element_type)
@@ -868,6 +869,7 @@ fn assemble_structural_2d_model_low_level<F: physics::solenoid_stress::Real + Nu
                 &prescribed,
                 formulation,
                 quadrature,
+                par,
             )
             .map_err(|msg| PyInteropError::ValueError { msg }.into())
         }
@@ -885,6 +887,7 @@ fn assemble_structural_2d_model_low_level<F: physics::solenoid_stress::Real + Nu
                 &prescribed,
                 formulation,
                 quadrature,
+                par,
             )
             .map_err(|msg| PyInteropError::ValueError { msg }.into())
         }
@@ -908,6 +911,7 @@ fn solenoid_stress_fem_assemble_model_2d_f64(
     formulation: u8,
     thickness: f64,
     quadrature: u8,
+    par: bool,
 ) -> PyResult<SolenoidStress2dModelF64> {
     Ok(SolenoidStress2dModelF64 {
         inner: assemble_structural_2d_model_low_level::<f64>(
@@ -925,6 +929,7 @@ fn solenoid_stress_fem_assemble_model_2d_f64(
             formulation,
             thickness,
             quadrature,
+            par,
         )?,
     })
 }
@@ -946,6 +951,7 @@ fn solenoid_stress_fem_assemble_model_2d_f32(
     formulation: u8,
     thickness: f32,
     quadrature: u8,
+    par: bool,
 ) -> PyResult<SolenoidStress2dModelF32> {
     Ok(SolenoidStress2dModelF32 {
         inner: assemble_structural_2d_model_low_level::<f32>(
@@ -963,6 +969,7 @@ fn solenoid_stress_fem_assemble_model_2d_f32(
             formulation,
             thickness,
             quadrature,
+            par,
         )?,
     })
 }

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -908,6 +908,38 @@ def test_model_dtype_resolution_includes_material_tables() -> None:
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
+@pytest.mark.parametrize("element_type", ELEMENT_TYPES)
+def test_parallel_structural_assembly_matches_serial(dtype: DType, element_type: str) -> None:
+    nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=3, nz=2, dtype=dtype)
+    material = np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)])
+    material_ids = np.zeros(elements.shape[0], dtype=np.uint64)
+    serial = fem.assemble_structural_2d(
+        nodes=nodes,
+        elements=elements,
+        material_ids=material_ids,
+        material_table=material,
+        element_type=element_type,
+        par=False,
+    )
+    parallel = fem.assemble_structural_2d(
+        nodes=nodes,
+        elements=elements,
+        material_ids=material_ids,
+        material_table=material,
+        element_type=element_type,
+        par=True,
+    )
+    rtol, atol = tolerance(dtype)
+
+    assert np.allclose(
+        parallel.stiffness.toarray(),
+        serial.stiffness.toarray(),
+        rtol=rtol,
+        atol=atol,
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
 @pytest.mark.parametrize("quadrature", QUADRATURES)
 def test_axisymmetric_model_reuses_factorization_across_load_cases(dtype: DType, quadrature: str) -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=4, nz=2, dtype=dtype)


### PR DESCRIPTION
## 8.4.0 2026-06-05

* Rust
    * Add thread-parallel stiffness matrix assembly for 2D FEM solver
* Python
    * Plumb parallel option into 2D FEM interface