### PR TITLE
Add iterative solve option for 2D FEM

### DIFF
--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
       - name: Publish
         if: github.ref == 'refs/heads/release'
         env:

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -24,7 +24,7 @@ jobs:
       run: cargo fmt --check --verbose
     - name: Lint
       run: cargo clippy
-    - name: Build
-      run: cargo build --verbose
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2
     - name: Run tests
       run: cargo test --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,14 @@
 # Changelog
 
-## 8.5.0 2026-06-05
+## 9.0.0 2026-06-05
 
 * Rust
+    * !Add thread-parallel stiffness matrix assembly for 2D FEM solver
+    * Add direct/iterative solve selection for 2D FEM using BiCGSTAB with optional equilibration
     * Add optional iterative solve, equilibration, and preconditioning for 2D FEM solver
     * Run cargo-semver-checks during testing
 * Python
     * Add bindings plumbing for iterative solver
-
-## 8.4.0 2026-06-05
-
-* Rust
-    * Add thread-parallel stiffness matrix assembly for 2D FEM solver
-    * Add direct/iterative solve selection for 2D FEM using BiCGSTAB with optional equilibration
-* Python
     * Plumb parallel option into 2D FEM interface
     * Add 2D FEM solve diagnostics and BiCGSTAB options
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 # Changelog
 
+## 8.5.0 2026-06-05
+
+* Rust
+    * Add optional iterative solve, equilibration, and preconditioning for 2D FEM solver
+    * Run cargo-semver-checks during testing
+* Python
+    * Add bindings plumbing for iterative solver
+
 ## 8.4.0 2026-06-05
 
 * Rust
     * Add thread-parallel stiffness matrix assembly for 2D FEM solver
+    * Add direct/iterative solve selection for 2D FEM using BiCGSTAB with optional equilibration
 * Python
     * Plumb parallel option into 2D FEM interface
+    * Add 2D FEM solve diagnostics and BiCGSTAB options
 
 ## 8.3.0 2026-05-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfsem"
-version = "8.5.0"
+version = "9.0.0"
 dependencies = [
  "criterion",
  "deimos_numerics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,10 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfsem"
-version = "8.3.0"
+version = "8.5.0"
 dependencies = [
  "criterion",
+ "deimos_numerics",
  "faer",
  "faer-traits",
  "itertools 0.14.0",
@@ -296,9 +297,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -315,6 +316,20 @@ name = "defer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
+name = "deimos_numerics"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c439fc1af4cc901c8cd7154818ed7df69f20e0e57a6b80a58a2675b19f85df"
+dependencies = [
+ "crunchy",
+ "faer",
+ "faer-traits",
+ "levenberg-marquardt",
+ "nalgebra",
+ "num-traits",
+]
 
 [[package]]
 name = "digest"
@@ -631,108 +646,162 @@ name = "glam"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "glam"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "glam"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "glam"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "glam"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "glam"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "glam"
 version = "0.30.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12d847aeb25f41be4c0ec9587d624e9cd631bc007a8fd7ce3f5851e064c6460"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "glam"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "glam"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "half"
@@ -808,6 +877,18 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "levenberg-marquardt"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7a65739a815308eef33a6d8c78e435a7317305d5b0af0c8c465a2d7ac6fc6"
+dependencies = [
+ "cfg-if",
+ "nalgebra",
+ "num-traits",
+ "rustc_version",
+]
 
 [[package]]
 name = "libc"
@@ -1508,6 +1589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1632,12 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfsem"
-version = "8.5.0"
+version = "9.0.0"
 edition = "2024"
 authors = ["Commonwealth Fusion Systems <jlogan@cfs.energy>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfsem"
-version = "8.3.0"
+version = "8.5.0"
 edition = "2024"
 authors = ["Commonwealth Fusion Systems <jlogan@cfs.energy>"]
 license = "MIT"
@@ -24,6 +24,7 @@ libm = "^0.2"
 num-traits = { version = "0.2.19", features = ["libm"] }
 faer = "0.24.0"
 faer-traits = "0.24.0"
+deimos_numerics = "0.16.2"
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/cfsem/solenoid_stress/__init__.py
+++ b/cfsem/solenoid_stress/__init__.py
@@ -5,7 +5,7 @@ This subpackage includes three complementary toolsets:
 - a 1D finite-difference radial stress solver for deck-of-cards winding-pack models,
 - a 2D quadrilateral FEM implementation centered on reusable sparse load and
   recovery operators, with convenience methods for `build_rhs(...)`, `solve(...)`, and
-  quadrature-field recovery,
+  quadrature-field recovery, including direct and iterative linear solve options,
 - analytic reference formulas used for validation and convergence studies.
 """
 
@@ -29,6 +29,8 @@ from .fem2d import (
     QuadMeshQuery,
     QuadratureFieldSamples,
     Structural2DFEMModel,
+    Structural2DSolveDiagnostics,
+    Structural2DSolveResult,
     assemble_structural_2d,
     cfsem_radial_material,
     interpolate_quad_mesh_values,
@@ -56,6 +58,8 @@ __all__ = [
     "SolenoidStress1D",
     "SolenoidStress1DOperators",
     "Structural2DFEMModel",
+    "Structural2DSolveDiagnostics",
+    "Structural2DSolveResult",
     "assemble_structural_2d",
     "cfsem_radial_material",
     "interpolate_quad_mesh_values",

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -591,8 +591,10 @@ class Structural2DFEMModel:
                 `[generalized force] = [energy / distance]`.
             method: Linear solve method, either `"direct"` for cached sparse LU or `"bicgstab"`
                 for an iterative solve.
-            tolerance: Optional absolute BiCGSTAB residual tolerance in reduced-RHS units. If
-                omitted, Rust chooses an RHS-scaled default.
+            tolerance: Optional absolute BiCGSTAB residual tolerance for the solved system. If
+                omitted, Rust chooses an RHS-scaled default. When Ruiz equilibration is enabled,
+                this same value is applied to the equilibrated system rather than rescaled to
+                original reduced-RHS units.
             max_iterations: Optional maximum number of BiCGSTAB iterations.
             preconditioner: BiCGSTAB preconditioner, either `"diagonal"` or `"none"`.
             equilibration: BiCGSTAB equilibration mode, either `"ruiz"` or `"none"`.

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -616,8 +616,9 @@ class Structural2DFEMModel:
         ), f"rhs must have length {self.ndof_reduced}; got {rhs_arr.shape}"
         norm_floor = _positive_float_or_none("equilibration_norm_floor", equilibration_norm_floor)
         norm_ceil = _positive_float_or_none("equilibration_norm_ceil", equilibration_norm_ceil)
-        if norm_floor is not None and norm_ceil is not None and norm_ceil <= norm_floor:
-            raise ValueError("equilibration_norm_ceil must be greater than equilibration_norm_floor")
+        assert (
+            norm_floor is None or norm_ceil is None or norm_ceil > norm_floor
+        ), "equilibration_norm_ceil must be greater than equilibration_norm_floor"
         (
             displacement_raw,
             method_code,
@@ -1499,67 +1500,48 @@ def _dispatch_pair(dtype: np.dtype[Any], f32: Any, f64: Any) -> Any:
 
 
 def _solve_method_code(method: str) -> int:
-    if method == "direct":
-        return 0
-    if method == "bicgstab":
-        return 1
-    raise ValueError('method must be "direct" or "bicgstab"')
+    code_by_method = {"direct": 0, "bicgstab": 1}
+    assert method in code_by_method, 'method must be "direct" or "bicgstab"'
+    return code_by_method[method]
 
 
 def _solve_method_name(code: int) -> Literal["direct", "bicgstab"]:
-    if code == 0:
-        return "direct"
-    if code == 1:
-        return "bicgstab"
-    raise ValueError(f"unexpected solve method code {code}")
+    name_by_code: tuple[Literal["direct"], Literal["bicgstab"]] = ("direct", "bicgstab")
+    assert 0 <= code < len(name_by_code), f"unexpected solve method code {code}"
+    return name_by_code[code]
 
 
 def _bicgstab_preconditioner_code(preconditioner: str) -> int:
-    if preconditioner == "none":
-        return 0
-    if preconditioner == "diagonal":
-        return 1
-    raise ValueError('preconditioner must be "none" or "diagonal"')
+    code_by_preconditioner = {"none": 0, "diagonal": 1}
+    assert preconditioner in code_by_preconditioner, 'preconditioner must be "none" or "diagonal"'
+    return code_by_preconditioner[preconditioner]
 
 
 def _bicgstab_equilibration_code(equilibration: str) -> int:
-    if equilibration == "none":
-        return 0
-    if equilibration == "ruiz":
-        return 1
-    raise ValueError('equilibration must be "none" or "ruiz"')
+    code_by_equilibration = {"none": 0, "ruiz": 1}
+    assert equilibration in code_by_equilibration, 'equilibration must be "none" or "ruiz"'
+    return code_by_equilibration[equilibration]
 
 
 def _bicgstab_initial_guess_code(initial_guess: str) -> int:
-    if initial_guess == "zero":
-        return 0
-    if initial_guess == "previous":
-        return 1
-    raise ValueError('initial_guess must be "zero" or "previous"')
+    code_by_initial_guess = {"zero": 0, "previous": 1}
+    assert initial_guess in code_by_initial_guess, 'initial_guess must be "zero" or "previous"'
+    return code_by_initial_guess[initial_guess]
 
 
 def _positive_float_or_none(name: str, value: float | None) -> float | None:
-    if value is None:
-        return None
-    if not np.isfinite(value) or value <= 0.0:
-        raise ValueError(f"{name} must be finite and positive")
-    return float(value)
+    assert value is None or (np.isfinite(value) and value > 0.0), f"{name} must be finite and positive"
+    return None if value is None else float(value)
 
 
 def _nonnegative_float_or_none(name: str, value: float | None) -> float | None:
-    if value is None:
-        return None
-    if not np.isfinite(value) or value < 0.0:
-        raise ValueError(f"{name} must be finite and nonnegative")
-    return float(value)
+    assert value is None or (np.isfinite(value) and value >= 0.0), f"{name} must be finite and nonnegative"
+    return None if value is None else float(value)
 
 
 def _positive_int_or_none(name: str, value: int | None) -> int | None:
-    if value is None:
-        return None
-    if value < 1:
-        raise ValueError(f"{name} must be at least 1")
-    return int(value)
+    assert value is None or value >= 1, f"{name} must be at least 1"
+    return None if value is None else int(value)
 
 
 def assemble_structural_2d(

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, overload, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -177,6 +177,38 @@ class ElementQuadrature:
     weights_area: npt.NDArray[np.floating[Any]]
     weights_volume: npt.NDArray[np.floating[Any]]
     nq_per_element: int
+
+
+@dataclass(frozen=True, slots=True)
+class Structural2DSolveDiagnostics:
+    """Diagnostics from one 2D FEM linear solve.
+
+    Args:
+        method: Solver method used for the reduced structural system.
+        converged: Whether the selected solver converged.
+        iterations: Number of BiCGSTAB iterations, or zero for direct solves.
+        residual_norm: Final residual norm in reduced-RHS units, or zero for direct solves.
+        equilibrated: Whether row/column equilibration was applied before the solve.
+    """
+
+    method: Literal["direct", "bicgstab"]
+    converged: bool
+    iterations: int
+    residual_norm: float
+    equilibrated: bool
+
+
+@dataclass(frozen=True, slots=True)
+class Structural2DSolveResult:
+    """Full displacement solution plus linear-solver diagnostics.
+
+    Args:
+        displacement: Full displacement vector with shape `(ndof_full,)`.
+        diagnostics: Solver diagnostics for the reduced structural solve.
+    """
+
+    displacement: npt.NDArray[np.floating[Any]]
+    diagnostics: Structural2DSolveDiagnostics
 
 
 @dataclass(frozen=True, slots=True)
@@ -500,23 +532,125 @@ class Structural2DFEMModel:
         )
         return np.asarray(rhs, dtype=self.dtype)
 
-    def solve(self, rhs: ArrayLike) -> npt.NDArray[np.floating[Any]]:
+    @overload
+    def solve(
+        self,
+        rhs: ArrayLike,
+        *,
+        method: Literal["direct", "bicgstab"] = "direct",
+        tolerance: float | None = None,
+        max_iterations: int | None = None,
+        preconditioner: Literal["none", "diagonal"] = "diagonal",
+        equilibration: Literal["none", "ruiz"] = "ruiz",
+        equilibration_max_iterations: int | None = None,
+        equilibration_tolerance: float | None = None,
+        equilibration_norm_floor: float | None = None,
+        equilibration_norm_ceil: float | None = None,
+        initial_guess: Literal["zero", "previous"] = "zero",
+        return_diagnostics: Literal[False] = False,
+    ) -> npt.NDArray[np.floating[Any]]: ...
+
+    @overload
+    def solve(
+        self,
+        rhs: ArrayLike,
+        *,
+        method: Literal["direct", "bicgstab"] = "direct",
+        tolerance: float | None = None,
+        max_iterations: int | None = None,
+        preconditioner: Literal["none", "diagonal"] = "diagonal",
+        equilibration: Literal["none", "ruiz"] = "ruiz",
+        equilibration_max_iterations: int | None = None,
+        equilibration_tolerance: float | None = None,
+        equilibration_norm_floor: float | None = None,
+        equilibration_norm_ceil: float | None = None,
+        initial_guess: Literal["zero", "previous"] = "zero",
+        return_diagnostics: Literal[True],
+    ) -> Structural2DSolveResult: ...
+
+    def solve(
+        self,
+        rhs: ArrayLike,
+        *,
+        method: Literal["direct", "bicgstab"] = "direct",
+        tolerance: float | None = None,
+        max_iterations: int | None = None,
+        preconditioner: Literal["none", "diagonal"] = "diagonal",
+        equilibration: Literal["none", "ruiz"] = "ruiz",
+        equilibration_max_iterations: int | None = None,
+        equilibration_tolerance: float | None = None,
+        equilibration_norm_floor: float | None = None,
+        equilibration_norm_ceil: float | None = None,
+        initial_guess: Literal["zero", "previous"] = "zero",
+        return_diagnostics: bool = False,
+    ) -> npt.NDArray[np.floating[Any]] | Structural2DSolveResult:
         """Solve the reduced system and recover the full displacement field.
 
         Args:
             rhs: Reduced right-hand side with shape `(ndof_reduced,)` and units
                 `[generalized force] = [energy / distance]`.
+            method: Linear solve method, either `"direct"` for cached sparse LU or `"bicgstab"`
+                for an iterative solve.
+            tolerance: Optional absolute BiCGSTAB residual tolerance in reduced-RHS units. If
+                omitted, Rust chooses an RHS-scaled default.
+            max_iterations: Optional maximum number of BiCGSTAB iterations.
+            preconditioner: BiCGSTAB preconditioner, either `"diagonal"` or `"none"`.
+            equilibration: BiCGSTAB equilibration mode, either `"ruiz"` or `"none"`.
+            equilibration_max_iterations: Optional maximum number of equilibration iterations.
+            equilibration_tolerance: Optional dimensionless equilibration tolerance.
+            equilibration_norm_floor: Optional lower clamp for measured equilibration norms.
+            equilibration_norm_ceil: Optional upper clamp for measured equilibration norms.
+            initial_guess: BiCGSTAB initial guess, either `"zero"` or `"previous"`.
+            return_diagnostics: If true, return `Structural2DSolveResult` with displacement and
+                diagnostics. If false, return the displacement array directly.
 
         Returns:
-            NDArray: Full displacement vector with shape `(ndof_full,)` and component ordering
-            `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
+            NDArray | Structural2DSolveResult: Full displacement vector with shape
+            `(ndof_full,)` and component ordering `[u_r0, u_z0, u_r1, u_z1, ...]`, or the same
+            displacement packaged with solver diagnostics. Units are `[length]`.
         """
 
-        rhs_arr = np.asarray(rhs, dtype=self.dtype).reshape(-1)
+        rhs_arr = np.ascontiguousarray(np.asarray(rhs, dtype=self.dtype).reshape(-1))
         assert (
             rhs_arr.shape[0] == self.ndof_reduced
         ), f"rhs must have length {self.ndof_reduced}; got {rhs_arr.shape}"
-        return np.asarray(self._backend.solve(rhs_arr), dtype=self.dtype)
+        norm_floor = _positive_float_or_none("equilibration_norm_floor", equilibration_norm_floor)
+        norm_ceil = _positive_float_or_none("equilibration_norm_ceil", equilibration_norm_ceil)
+        if norm_floor is not None and norm_ceil is not None and norm_ceil <= norm_floor:
+            raise ValueError("equilibration_norm_ceil must be greater than equilibration_norm_floor")
+        (
+            displacement_raw,
+            method_code,
+            converged,
+            iterations,
+            residual_norm,
+            equilibrated,
+        ) = self._backend.solve(
+            rhs_arr,
+            _solve_method_code(method),
+            _positive_float_or_none("tolerance", tolerance),
+            _positive_int_or_none("max_iterations", max_iterations),
+            _bicgstab_preconditioner_code(preconditioner),
+            _bicgstab_equilibration_code(equilibration),
+            _positive_int_or_none("equilibration_max_iterations", equilibration_max_iterations),
+            _nonnegative_float_or_none("equilibration_tolerance", equilibration_tolerance),
+            norm_floor,
+            norm_ceil,
+            _bicgstab_initial_guess_code(initial_guess),
+        )
+        displacement = np.asarray(displacement_raw, dtype=self.dtype)
+        if not return_diagnostics:
+            return displacement
+        return Structural2DSolveResult(
+            displacement=displacement,
+            diagnostics=Structural2DSolveDiagnostics(
+                method=_solve_method_name(int(method_code)),
+                converged=bool(converged),
+                iterations=int(iterations),
+                residual_norm=float(residual_norm),
+                equilibrated=bool(equilibrated),
+            ),
+        )
 
     def recover_full(self, reduced_solution: ArrayLike) -> npt.NDArray[np.floating[Any]]:
         """Reinsert prescribed Dirichlet values into a reduced displacement vector.
@@ -1364,6 +1498,70 @@ def _dispatch_pair(dtype: np.dtype[Any], f32: Any, f64: Any) -> Any:
     return f64
 
 
+def _solve_method_code(method: str) -> int:
+    if method == "direct":
+        return 0
+    if method == "bicgstab":
+        return 1
+    raise ValueError('method must be "direct" or "bicgstab"')
+
+
+def _solve_method_name(code: int) -> Literal["direct", "bicgstab"]:
+    if code == 0:
+        return "direct"
+    if code == 1:
+        return "bicgstab"
+    raise ValueError(f"unexpected solve method code {code}")
+
+
+def _bicgstab_preconditioner_code(preconditioner: str) -> int:
+    if preconditioner == "none":
+        return 0
+    if preconditioner == "diagonal":
+        return 1
+    raise ValueError('preconditioner must be "none" or "diagonal"')
+
+
+def _bicgstab_equilibration_code(equilibration: str) -> int:
+    if equilibration == "none":
+        return 0
+    if equilibration == "ruiz":
+        return 1
+    raise ValueError('equilibration must be "none" or "ruiz"')
+
+
+def _bicgstab_initial_guess_code(initial_guess: str) -> int:
+    if initial_guess == "zero":
+        return 0
+    if initial_guess == "previous":
+        return 1
+    raise ValueError('initial_guess must be "zero" or "previous"')
+
+
+def _positive_float_or_none(name: str, value: float | None) -> float | None:
+    if value is None:
+        return None
+    if not np.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
+    return float(value)
+
+
+def _nonnegative_float_or_none(name: str, value: float | None) -> float | None:
+    if value is None:
+        return None
+    if not np.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return float(value)
+
+
+def _positive_int_or_none(name: str, value: int | None) -> int | None:
+    if value is None:
+        return None
+    if value < 1:
+        raise ValueError(f"{name} must be at least 1")
+    return int(value)
+
+
 def assemble_structural_2d(
     nodes: ArrayLike,
     elements: ArrayLike,
@@ -1748,6 +1946,8 @@ __all__ = [
     "QuadMeshQuery",
     "QuadratureFieldSamples",
     "assemble_structural_2d",
+    "Structural2DSolveDiagnostics",
+    "Structural2DSolveResult",
     "cfsem_radial_material",
     "interpolate_quad_mesh_values",
     "infer_quad9_mesh",

--- a/docs/python/solenoid_stress.md
+++ b/docs/python/solenoid_stress.md
@@ -43,7 +43,9 @@ array. Passing `method="bicgstab"` selects the iterative solver; this path suppo
 preconditioning, Ruiz-style row/column equilibration, optional reuse of the previous converged
 iterative solution as the initial guess, and optional diagnostics via `return_diagnostics=True`.
 Equilibration scales and the scaled stiffness matrix are cached on the model for repeated
-right-hand sides.
+right-hand sides. The BiCGSTAB tolerance is passed unchanged to the system being solved. With
+equilibration enabled, this means the tolerance applies to the equilibrated residual rather than
+being rescaled to original reduced-RHS units.
 
 ### Formulation Notes
 

--- a/docs/python/solenoid_stress.md
+++ b/docs/python/solenoid_stress.md
@@ -3,7 +3,7 @@
 This package includes three complementary layers:
 
 - a 1D finite-difference radial stress solver for winding-pack models with zero `rz` shear,
-- a 2D quadrilateral FEM solver with axisymmetric and plane-strain formulations, reusable sparse load operators, and a cached Rust-side LU solve,
+- a 2D quadrilateral FEM solver with axisymmetric and plane-strain formulations, reusable sparse load operators, cached Rust-side LU solves, and optional BiCGSTAB iterative solves,
 - analytic reference formulas used for validation and convergence studies.
 
 ## 1D Finite-Difference Solver
@@ -27,14 +27,23 @@ The FEM path supports:
 - optional threaded stiffness assembly with `par=True`,
 - reusable reduced-space operators for body force, pressure, traction, and nodal-temperature thermal strain,
 - reduced quadrature-point recovery operators for strain and stress,
+- direct sparse-LU or BiCGSTAB reduced-system solves,
 - model-owned Dirichlet constraints applied during assembly.
 
 The intended workflow is:
 
 1. call `assemble_structural_2d(...)` once with mesh, materials, load topology, and prescribed Dirichlet values,
 2. build each reduced load vector with `model.build_rhs(...)` or the exposed sparse operators,
-3. solve with `model.solve(rhs)`, which reuses a cached LU factorization,
+3. solve with `model.solve(rhs)`, using the default cached LU factorization or
+   `model.solve(rhs, method="bicgstab", ...)` for an iterative solve,
 4. recover quadrature strain and stress with `model.evaluate_quadrature(...)`.
+
+By default, `model.solve(rhs)` uses the direct sparse-LU path and returns the full displacement
+array. Passing `method="bicgstab"` selects the iterative solver; this path supports diagonal
+preconditioning, Ruiz-style row/column equilibration, optional reuse of the previous converged
+iterative solution as the initial guess, and optional diagnostics via `return_diagnostics=True`.
+Equilibration scales and the scaled stiffness matrix are cached on the model for repeated
+right-hand sides.
 
 ### Formulation Notes
 

--- a/src/physics/solenoid_stress/mod.rs
+++ b/src/physics/solenoid_stress/mod.rs
@@ -508,8 +508,9 @@ pub use convenience::{
 pub use model::{
     BicgstabEquilibration, BicgstabInitialGuess, BicgstabPreconditioner, BicgstabSolveOptions,
     EquilibrationSolveOptions, ReducedRecoveryOperators, Structural2dElementType,
-    Structural2dElements, Structural2dModel, Structural2dSolveDiagnostics, Structural2dSolveMethod,
-    Structural2dSolveMethodName, Structural2dSolveOutput, assemble_structural_2d,
+    Structural2dElements, Structural2dIterativeScalar, Structural2dModel,
+    Structural2dSolveDiagnostics, Structural2dSolveMethod, Structural2dSolveMethodName,
+    Structural2dSolveOutput, assemble_structural_2d,
 };
 pub(crate) use types::validate_element_material_inputs;
 pub use types::{

--- a/src/physics/solenoid_stress/mod.rs
+++ b/src/physics/solenoid_stress/mod.rs
@@ -506,8 +506,10 @@ pub use convenience::{
     rotate_thermal_expansion_in_plane, rotate_thermal_material_in_plane,
 };
 pub use model::{
-    ReducedRecoveryOperators, Structural2dElementType, Structural2dElements, Structural2dModel,
-    assemble_structural_2d,
+    BicgstabEquilibration, BicgstabInitialGuess, BicgstabPreconditioner, BicgstabSolveOptions,
+    EquilibrationSolveOptions, ReducedRecoveryOperators, Structural2dElementType,
+    Structural2dElements, Structural2dModel, Structural2dSolveDiagnostics, Structural2dSolveMethod,
+    Structural2dSolveMethodName, Structural2dSolveOutput, assemble_structural_2d,
 };
 pub(crate) use types::validate_element_material_inputs;
 pub use types::{

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -83,7 +83,11 @@ impl Structural2dSolveMethodName {
 /// Options for the BiCGSTAB reduced-system solve.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BicgstabSolveOptions<F: Real> {
-    /// Absolute residual tolerance in RHS units. If `None`, the solve uses a RHS-scaled default.
+    /// Absolute BiCGSTAB residual tolerance in the units of the solved system.
+    ///
+    /// With equilibration disabled, this is in reduced-RHS units. With equilibration enabled, the
+    /// same value is passed to the equilibrated linear system rather than being rescaled back to
+    /// original RHS units.
     pub tolerance: Option<F>,
     /// Maximum number of BiCGSTAB iterations. If `None`, a size-based default is used.
     pub max_iterations: Option<usize>,
@@ -764,7 +768,6 @@ impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
                     .equilibrated_stiffness
                     .as_ref()
                     .ok_or_else(|| "equilibrated stiffness was not initialized".to_string())?;
-                let solver_tolerance = tolerance * min_value(equilibration.row_scale())?;
                 equilibration.scale_rhs_in_place(&mut rhs_work);
                 equilibration.scale_initial_guess_in_place(&mut initial_guess);
                 let (mut reduced_solution, mut diagnostics) = match options.preconditioner {
@@ -772,7 +775,7 @@ impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
                         equilibrated_stiffness.as_ref(),
                         &initial_guess,
                         &rhs_work,
-                        solver_tolerance,
+                        tolerance,
                         max_iterations,
                         true,
                     )?,
@@ -790,7 +793,7 @@ impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
                             preconditioner,
                             &initial_guess,
                             &rhs_work,
-                            solver_tolerance,
+                            tolerance,
                             max_iterations,
                             true,
                         )?
@@ -937,20 +940,6 @@ fn resolve_bicgstab_tolerance<F: Real>(rhs: &[F], tolerance: Option<F>) -> F {
         F::one()
     };
     scale * F::epsilon().sqrt()
-}
-
-/// Return the minimum scalar in a non-empty slice.
-fn min_value<F: Real>(values: &[F]) -> Result<F, String> {
-    if values.is_empty() {
-        return Err("cannot compute minimum of an empty slice".to_string());
-    }
-    let mut minimum = values[0];
-    for &value in &values[1..] {
-        if value < minimum {
-            minimum = value;
-        }
-    }
-    Ok(minimum)
 }
 
 /// Compute `||A x - b||_2` for one CSC matrix-vector product.

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -4,10 +4,11 @@ use deimos_numerics::sparse::{
     BiCGSTAB, BiCGSTABSolveError, CompensatedField, DiagonalPrecond, Equilibration,
     EquilibrationParams, Precond, SparseMatVec,
 };
-use faer::Col;
 use faer::linalg::solvers::Solve;
+use faer::sparse::linalg::matmul::sparse_dense_matmul;
 use faer::sparse::linalg::solvers::Lu;
 use faer::sparse::{SparseColMat, SparseColMatRef, SparseRowMat, Triplet};
+use faer::{Accum, Col, Par};
 
 use crate::mesh::elements::quad2d::{quad4, quad9};
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
@@ -753,9 +754,10 @@ impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
                     .equilibration
                     .as_ref()
                     .expect("equilibration should be initialized");
+                let solver_tolerance = tolerance * min_value(equilibration.row_scale())?;
                 equilibration.scale_rhs_in_place(&mut rhs_work);
                 equilibration.scale_initial_guess_in_place(&mut initial_guess);
-                let (mut reduced_solution, diagnostics) = match options.preconditioner {
+                let (mut reduced_solution, mut diagnostics) = match options.preconditioner {
                     BicgstabPreconditioner::None => solve_bicgstab_no_precond(
                         self.equilibrated_stiffness
                             .as_ref()
@@ -763,7 +765,7 @@ impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
                             .as_ref(),
                         &initial_guess,
                         &rhs_work,
-                        tolerance,
+                        solver_tolerance,
                         max_iterations,
                         true,
                     )?,
@@ -778,12 +780,14 @@ impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
                             .clone(),
                         &initial_guess,
                         &rhs_work,
-                        tolerance,
+                        solver_tolerance,
                         max_iterations,
                         true,
                     )?,
                 };
                 equilibration.unscale_solution_in_place(&mut reduced_solution);
+                diagnostics.residual_norm =
+                    csc_residual_norm(self.stiffness.as_ref(), &reduced_solution, rhs)?;
                 self.previous_bicgstab_solution = Some(reduced_solution.clone());
                 Ok((reduced_solution, diagnostics))
             }
@@ -922,6 +926,58 @@ fn resolve_bicgstab_tolerance<F: Real>(rhs: &[F], tolerance: Option<F>) -> F {
         F::one()
     };
     scale * F::epsilon().sqrt()
+}
+
+/// Return the minimum scalar in a non-empty slice.
+fn min_value<F: Real>(values: &[F]) -> Result<F, String> {
+    if values.is_empty() {
+        return Err("cannot compute minimum of an empty slice".to_string());
+    }
+    let mut minimum = values[0];
+    for &value in &values[1..] {
+        if value < minimum {
+            minimum = value;
+        }
+    }
+    Ok(minimum)
+}
+
+/// Compute `||A x - b||_2` for one CSC matrix-vector product.
+fn csc_residual_norm<F: Real>(
+    matrix: SparseColMatRef<'_, usize, F>,
+    solution: &[F],
+    rhs: &[F],
+) -> Result<F, String> {
+    if solution.len() != matrix.ncols() {
+        return Err(format!(
+            "solution has length {}, but CSC matrix has {} columns",
+            solution.len(),
+            matrix.ncols()
+        ));
+    }
+    if rhs.len() != matrix.nrows() {
+        return Err(format!(
+            "rhs has length {}, but CSC matrix has {} rows",
+            rhs.len(),
+            matrix.nrows()
+        ));
+    }
+    let solution = Col::from_fn(matrix.ncols(), |index| solution[index]);
+    let mut residual = Col::<F>::zeros(matrix.nrows());
+    sparse_dense_matmul(
+        residual.as_mat_mut(),
+        Accum::Replace,
+        matrix,
+        solution.as_mat(),
+        F::one(),
+        Par::Seq,
+    );
+    let mut norm_sq = F::zero();
+    for row in 0..rhs.len() {
+        let value = residual[row] - rhs[row];
+        norm_sq = value.mul_add(value, norm_sq);
+    }
+    Ok(norm_sq.sqrt())
 }
 
 /// Solve a reduced system with unpreconditioned BiCGSTAB.
@@ -1701,6 +1757,14 @@ mod tests {
 
         assert!(iterative.diagnostics.converged);
         assert!(iterative.diagnostics.iterations > 0);
+        let reduced_solution = model
+            .free_dofs
+            .iter()
+            .map(|&dof| iterative.displacement[dof])
+            .collect::<Vec<_>>();
+        let residual_norm =
+            csc_residual_norm(model.stiffness.as_ref(), &reduced_solution, &rhs).unwrap();
+        assert!((iterative.diagnostics.residual_norm - residual_norm).abs() < 1.0e-12);
         for (actual, expected) in iterative.displacement.iter().zip(&direct) {
             assert!((actual - expected).abs() < 1.0e-10);
         }

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -729,18 +729,24 @@ impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
                         max_iterations,
                         false,
                     )?,
-                    BicgstabPreconditioner::Diagonal => solve_bicgstab_with_precond(
-                        self.stiffness.as_ref(),
-                        self.diagonal_preconditioner
+                    BicgstabPreconditioner::Diagonal => {
+                        let preconditioner = self
+                            .diagonal_preconditioner
                             .as_ref()
-                            .expect("diagonal preconditioner should be initialized")
-                            .clone(),
-                        &initial_guess,
-                        &rhs_work,
-                        tolerance,
-                        max_iterations,
-                        false,
-                    )?,
+                            .ok_or_else(|| {
+                                "diagonal preconditioner was not initialized".to_string()
+                            })?
+                            .clone();
+                        solve_bicgstab_with_precond(
+                            self.stiffness.as_ref(),
+                            preconditioner,
+                            &initial_guess,
+                            &rhs_work,
+                            tolerance,
+                            max_iterations,
+                            false,
+                        )?
+                    }
                 };
                 self.previous_bicgstab_solution = Some(reduced_solution.clone());
                 Ok((reduced_solution, diagnostics))
@@ -753,37 +759,42 @@ impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
                 let equilibration = self
                     .equilibration
                     .as_ref()
-                    .expect("equilibration should be initialized");
+                    .ok_or_else(|| "equilibration was not initialized".to_string())?;
+                let equilibrated_stiffness = self
+                    .equilibrated_stiffness
+                    .as_ref()
+                    .ok_or_else(|| "equilibrated stiffness was not initialized".to_string())?;
                 let solver_tolerance = tolerance * min_value(equilibration.row_scale())?;
                 equilibration.scale_rhs_in_place(&mut rhs_work);
                 equilibration.scale_initial_guess_in_place(&mut initial_guess);
                 let (mut reduced_solution, mut diagnostics) = match options.preconditioner {
                     BicgstabPreconditioner::None => solve_bicgstab_no_precond(
-                        self.equilibrated_stiffness
-                            .as_ref()
-                            .expect("equilibrated stiffness should be initialized")
-                            .as_ref(),
+                        equilibrated_stiffness.as_ref(),
                         &initial_guess,
                         &rhs_work,
                         solver_tolerance,
                         max_iterations,
                         true,
                     )?,
-                    BicgstabPreconditioner::Diagonal => solve_bicgstab_with_precond(
-                        self.equilibrated_stiffness
+                    BicgstabPreconditioner::Diagonal => {
+                        let preconditioner = self
+                            .equilibrated_diagonal_preconditioner
                             .as_ref()
-                            .expect("equilibrated stiffness should be initialized")
-                            .as_ref(),
-                        self.equilibrated_diagonal_preconditioner
-                            .as_ref()
-                            .expect("equilibrated diagonal preconditioner should be initialized")
-                            .clone(),
-                        &initial_guess,
-                        &rhs_work,
-                        solver_tolerance,
-                        max_iterations,
-                        true,
-                    )?,
+                            .ok_or_else(|| {
+                                "equilibrated diagonal preconditioner was not initialized"
+                                    .to_string()
+                            })?
+                            .clone();
+                        solve_bicgstab_with_precond(
+                            equilibrated_stiffness.as_ref(),
+                            preconditioner,
+                            &initial_guess,
+                            &rhs_work,
+                            solver_tolerance,
+                            max_iterations,
+                            true,
+                        )?
+                    }
                 };
                 equilibration.unscale_solution_in_place(&mut reduced_solution);
                 diagnostics.residual_norm =
@@ -850,7 +861,7 @@ impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
             let stiffness = self
                 .equilibrated_stiffness
                 .as_ref()
-                .expect("equilibrated stiffness should be initialized");
+                .ok_or_else(|| "equilibrated stiffness was not initialized".to_string())?;
             self.equilibrated_diagonal_preconditioner = Some(
                 DiagonalPrecond::try_from(stiffness.as_ref()).map_err(|err| {
                     format!("failed to build equilibrated diagonal preconditioner: {err:?}")

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -1,9 +1,13 @@
 //! Reduced-model assembly and solve wrapper for the 2D structural FEM.
 
+use deimos_numerics::sparse::{
+    BiCGSTAB, BiCGSTABSolveError, DiagonalPrecond, Equilibration, EquilibrationParams, Precond,
+    SparseMatVec,
+};
 use faer::Col;
 use faer::linalg::solvers::Solve;
 use faer::sparse::linalg::solvers::Lu;
-use faer::sparse::{SparseColMat, SparseRowMat, Triplet};
+use faer::sparse::{SparseColMat, SparseColMatRef, SparseRowMat, Triplet};
 
 use crate::mesh::elements::quad2d::{quad4, quad9};
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
@@ -30,6 +34,148 @@ pub enum Structural2dElementType {
     Quad4,
     /// Quadratic nine-node quadrilateral in the analysis plane.
     Quad9,
+}
+
+/// Linear-solver method used for one reduced 2D structural FEM solve.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Structural2dSolveMethod<F: Real> {
+    /// Sparse LU direct solve with lazy factorization caching.
+    Direct,
+    /// BiCGSTAB Krylov solve with optional diagonal preconditioning and equilibration.
+    Bicgstab(BicgstabSolveOptions<F>),
+}
+
+/// Compact solver name used by diagnostics and Python bindings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Structural2dSolveMethodName {
+    /// Sparse LU direct solve.
+    Direct,
+    /// BiCGSTAB Krylov solve.
+    Bicgstab,
+}
+
+impl Structural2dSolveMethodName {
+    /// Return the compact code used by the Python binding.
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::Direct => 0,
+            Self::Bicgstab => 1,
+        }
+    }
+}
+
+/// Options for the BiCGSTAB reduced-system solve.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BicgstabSolveOptions<F: Real> {
+    /// Absolute residual tolerance in RHS units. If `None`, the solve uses a RHS-scaled default.
+    pub tolerance: Option<F>,
+    /// Maximum number of BiCGSTAB iterations. If `None`, a size-based default is used.
+    pub max_iterations: Option<usize>,
+    /// Optional preconditioner used by BiCGSTAB.
+    pub preconditioner: BicgstabPreconditioner,
+    /// Optional matrix equilibration applied before BiCGSTAB.
+    pub equilibration: BicgstabEquilibration<F>,
+    /// Initial-guess policy for the reduced displacement vector.
+    pub initial_guess: BicgstabInitialGuess,
+}
+
+impl<F: Real> Default for BicgstabSolveOptions<F> {
+    fn default() -> Self {
+        Self {
+            tolerance: None,
+            max_iterations: None,
+            preconditioner: BicgstabPreconditioner::Diagonal,
+            equilibration: BicgstabEquilibration::Ruiz(EquilibrationSolveOptions::default()),
+            initial_guess: BicgstabInitialGuess::Zero,
+        }
+    }
+}
+
+/// Preconditioner selection for BiCGSTAB.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BicgstabPreconditioner {
+    /// No preconditioner.
+    None,
+    /// Diagonal/Jacobi-style preconditioner.
+    Diagonal,
+}
+
+/// Equilibration selection for BiCGSTAB.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BicgstabEquilibration<F: Real> {
+    /// Solve the original reduced system directly.
+    None,
+    /// Apply Ruiz-style row/column equilibration before solving.
+    Ruiz(EquilibrationSolveOptions<F>),
+}
+
+/// Parameters controlling Ruiz-style sparse matrix equilibration.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EquilibrationSolveOptions<F: Real> {
+    /// Maximum number of equilibration iterations.
+    pub max_iterations: usize,
+    /// Dimensionless row/column balance tolerance.
+    pub tolerance: F,
+    /// Lower clamp applied to measured row/column norms.
+    pub norm_floor: F,
+    /// Upper clamp applied to measured row/column norms.
+    pub norm_ceil: F,
+}
+
+impl<F: Real> Default for EquilibrationSolveOptions<F> {
+    fn default() -> Self {
+        let params = EquilibrationParams::<F>::default();
+        Self {
+            max_iterations: params.max_iters,
+            tolerance: params.tol,
+            norm_floor: params.norm_floor,
+            norm_ceil: params.norm_ceil,
+        }
+    }
+}
+
+impl<F: Real> From<EquilibrationSolveOptions<F>> for EquilibrationParams<F> {
+    fn from(options: EquilibrationSolveOptions<F>) -> Self {
+        Self {
+            max_iters: options.max_iterations,
+            tol: options.tolerance,
+            norm_floor: options.norm_floor,
+            norm_ceil: options.norm_ceil,
+        }
+    }
+}
+
+/// Initial-guess policy for iterative solves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BicgstabInitialGuess {
+    /// Start from a zero reduced displacement vector.
+    Zero,
+    /// Reuse the previous converged BiCGSTAB reduced solution when available.
+    Previous,
+}
+
+/// Full displacement solution plus solve diagnostics.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Structural2dSolveOutput<F: Real> {
+    /// Full displacement vector with shape `(ndof_full,)`.
+    pub displacement: Vec<F>,
+    /// Solver diagnostics for the reduced solve.
+    pub diagnostics: Structural2dSolveDiagnostics<F>,
+}
+
+/// Diagnostics from one reduced structural solve.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Structural2dSolveDiagnostics<F: Real> {
+    /// Solver method used for this solve.
+    pub method: Structural2dSolveMethodName,
+    /// Whether the selected solver converged.
+    pub converged: bool,
+    /// Number of BiCGSTAB iterations, or zero for direct solves.
+    pub iterations: usize,
+    /// Latest residual norm in RHS units, or zero for direct solves.
+    pub residual_norm: F,
+    /// Whether row/column equilibration was applied.
+    pub equilibrated: bool,
 }
 
 impl Structural2dElementType {
@@ -211,6 +357,12 @@ pub struct Structural2dModel<F: Real> {
     /// Units: `[length]`.
     pub fixed_values: Vec<F>,
     lu: Option<Lu<usize, F>>,
+    diagonal_preconditioner: Option<DiagonalPrecond<F>>,
+    equilibration: Option<Equilibration<F>>,
+    equilibration_options: Option<EquilibrationSolveOptions<F>>,
+    equilibrated_stiffness: Option<SparseColMat<usize, F>>,
+    equilibrated_diagonal_preconditioner: Option<DiagonalPrecond<F>>,
+    previous_bicgstab_solution: Option<Vec<F>>,
 }
 
 impl<F: Real> Structural2dModel<F> {
@@ -285,6 +437,40 @@ impl<F: Real> Structural2dModel<F> {
     ///     Full displacement vector with shape `(ndof_full,)` and component ordering
     ///     `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
     pub fn solve(&mut self, rhs: &[F]) -> Result<Vec<F>, String> {
+        let reduced_solution = self.solve_direct_reduced(rhs)?;
+        Ok(self.recover_full(&reduced_solution))
+    }
+
+    /// Solve the reduced structural system with an explicit solver method.
+    ///
+    /// Args:
+    ///     rhs: Reduced right-hand side with shape `(ndof_reduced,)` and units
+    ///         `[generalized force] = [energy / distance]`.
+    ///     method: Solver method and method-specific options.
+    ///
+    /// Returns:
+    ///     Full displacement vector and solve diagnostics.
+    pub fn solve_with_method(
+        &mut self,
+        rhs: &[F],
+        method: Structural2dSolveMethod<F>,
+    ) -> Result<Structural2dSolveOutput<F>, String> {
+        let (reduced_solution, diagnostics) = match method {
+            Structural2dSolveMethod::Direct => {
+                (self.solve_direct_reduced(rhs)?, direct_diagnostics())
+            }
+            Structural2dSolveMethod::Bicgstab(options) => {
+                self.solve_bicgstab_reduced(rhs, options)?
+            }
+        };
+        Ok(Structural2dSolveOutput {
+            displacement: self.recover_full(&reduced_solution),
+            diagnostics,
+        })
+    }
+
+    /// Solve the reduced structural system with the cached sparse LU factorization.
+    fn solve_direct_reduced(&mut self, rhs: &[F]) -> Result<Vec<F>, String> {
         if rhs.len() != self.ndof_reduced {
             return Err(format!(
                 "rhs has length {}, but reduced system has {} rows",
@@ -293,7 +479,7 @@ impl<F: Real> Structural2dModel<F> {
             ));
         }
         if self.ndof_reduced == 0 {
-            return Ok(self.recover_full(&[]));
+            return Ok(Vec::new());
         }
         if self.lu.is_none() {
             self.lu = Some(
@@ -311,7 +497,183 @@ impl<F: Real> Structural2dModel<F> {
         let reduced_solution = (0..self.ndof_reduced)
             .map(|index| reduced_solution[index])
             .collect::<Vec<_>>();
-        Ok(self.recover_full(&reduced_solution))
+        Ok(reduced_solution)
+    }
+
+    /// Solve the reduced structural system with BiCGSTAB.
+    fn solve_bicgstab_reduced(
+        &mut self,
+        rhs: &[F],
+        options: BicgstabSolveOptions<F>,
+    ) -> Result<(Vec<F>, Structural2dSolveDiagnostics<F>), String> {
+        validate_bicgstab_options(options)?;
+        if rhs.len() != self.ndof_reduced {
+            return Err(format!(
+                "rhs has length {}, but reduced system has {} rows",
+                rhs.len(),
+                self.ndof_reduced
+            ));
+        }
+        if self.ndof_reduced == 0 {
+            return Ok((
+                Vec::new(),
+                Structural2dSolveDiagnostics {
+                    method: Structural2dSolveMethodName::Bicgstab,
+                    converged: true,
+                    iterations: 0,
+                    residual_norm: F::zero(),
+                    equilibrated: !matches!(options.equilibration, BicgstabEquilibration::None),
+                },
+            ));
+        }
+
+        let tolerance = resolve_bicgstab_tolerance(rhs, options.tolerance);
+        let max_iterations = options
+            .max_iterations
+            .unwrap_or_else(|| self.ndof_reduced.saturating_mul(2).max(100));
+        let mut rhs_work = rhs.to_vec();
+        let mut initial_guess = self.bicgstab_initial_guess(options.initial_guess);
+
+        match options.equilibration {
+            BicgstabEquilibration::None => {
+                if options.preconditioner == BicgstabPreconditioner::Diagonal {
+                    self.ensure_diagonal_preconditioner()?;
+                }
+                let (reduced_solution, diagnostics) = match options.preconditioner {
+                    BicgstabPreconditioner::None => solve_bicgstab_no_precond(
+                        self.stiffness.as_ref(),
+                        &initial_guess,
+                        &rhs_work,
+                        tolerance,
+                        max_iterations,
+                        false,
+                    )?,
+                    BicgstabPreconditioner::Diagonal => solve_bicgstab_with_precond(
+                        self.stiffness.as_ref(),
+                        self.diagonal_preconditioner
+                            .as_ref()
+                            .expect("diagonal preconditioner should be initialized")
+                            .clone(),
+                        &initial_guess,
+                        &rhs_work,
+                        tolerance,
+                        max_iterations,
+                        false,
+                    )?,
+                };
+                self.previous_bicgstab_solution = Some(reduced_solution.clone());
+                Ok((reduced_solution, diagnostics))
+            }
+            BicgstabEquilibration::Ruiz(equilibration_options) => {
+                self.ensure_equilibration(equilibration_options)?;
+                if options.preconditioner == BicgstabPreconditioner::Diagonal {
+                    self.ensure_equilibrated_diagonal_preconditioner()?;
+                }
+                let equilibration = self
+                    .equilibration
+                    .as_ref()
+                    .expect("equilibration should be initialized");
+                equilibration.scale_rhs_in_place(&mut rhs_work);
+                equilibration.scale_initial_guess_in_place(&mut initial_guess);
+                let (mut reduced_solution, diagnostics) = match options.preconditioner {
+                    BicgstabPreconditioner::None => solve_bicgstab_no_precond(
+                        self.equilibrated_stiffness
+                            .as_ref()
+                            .expect("equilibrated stiffness should be initialized")
+                            .as_ref(),
+                        &initial_guess,
+                        &rhs_work,
+                        tolerance,
+                        max_iterations,
+                        true,
+                    )?,
+                    BicgstabPreconditioner::Diagonal => solve_bicgstab_with_precond(
+                        self.equilibrated_stiffness
+                            .as_ref()
+                            .expect("equilibrated stiffness should be initialized")
+                            .as_ref(),
+                        self.equilibrated_diagonal_preconditioner
+                            .as_ref()
+                            .expect("equilibrated diagonal preconditioner should be initialized")
+                            .clone(),
+                        &initial_guess,
+                        &rhs_work,
+                        tolerance,
+                        max_iterations,
+                        true,
+                    )?,
+                };
+                equilibration.unscale_solution_in_place(&mut reduced_solution);
+                self.previous_bicgstab_solution = Some(reduced_solution.clone());
+                Ok((reduced_solution, diagnostics))
+            }
+        }
+    }
+
+    /// Return the reduced-space initial guess requested by the iterative solve options.
+    fn bicgstab_initial_guess(&self, policy: BicgstabInitialGuess) -> Vec<F> {
+        match policy {
+            BicgstabInitialGuess::Zero => vec![F::zero(); self.ndof_reduced],
+            BicgstabInitialGuess::Previous => self
+                .previous_bicgstab_solution
+                .as_ref()
+                .filter(|solution| solution.len() == self.ndof_reduced)
+                .cloned()
+                .unwrap_or_else(|| vec![F::zero(); self.ndof_reduced]),
+        }
+    }
+
+    /// Build and cache the diagonal preconditioner for the original reduced stiffness.
+    fn ensure_diagonal_preconditioner(&mut self) -> Result<(), String> {
+        if self.diagonal_preconditioner.is_none() {
+            self.diagonal_preconditioner = Some(
+                DiagonalPrecond::try_from(self.stiffness.as_ref())
+                    .map_err(|err| format!("failed to build diagonal preconditioner: {err:?}"))?,
+            );
+        }
+        Ok(())
+    }
+
+    /// Build and cache equilibration scales and the scaled reduced stiffness.
+    fn ensure_equilibration(
+        &mut self,
+        options: EquilibrationSolveOptions<F>,
+    ) -> Result<(), String> {
+        if self.equilibration_options != Some(options) {
+            self.equilibration = None;
+            self.equilibrated_stiffness = None;
+            self.equilibrated_diagonal_preconditioner = None;
+            self.equilibration_options = Some(options);
+        }
+        if self.equilibration.is_none() || self.equilibrated_stiffness.is_none() {
+            let equilibration = Equilibration::<F>::compute_from_csc(
+                self.stiffness.as_ref(),
+                EquilibrationParams::from(options),
+            )
+            .map_err(|err| format!("failed to equilibrate reduced stiffness: {err:?}"))?;
+            let mut equilibrated_stiffness = self.stiffness.clone();
+            equilibration.scale_csc_matrix_in_place(&mut equilibrated_stiffness);
+            self.equilibration = Some(equilibration);
+            self.equilibrated_stiffness = Some(equilibrated_stiffness);
+            self.equilibrated_diagonal_preconditioner = None;
+        }
+        Ok(())
+    }
+
+    /// Build and cache the diagonal preconditioner for the equilibrated reduced stiffness.
+    fn ensure_equilibrated_diagonal_preconditioner(&mut self) -> Result<(), String> {
+        if self.equilibrated_diagonal_preconditioner.is_none() {
+            let stiffness = self
+                .equilibrated_stiffness
+                .as_ref()
+                .expect("equilibrated stiffness should be initialized");
+            self.equilibrated_diagonal_preconditioner = Some(
+                DiagonalPrecond::try_from(stiffness.as_ref()).map_err(|err| {
+                    format!("failed to build equilibrated diagonal preconditioner: {err:?}")
+                })?,
+            );
+        }
+        Ok(())
     }
 
     /// Reinsert prescribed Dirichlet values into a reduced displacement vector.
@@ -476,6 +838,141 @@ impl<F: Real> Structural2dModel<F> {
             nq_per_element: self.recovery.nq_per_element,
         })
     }
+}
+
+/// Diagnostics for the sparse LU path.
+fn direct_diagnostics<F: Real>() -> Structural2dSolveDiagnostics<F> {
+    Structural2dSolveDiagnostics {
+        method: Structural2dSolveMethodName::Direct,
+        converged: true,
+        iterations: 0,
+        residual_norm: F::zero(),
+        equilibrated: false,
+    }
+}
+
+/// Validate BiCGSTAB and equilibration options before allocating solver scratch space.
+fn validate_bicgstab_options<F: Real>(options: BicgstabSolveOptions<F>) -> Result<(), String> {
+    if let Some(tolerance) = options.tolerance
+        && (!tolerance.is_finite() || tolerance <= F::zero())
+    {
+        return Err(format!(
+            "BiCGSTAB tolerance must be finite and positive; got {tolerance:?}"
+        ));
+    }
+    if let Some(max_iterations) = options.max_iterations
+        && max_iterations == 0
+    {
+        return Err("BiCGSTAB max_iterations must be at least 1".to_string());
+    }
+    if let BicgstabEquilibration::Ruiz(equilibration) = options.equilibration {
+        if equilibration.max_iterations == 0 {
+            return Err("equilibration max_iterations must be at least 1".to_string());
+        }
+        if !equilibration.tolerance.is_finite() || equilibration.tolerance < F::zero() {
+            return Err(format!(
+                "equilibration tolerance must be finite and nonnegative; got {:?}",
+                equilibration.tolerance
+            ));
+        }
+        if !equilibration.norm_floor.is_finite()
+            || equilibration.norm_floor <= F::zero()
+            || !equilibration.norm_ceil.is_finite()
+            || equilibration.norm_ceil <= equilibration.norm_floor
+        {
+            return Err(format!(
+                "equilibration norm clamps must satisfy 0 < floor < ceil; got floor={:?}, ceil={:?}",
+                equilibration.norm_floor, equilibration.norm_ceil
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a RHS-scaled absolute residual tolerance when the caller does not provide one.
+fn resolve_bicgstab_tolerance<F: Real>(rhs: &[F], tolerance: Option<F>) -> F {
+    if let Some(tolerance) = tolerance {
+        return tolerance;
+    }
+    let mut norm_sq = F::zero();
+    for &value in rhs {
+        norm_sq = value.mul_add(value, norm_sq);
+    }
+    let rhs_norm = norm_sq.sqrt();
+    let scale = if rhs_norm > F::zero() {
+        rhs_norm
+    } else {
+        F::one()
+    };
+    scale * F::epsilon().sqrt()
+}
+
+/// Solve a reduced system with unpreconditioned BiCGSTAB.
+fn solve_bicgstab_no_precond<F: Real>(
+    matrix: SparseColMatRef<'_, usize, F>,
+    initial_guess: &[F],
+    rhs: &[F],
+    tolerance: F,
+    max_iterations: usize,
+    equilibrated: bool,
+) -> Result<(Vec<F>, Structural2dSolveDiagnostics<F>), String> {
+    match BiCGSTAB::solve(matrix, initial_guess, rhs, tolerance, max_iterations) {
+        Ok(solver) => Ok(bicgstab_success(solver, equilibrated)),
+        Err(BiCGSTABSolveError::InvalidInput(err)) => Err(format!("invalid BiCGSTAB input: {err}")),
+        Err(BiCGSTABSolveError::NoConvergence(solver)) => Err(format!(
+            "BiCGSTAB did not converge within {} iterations; residual norm is {:?}",
+            solver.iteration_count(),
+            solver.err()
+        )),
+    }
+}
+
+/// Solve a reduced system with diagonally preconditioned BiCGSTAB.
+fn solve_bicgstab_with_precond<F: Real>(
+    matrix: SparseColMatRef<'_, usize, F>,
+    preconditioner: DiagonalPrecond<F>,
+    initial_guess: &[F],
+    rhs: &[F],
+    tolerance: F,
+    max_iterations: usize,
+    equilibrated: bool,
+) -> Result<(Vec<F>, Structural2dSolveDiagnostics<F>), String> {
+    match BiCGSTAB::solve_with_precond(
+        matrix,
+        preconditioner,
+        initial_guess,
+        rhs,
+        tolerance,
+        max_iterations,
+    ) {
+        Ok(solver) => Ok(bicgstab_success(solver, equilibrated)),
+        Err(BiCGSTABSolveError::InvalidInput(err)) => Err(format!("invalid BiCGSTAB input: {err}")),
+        Err(BiCGSTABSolveError::NoConvergence(solver)) => Err(format!(
+            "BiCGSTAB did not converge within {} iterations; residual norm is {:?}",
+            solver.iteration_count(),
+            solver.err()
+        )),
+    }
+}
+
+/// Convert a converged BiCGSTAB solver state into a reduced solution and diagnostics.
+fn bicgstab_success<F: Real, A, P>(
+    solver: BiCGSTAB<F, A, P>,
+    equilibrated: bool,
+) -> (Vec<F>, Structural2dSolveDiagnostics<F>)
+where
+    A: SparseMatVec<F>,
+    P: Precond<F>,
+{
+    let diagnostics = Structural2dSolveDiagnostics {
+        method: Structural2dSolveMethodName::Bicgstab,
+        converged: true,
+        iterations: solver.iteration_count(),
+        residual_norm: solver.err(),
+        equilibrated,
+    };
+    let solution = solver.x().iter().copied().collect::<Vec<_>>();
+    (solution, diagnostics)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -765,6 +1262,12 @@ where
         fixed_dofs,
         fixed_values,
         lu: None,
+        diagonal_preconditioner: None,
+        equilibration: None,
+        equilibration_options: None,
+        equilibrated_stiffness: None,
+        equilibrated_diagonal_preconditioner: None,
+        previous_bicgstab_solution: None,
     })
 }
 
@@ -1137,4 +1640,52 @@ fn pack_rank4_field<F: Real>(flat: Vec<F>) -> Result<Vec<[F; 4]>, String> {
         packed.push([chunk[0], chunk[1], chunk[2], chunk[3]]);
     }
     Ok(packed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::solenoid_stress::convenience::isotropic_axisymmetric_material;
+
+    #[test]
+    fn bicgstab_solve_matches_direct_solve() {
+        let material = [isotropic_axisymmetric_material(200.0e9_f64, 0.27)];
+        let mut model = assemble_structural_2d(
+            &crate::physics::solenoid_stress::test_utils::SINGLE_QUAD4_NODES,
+            Structural2dElements::Quad4(
+                &crate::physics::solenoid_stress::test_utils::SINGLE_QUAD4_ELEMENTS,
+            ),
+            &[0],
+            &material,
+            &[],
+            &[],
+            None,
+            None,
+            &[(0, 0.0), (1, 0.0), (3, 0.0), (5, 0.0), (7, 0.0)],
+            Structural2dFormulation::Axisymmetric,
+            QuadratureRule::GaussLegendre3,
+            false,
+        )
+        .unwrap();
+        let rhs = model
+            .build_rhs(Some(&[2.0e5, -1.0e5]), None, None, None)
+            .unwrap();
+        let direct = model.solve(&rhs).unwrap();
+        let iterative = model
+            .solve_with_method(
+                &rhs,
+                Structural2dSolveMethod::Bicgstab(BicgstabSolveOptions {
+                    tolerance: Some(1.0e-9),
+                    max_iterations: Some(1000),
+                    ..BicgstabSolveOptions::default()
+                }),
+            )
+            .unwrap();
+
+        assert!(iterative.diagnostics.converged);
+        assert!(iterative.diagnostics.iterations > 0);
+        for (actual, expected) in iterative.displacement.iter().zip(&direct) {
+            assert!((actual - expected).abs() < 1.0e-10);
+        }
+    }
 }

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -1,8 +1,8 @@
 //! Reduced-model assembly and solve wrapper for the 2D structural FEM.
 
 use deimos_numerics::sparse::{
-    BiCGSTAB, BiCGSTABSolveError, DiagonalPrecond, Equilibration, EquilibrationParams, Precond,
-    SparseMatVec,
+    BiCGSTAB, BiCGSTABSolveError, CompensatedField, DiagonalPrecond, Equilibration,
+    EquilibrationParams, Precond, SparseMatVec,
 };
 use faer::Col;
 use faer::linalg::solvers::Solve;
@@ -26,6 +26,21 @@ use crate::physics::solenoid_stress::recovery::quadrature_field_operators_for_fa
 use crate::physics::solenoid_stress::types::{
     PressureLoad, Real, Structural2dFormulation, ThermalMaterial, TractionLoad, dof_per_element,
 };
+
+mod private {
+    use super::{CompensatedField, Real};
+
+    pub trait IterativeScalarSealed: Real + CompensatedField {}
+
+    impl<T> IterativeScalarSealed for T where T: Real + CompensatedField {}
+}
+
+/// Scalar types supported by the iterative 2D structural FEM solve path.
+///
+/// This trait is sealed and implemented by the floating-point types supported by the backend.
+pub trait Structural2dIterativeScalar: Real + private::IterativeScalarSealed {}
+
+impl<T> Structural2dIterativeScalar for T where T: Real + private::IterativeScalarSealed {}
 
 /// Public element-family selector for the 2D structural solver.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -441,34 +456,6 @@ impl<F: Real> Structural2dModel<F> {
         Ok(self.recover_full(&reduced_solution))
     }
 
-    /// Solve the reduced structural system with an explicit solver method.
-    ///
-    /// Args:
-    ///     rhs: Reduced right-hand side with shape `(ndof_reduced,)` and units
-    ///         `[generalized force] = [energy / distance]`.
-    ///     method: Solver method and method-specific options.
-    ///
-    /// Returns:
-    ///     Full displacement vector and solve diagnostics.
-    pub fn solve_with_method(
-        &mut self,
-        rhs: &[F],
-        method: Structural2dSolveMethod<F>,
-    ) -> Result<Structural2dSolveOutput<F>, String> {
-        let (reduced_solution, diagnostics) = match method {
-            Structural2dSolveMethod::Direct => {
-                (self.solve_direct_reduced(rhs)?, direct_diagnostics())
-            }
-            Structural2dSolveMethod::Bicgstab(options) => {
-                self.solve_bicgstab_reduced(rhs, options)?
-            }
-        };
-        Ok(Structural2dSolveOutput {
-            displacement: self.recover_full(&reduced_solution),
-            diagnostics,
-        })
-    }
-
     /// Solve the reduced structural system with the cached sparse LU factorization.
     fn solve_direct_reduced(&mut self, rhs: &[F]) -> Result<Vec<F>, String> {
         if rhs.len() != self.ndof_reduced {
@@ -498,6 +485,199 @@ impl<F: Real> Structural2dModel<F> {
             .map(|index| reduced_solution[index])
             .collect::<Vec<_>>();
         Ok(reduced_solution)
+    }
+
+    /// Reinsert prescribed Dirichlet values into a reduced displacement vector.
+    ///
+    /// Args:
+    ///     reduced_solution: Reduced displacement vector with shape `(ndof_reduced,)`.
+    ///         Units are `[length]`.
+    ///
+    /// Returns:
+    ///     Full displacement vector with shape `(ndof_full,)` and component ordering
+    ///     `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
+    pub fn recover_full(&self, reduced_solution: &[F]) -> Vec<F> {
+        assert!(
+            reduced_solution.len() == self.ndof_reduced,
+            "reduced_solution has length {}, but reduced system has {} rows",
+            reduced_solution.len(),
+            self.ndof_reduced
+        );
+        let mut full = vec![F::zero(); self.ndof_full];
+        for (&dof, &value) in self.fixed_dofs.iter().zip(&self.fixed_values) {
+            full[dof] = value;
+        }
+        for (&dof, &value) in self.free_dofs.iter().zip(reduced_solution) {
+            full[dof] = value;
+        }
+        full
+    }
+
+    /// Recompute the physical quadrature points and mapped weights for the stored analysis mesh.
+    ///
+    /// Returns:
+    ///     Element-major quadrature data with:
+    ///     - `points` length `nelem * nq_per_element`, each entry `(r, z)` with units `[length]`
+    ///     - `weights_area` length `nelem * nq_per_element` with units `[area]`
+    ///     - `weights_volume` length `nelem * nq_per_element` with units `[volume]`
+    ///     - `nq_per_element` giving the number of consecutive quadrature entries per element
+    pub fn element_quadrature(&self) -> Result<Structural2dElementQuadrature<F>, String> {
+        match self.element_type {
+            Structural2dElementType::Quad4 => {
+                element_quadrature_for_family::<F, Quad4Family, { quad4::NODES_PER_ELEMENT }>(
+                    &self.analysis_nodes,
+                    &self.analysis_elements_flat,
+                    self.nelem,
+                    self.formulation,
+                    self.quadrature,
+                )
+            }
+            Structural2dElementType::Quad9 => {
+                element_quadrature_for_family::<F, Quad9Family, { quad9::NODES_PER_ELEMENT }>(
+                    &self.analysis_nodes,
+                    &self.analysis_elements_flat,
+                    self.nelem,
+                    self.formulation,
+                    self.quadrature,
+                )
+            }
+        }
+    }
+
+    /// Return per-element analysis-plane area and represented volume from the model quadrature data.
+    ///
+    /// Returns:
+    ///     Per-element measures with:
+    ///     - `areas` shape `(nelem,)` and units `[area]`
+    ///     - `volumes` shape `(nelem,)` and units `[volume]`
+    pub fn element_measures(&self) -> Result<Structural2dElementMeasures<F>, String> {
+        let quadrature = self.element_quadrature()?;
+        let mut areas = vec![F::zero(); self.nelem];
+        let mut volumes = vec![F::zero(); self.nelem];
+        for element in 0..self.nelem {
+            let start = element * quadrature.nq_per_element;
+            let end = start + quadrature.nq_per_element;
+            for &weight in &quadrature.weights_area[start..end] {
+                areas[element] = areas[element] + weight;
+            }
+            for &weight in &quadrature.weights_volume[start..end] {
+                volumes[element] = volumes[element] + weight;
+            }
+        }
+        Ok(Structural2dElementMeasures { areas, volumes })
+    }
+
+    /// Recover quadrature-point strain and stress fields.
+    ///
+    /// Args:
+    ///     displacements_full: Full displacement vector with shape `(ndof_full,)` and component
+    ///         ordering `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
+    ///     nodal_temperature: Optional nodal temperatures with shape `(n_temperature_nodes,)`.
+    ///         Units are `[temperature]`. Required only when the model includes thermal materials.
+    ///
+    /// Returns:
+    ///     Recovered quadrature fields where:
+    ///     - `points` has length `nelem * nq_per_element` and units `[length]`
+    ///     - `strain`, `thermal_strain`, and `elastic_strain` each have length
+    ///       `nelem * nq_per_element`, with component order `[rr, zz, tt, rz]` and units `[strain]`
+    ///     - `stress` has length `nelem * nq_per_element`, with component order
+    ///       `[rr, zz, tt, rz]` and units `[stress]`
+    ///     - `nq_per_element` gives the number of consecutive samples per element
+    pub fn evaluate_quadrature(
+        &self,
+        displacements_full: &[F],
+        nodal_temperature: Option<&[F]>,
+    ) -> Result<QuadratureFieldSamples<F>, String> {
+        if displacements_full.len() != self.ndof_full {
+            return Err(format!(
+                "displacements_full has length {}, but full system has {} DOFs",
+                displacements_full.len(),
+                self.ndof_full
+            ));
+        }
+
+        let reduced = self
+            .free_dofs
+            .iter()
+            .map(|&dof| displacements_full[dof])
+            .collect::<Vec<_>>();
+        let temperature = normalize_temperature(
+            nodal_temperature,
+            self.recovery.n_temperature_nodes,
+            "nodal_temperature",
+        )?;
+
+        let strain = add_constant(
+            csr_matvec(&self.recovery.strain_operator, &reduced),
+            &self.recovery.strain_constant,
+        );
+        let stress_from_displacement = add_constant(
+            csr_matvec(&self.recovery.stress_operator, &reduced),
+            &self.recovery.stress_constant,
+        );
+        let thermal_strain = add_constant(
+            csr_matvec(&self.recovery.thermal_strain_operator, temperature),
+            &self.recovery.thermal_strain_constant,
+        );
+        let thermal_stress = add_constant(
+            csr_matvec(&self.recovery.thermal_stress_operator, temperature),
+            &self.recovery.thermal_stress_constant,
+        );
+        let stress = subtract_vectors(&stress_from_displacement, &thermal_stress)?;
+        let strain = pack_rank4_field(strain)?;
+        let thermal_strain = pack_rank4_field(thermal_strain)?;
+        let stress = pack_rank4_field(stress)?;
+        let elastic_strain = strain
+            .iter()
+            .zip(&thermal_strain)
+            .map(|(total, thermal)| {
+                [
+                    total[0] - thermal[0],
+                    total[1] - thermal[1],
+                    total[2] - thermal[2],
+                    total[3] - thermal[3],
+                ]
+            })
+            .collect();
+
+        Ok(QuadratureFieldSamples {
+            points: self.recovery.points.clone(),
+            strain,
+            thermal_strain,
+            elastic_strain,
+            stress,
+            nq_per_element: self.recovery.nq_per_element,
+        })
+    }
+}
+
+impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
+    /// Solve the reduced structural system with an explicit solver method.
+    ///
+    /// Args:
+    ///     rhs: Reduced right-hand side with shape `(ndof_reduced,)` and units
+    ///         `[generalized force] = [energy / distance]`.
+    ///     method: Solver method and method-specific options.
+    ///
+    /// Returns:
+    ///     Full displacement vector and solve diagnostics.
+    pub fn solve_with_method(
+        &mut self,
+        rhs: &[F],
+        method: Structural2dSolveMethod<F>,
+    ) -> Result<Structural2dSolveOutput<F>, String> {
+        let (reduced_solution, diagnostics) = match method {
+            Structural2dSolveMethod::Direct => {
+                (self.solve_direct_reduced(rhs)?, direct_diagnostics())
+            }
+            Structural2dSolveMethod::Bicgstab(options) => {
+                self.solve_bicgstab_reduced(rhs, options)?
+            }
+        };
+        Ok(Structural2dSolveOutput {
+            displacement: self.recover_full(&reduced_solution),
+            diagnostics,
+        })
     }
 
     /// Solve the reduced structural system with BiCGSTAB.
@@ -675,169 +855,6 @@ impl<F: Real> Structural2dModel<F> {
         }
         Ok(())
     }
-
-    /// Reinsert prescribed Dirichlet values into a reduced displacement vector.
-    ///
-    /// Args:
-    ///     reduced_solution: Reduced displacement vector with shape `(ndof_reduced,)`.
-    ///         Units are `[length]`.
-    ///
-    /// Returns:
-    ///     Full displacement vector with shape `(ndof_full,)` and component ordering
-    ///     `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
-    pub fn recover_full(&self, reduced_solution: &[F]) -> Vec<F> {
-        assert!(
-            reduced_solution.len() == self.ndof_reduced,
-            "reduced_solution has length {}, but reduced system has {} rows",
-            reduced_solution.len(),
-            self.ndof_reduced
-        );
-        let mut full = vec![F::zero(); self.ndof_full];
-        for (&dof, &value) in self.fixed_dofs.iter().zip(&self.fixed_values) {
-            full[dof] = value;
-        }
-        for (&dof, &value) in self.free_dofs.iter().zip(reduced_solution) {
-            full[dof] = value;
-        }
-        full
-    }
-
-    /// Recompute the physical quadrature points and mapped weights for the stored analysis mesh.
-    ///
-    /// Returns:
-    ///     Element-major quadrature data with:
-    ///     - `points` length `nelem * nq_per_element`, each entry `(r, z)` with units `[length]`
-    ///     - `weights_area` length `nelem * nq_per_element` with units `[area]`
-    ///     - `weights_volume` length `nelem * nq_per_element` with units `[volume]`
-    ///     - `nq_per_element` giving the number of consecutive quadrature entries per element
-    pub fn element_quadrature(&self) -> Result<Structural2dElementQuadrature<F>, String> {
-        match self.element_type {
-            Structural2dElementType::Quad4 => {
-                element_quadrature_for_family::<F, Quad4Family, { quad4::NODES_PER_ELEMENT }>(
-                    &self.analysis_nodes,
-                    &self.analysis_elements_flat,
-                    self.nelem,
-                    self.formulation,
-                    self.quadrature,
-                )
-            }
-            Structural2dElementType::Quad9 => {
-                element_quadrature_for_family::<F, Quad9Family, { quad9::NODES_PER_ELEMENT }>(
-                    &self.analysis_nodes,
-                    &self.analysis_elements_flat,
-                    self.nelem,
-                    self.formulation,
-                    self.quadrature,
-                )
-            }
-        }
-    }
-
-    /// Return per-element analysis-plane area and represented volume from the model quadrature data.
-    ///
-    /// Returns:
-    ///     Per-element measures with:
-    ///     - `areas` shape `(nelem,)` and units `[area]`
-    ///     - `volumes` shape `(nelem,)` and units `[volume]`
-    pub fn element_measures(&self) -> Result<Structural2dElementMeasures<F>, String> {
-        let quadrature = self.element_quadrature()?;
-        let mut areas = vec![F::zero(); self.nelem];
-        let mut volumes = vec![F::zero(); self.nelem];
-        for element in 0..self.nelem {
-            let start = element * quadrature.nq_per_element;
-            let end = start + quadrature.nq_per_element;
-            for &weight in &quadrature.weights_area[start..end] {
-                areas[element] = areas[element] + weight;
-            }
-            for &weight in &quadrature.weights_volume[start..end] {
-                volumes[element] = volumes[element] + weight;
-            }
-        }
-        Ok(Structural2dElementMeasures { areas, volumes })
-    }
-
-    /// Recover quadrature-point strain and stress fields.
-    ///
-    /// Args:
-    ///     displacements_full: Full displacement vector with shape `(ndof_full,)` and component
-    ///         ordering `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
-    ///     nodal_temperature: Optional nodal temperatures with shape `(n_temperature_nodes,)`.
-    ///         Units are `[temperature]`. Required only when the model includes thermal materials.
-    ///
-    /// Returns:
-    ///     Recovered quadrature fields where:
-    ///     - `points` has length `nelem * nq_per_element` and units `[length]`
-    ///     - `strain`, `thermal_strain`, and `elastic_strain` each have length
-    ///       `nelem * nq_per_element`, with component order `[rr, zz, tt, rz]` and units `[strain]`
-    ///     - `stress` has length `nelem * nq_per_element`, with component order
-    ///       `[rr, zz, tt, rz]` and units `[stress]`
-    ///     - `nq_per_element` gives the number of consecutive samples per element
-    pub fn evaluate_quadrature(
-        &self,
-        displacements_full: &[F],
-        nodal_temperature: Option<&[F]>,
-    ) -> Result<QuadratureFieldSamples<F>, String> {
-        if displacements_full.len() != self.ndof_full {
-            return Err(format!(
-                "displacements_full has length {}, but full system has {} DOFs",
-                displacements_full.len(),
-                self.ndof_full
-            ));
-        }
-
-        let reduced = self
-            .free_dofs
-            .iter()
-            .map(|&dof| displacements_full[dof])
-            .collect::<Vec<_>>();
-        let temperature = normalize_temperature(
-            nodal_temperature,
-            self.recovery.n_temperature_nodes,
-            "nodal_temperature",
-        )?;
-
-        let strain = add_constant(
-            csr_matvec(&self.recovery.strain_operator, &reduced),
-            &self.recovery.strain_constant,
-        );
-        let stress_from_displacement = add_constant(
-            csr_matvec(&self.recovery.stress_operator, &reduced),
-            &self.recovery.stress_constant,
-        );
-        let thermal_strain = add_constant(
-            csr_matvec(&self.recovery.thermal_strain_operator, temperature),
-            &self.recovery.thermal_strain_constant,
-        );
-        let thermal_stress = add_constant(
-            csr_matvec(&self.recovery.thermal_stress_operator, temperature),
-            &self.recovery.thermal_stress_constant,
-        );
-        let stress = subtract_vectors(&stress_from_displacement, &thermal_stress)?;
-        let strain = pack_rank4_field(strain)?;
-        let thermal_strain = pack_rank4_field(thermal_strain)?;
-        let stress = pack_rank4_field(stress)?;
-        let elastic_strain = strain
-            .iter()
-            .zip(&thermal_strain)
-            .map(|(total, thermal)| {
-                [
-                    total[0] - thermal[0],
-                    total[1] - thermal[1],
-                    total[2] - thermal[2],
-                    total[3] - thermal[3],
-                ]
-            })
-            .collect();
-
-        Ok(QuadratureFieldSamples {
-            points: self.recovery.points.clone(),
-            strain,
-            thermal_strain,
-            elastic_strain,
-            stress,
-            nq_per_element: self.recovery.nq_per_element,
-        })
-    }
 }
 
 /// Diagnostics for the sparse LU path.
@@ -908,7 +925,7 @@ fn resolve_bicgstab_tolerance<F: Real>(rhs: &[F], tolerance: Option<F>) -> F {
 }
 
 /// Solve a reduced system with unpreconditioned BiCGSTAB.
-fn solve_bicgstab_no_precond<F: Real>(
+fn solve_bicgstab_no_precond<F: Structural2dIterativeScalar>(
     matrix: SparseColMatRef<'_, usize, F>,
     initial_guess: &[F],
     rhs: &[F],
@@ -928,7 +945,7 @@ fn solve_bicgstab_no_precond<F: Real>(
 }
 
 /// Solve a reduced system with diagonally preconditioned BiCGSTAB.
-fn solve_bicgstab_with_precond<F: Real>(
+fn solve_bicgstab_with_precond<F: Structural2dIterativeScalar>(
     matrix: SparseColMatRef<'_, usize, F>,
     preconditioner: DiagonalPrecond<F>,
     initial_guess: &[F],
@@ -956,7 +973,7 @@ fn solve_bicgstab_with_precond<F: Real>(
 }
 
 /// Convert a converged BiCGSTAB solver state into a reduced solution and diagnostics.
-fn bicgstab_success<F: Real, A, P>(
+fn bicgstab_success<F: Structural2dIterativeScalar, A, P>(
     solver: BiCGSTAB<F, A, P>,
     equilibrated: bool,
 ) -> (Vec<F>, Structural2dSolveDiagnostics<F>)

--- a/src/physics/solenoid_stress/types.rs
+++ b/src/physics/solenoid_stress/types.rs
@@ -1,6 +1,5 @@
 //! Shared numeric traits and constants for the solenoid-stress backend.
 
-use deimos_numerics::sparse::CompensatedField;
 use faer_traits::RealField;
 use num_traits::{Float, FromPrimitive};
 
@@ -9,28 +8,12 @@ use num_traits::{Float, FromPrimitive};
 /// Keeping the bound in one place makes it easier to support both `f32` and `f64` entry points
 /// without duplicating generic constraints everywhere else.
 pub trait Real:
-    Float
-    + FromPrimitive
-    + RealField
-    + CompensatedField
-    + Copy
-    + std::fmt::Debug
-    + Send
-    + Sync
-    + 'static
+    Float + FromPrimitive + RealField + Copy + std::fmt::Debug + Send + Sync + 'static
 {
 }
 
 impl<T> Real for T where
-    T: Float
-        + FromPrimitive
-        + RealField
-        + CompensatedField
-        + Copy
-        + std::fmt::Debug
-        + Send
-        + Sync
-        + 'static
+    T: Float + FromPrimitive + RealField + Copy + std::fmt::Debug + Send + Sync + 'static
 {
 }
 

--- a/src/physics/solenoid_stress/types.rs
+++ b/src/physics/solenoid_stress/types.rs
@@ -1,5 +1,6 @@
 //! Shared numeric traits and constants for the solenoid-stress backend.
 
+use deimos_numerics::sparse::CompensatedField;
 use faer_traits::RealField;
 use num_traits::{Float, FromPrimitive};
 
@@ -8,12 +9,28 @@ use num_traits::{Float, FromPrimitive};
 /// Keeping the bound in one place makes it easier to support both `f32` and `f64` entry points
 /// without duplicating generic constraints everywhere else.
 pub trait Real:
-    Float + FromPrimitive + RealField + Copy + std::fmt::Debug + Send + Sync + 'static
+    Float
+    + FromPrimitive
+    + RealField
+    + CompensatedField
+    + Copy
+    + std::fmt::Debug
+    + Send
+    + Sync
+    + 'static
 {
 }
 
 impl<T> Real for T where
-    T: Float + FromPrimitive + RealField + Copy + std::fmt::Debug + Send + Sync + 'static
+    T: Float
+        + FromPrimitive
+        + RealField
+        + CompensatedField
+        + Copy
+        + std::fmt::Debug
+        + Send
+        + Sync
+        + 'static
 {
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -335,6 +335,82 @@ fn parse_solenoid_fem_quadrature(
         .map_err(|msg| PyInteropError::ValueError { msg }.into())
 }
 
+fn parse_solenoid_fem_solve_method<F: physics::solenoid_stress::Real>(
+    method: u8,
+    tolerance: Option<F>,
+    max_iterations: Option<usize>,
+    preconditioner: u8,
+    equilibration: u8,
+    equilibration_max_iterations: Option<usize>,
+    equilibration_tolerance: Option<F>,
+    equilibration_norm_floor: Option<F>,
+    equilibration_norm_ceil: Option<F>,
+    initial_guess: u8,
+) -> PyResult<physics::solenoid_stress::Structural2dSolveMethod<F>> {
+    match method {
+        0 => Ok(physics::solenoid_stress::Structural2dSolveMethod::Direct),
+        1 => {
+            let preconditioner = match preconditioner {
+                0 => physics::solenoid_stress::BicgstabPreconditioner::None,
+                1 => physics::solenoid_stress::BicgstabPreconditioner::Diagonal,
+                _ => {
+                    return Err(PyInteropError::ValueError {
+                        msg: "unsupported BiCGSTAB preconditioner code".to_string(),
+                    }
+                    .into());
+                }
+            };
+            let mut equilibration_options =
+                physics::solenoid_stress::EquilibrationSolveOptions::<F>::default();
+            if let Some(max_iterations) = equilibration_max_iterations {
+                equilibration_options.max_iterations = max_iterations;
+            }
+            if let Some(tolerance) = equilibration_tolerance {
+                equilibration_options.tolerance = tolerance;
+            }
+            if let Some(norm_floor) = equilibration_norm_floor {
+                equilibration_options.norm_floor = norm_floor;
+            }
+            if let Some(norm_ceil) = equilibration_norm_ceil {
+                equilibration_options.norm_ceil = norm_ceil;
+            }
+            let equilibration = match equilibration {
+                0 => physics::solenoid_stress::BicgstabEquilibration::None,
+                1 => physics::solenoid_stress::BicgstabEquilibration::Ruiz(equilibration_options),
+                _ => {
+                    return Err(PyInteropError::ValueError {
+                        msg: "unsupported BiCGSTAB equilibration code".to_string(),
+                    }
+                    .into());
+                }
+            };
+            let initial_guess = match initial_guess {
+                0 => physics::solenoid_stress::BicgstabInitialGuess::Zero,
+                1 => physics::solenoid_stress::BicgstabInitialGuess::Previous,
+                _ => {
+                    return Err(PyInteropError::ValueError {
+                        msg: "unsupported BiCGSTAB initial guess code".to_string(),
+                    }
+                    .into());
+                }
+            };
+            Ok(physics::solenoid_stress::Structural2dSolveMethod::Bicgstab(
+                physics::solenoid_stress::BicgstabSolveOptions {
+                    tolerance,
+                    max_iterations,
+                    preconditioner,
+                    equilibration,
+                    initial_guess,
+                },
+            ))
+        }
+        _ => Err(PyInteropError::ValueError {
+            msg: "unsupported structural solve method code".to_string(),
+        }
+        .into()),
+    }
+}
+
 fn flatten_points<F: Copy>(points: Vec<[F; 2]>) -> Vec<F> {
     let mut points_flat = Vec::with_capacity(points.len() * 2);
     for point in points {
@@ -728,17 +804,59 @@ macro_rules! impl_solenoid_stress_model_pyclass {
                 Ok(PyArray1::from_vec(py, rhs).unbind())
             }
 
+            #[pyo3(signature = (
+                rhs,
+                method=0,
+                tolerance=None,
+                max_iterations=None,
+                preconditioner=1,
+                equilibration=1,
+                equilibration_max_iterations=None,
+                equilibration_tolerance=None,
+                equilibration_norm_floor=None,
+                equilibration_norm_ceil=None,
+                initial_guess=0
+            ))]
             fn solve<'py>(
                 &mut self,
                 py: Python<'py>,
                 rhs: PyReadonlyArray1<'_, $ty>,
-            ) -> PyResult<Py<PyArray1<$ty>>> {
+                method: u8,
+                tolerance: Option<$ty>,
+                max_iterations: Option<usize>,
+                preconditioner: u8,
+                equilibration: u8,
+                equilibration_max_iterations: Option<usize>,
+                equilibration_tolerance: Option<$ty>,
+                equilibration_norm_floor: Option<$ty>,
+                equilibration_norm_ceil: Option<$ty>,
+                initial_guess: u8,
+            ) -> PyResult<(Py<PyArray1<$ty>>, u8, bool, usize, $ty, bool)> {
                 let rhs = rhs.as_slice()?;
-                let solution = self
+                let method = parse_solenoid_fem_solve_method(
+                    method,
+                    tolerance,
+                    max_iterations,
+                    preconditioner,
+                    equilibration,
+                    equilibration_max_iterations,
+                    equilibration_tolerance,
+                    equilibration_norm_floor,
+                    equilibration_norm_ceil,
+                    initial_guess,
+                )?;
+                let output = self
                     .inner
-                    .solve(rhs)
+                    .solve_with_method(rhs, method)
                     .map_err(|msg| PyInteropError::ValueError { msg })?;
-                Ok(PyArray1::from_vec(py, solution).unbind())
+                Ok((
+                    PyArray1::from_vec(py, output.displacement).unbind(),
+                    output.diagnostics.method.code(),
+                    output.diagnostics.converged,
+                    output.diagnostics.iterations,
+                    output.diagnostics.residual_norm,
+                    output.diagnostics.equilibrated,
+                ))
             }
 
             fn element_quadrature<'py>(

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -462,12 +462,12 @@ def kirsch_polar_stress(
     radius_ratio_4 = radius_ratio_2**2
     cos2 = np.cos(2.0 * theta)
     sin2 = np.sin(2.0 * theta)
-    sigma_rr = 0.5 * remote_stress * (
-        1.0 - radius_ratio_2 + (1.0 - 4.0 * radius_ratio_2 + 3.0 * radius_ratio_4) * cos2
+    sigma_rr = (
+        0.5
+        * remote_stress
+        * (1.0 - radius_ratio_2 + (1.0 - 4.0 * radius_ratio_2 + 3.0 * radius_ratio_4) * cos2)
     )
-    sigma_tt = 0.5 * remote_stress * (
-        1.0 + radius_ratio_2 - (1.0 + 3.0 * radius_ratio_4) * cos2
-    )
+    sigma_tt = 0.5 * remote_stress * (1.0 + radius_ratio_2 - (1.0 + 3.0 * radius_ratio_4) * cos2)
     sigma_rt = -0.5 * remote_stress * (1.0 + 2.0 * radius_ratio_2 - 3.0 * radius_ratio_4) * sin2
     return sigma_rr, sigma_tt, sigma_rt
 
@@ -630,7 +630,7 @@ def build_multimaterial_checkerboard_case(
 
 def tolerance(dtype: DType) -> tuple[float, float]:
     if dtype is np.float32:
-        return 5.0e-5, 5.0e-6
+        return 1e-3, 1e-5
     return 1.0e-12, 1.0e-12
 
 
@@ -827,18 +827,8 @@ def test_element_measures_and_quadrature_match_exact_cylindrical_shell_values(
     assert np.all(measures.volumes > 0.0)
     assert np.allclose(measures.areas.sum(), expected_area, rtol=rtol, atol=atol)
     assert np.allclose(measures.volumes.sum(), expected_volume, rtol=rtol, atol=atol)
-    assert np.allclose(
-        quadrature_data.weights_area.sum(axis=1),
-        measures.areas,
-        rtol=rtol,
-        atol=atol,
-    )
-    assert np.allclose(
-        quadrature_data.weights_volume.sum(axis=1),
-        measures.volumes,
-        rtol=rtol,
-        atol=atol,
-    )
+    assert np.allclose(quadrature_data.weights_area.sum(axis=1), measures.areas, rtol=rtol, atol=atol)
+    assert np.allclose(quadrature_data.weights_volume.sum(axis=1), measures.volumes, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
@@ -931,12 +921,7 @@ def test_parallel_structural_assembly_matches_serial(dtype: DType, element_type:
     )
     rtol, atol = tolerance(dtype)
 
-    assert np.allclose(
-        parallel.stiffness.toarray(),
-        serial.stiffness.toarray(),
-        rtol=rtol,
-        atol=atol,
-    )
+    assert np.allclose(parallel.stiffness.toarray(), serial.stiffness.toarray(), rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
@@ -956,14 +941,12 @@ def test_iterative_structural_solve_matches_direct_and_reports_diagnostics(
     )
 
     direct = model.solve(rhs)
-    solve_tolerance = 1.0e-9
-    if dtype is np.float32:
-        solve_tolerance = 1.0e-4 if equilibration == "ruiz" else 3.0e-6
+    solve_tolerance = 1e-3 if dtype is np.float32 else 1.0e-9
     iterative = model.solve(
         rhs,
         method="bicgstab",
         tolerance=solve_tolerance,
-        max_iterations=1000,
+        max_iterations=100,
         equilibration=equilibration,  # type: ignore[arg-type]
         return_diagnostics=True,
     )
@@ -973,12 +956,7 @@ def test_iterative_structural_solve_matches_direct_and_reports_diagnostics(
     assert iterative.diagnostics.converged
     assert iterative.diagnostics.iterations > 0
     assert iterative.diagnostics.equilibrated == (equilibration == "ruiz")
-    assert np.allclose(
-        iterative.displacement,
-        direct,
-        rtol=max(rtol, 5.0e-5),
-        atol=max(atol, 1.0e-8),
-    )
+    assert np.allclose(iterative.displacement, direct, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -940,6 +940,48 @@ def test_parallel_structural_assembly_matches_serial(dtype: DType, element_type:
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
+@pytest.mark.parametrize("equilibration", ["ruiz", "none"])
+def test_iterative_structural_solve_matches_direct_and_reports_diagnostics(
+    dtype: DType,
+    equilibration: str,
+) -> None:
+    nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=3, nz=2, dtype=dtype)
+    model, rhs = assemble_model_and_rhs(
+        nodes=nodes,
+        elements=elements,
+        material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
+        material_table=np.asarray([isotropic_axisymmetric_material(200.0, 0.27, dtype=dtype)]),
+        body_force=np.array([2.0, -1.0], dtype=dtype),
+        prescribed=prescribed_z_dofs(nodes.shape[0]),
+    )
+
+    direct = model.solve(rhs)
+    solve_tolerance = 1.0e-9
+    if dtype is np.float32:
+        solve_tolerance = 1.0e-4
+    iterative = model.solve(
+        rhs,
+        method="bicgstab",
+        tolerance=solve_tolerance,
+        max_iterations=1000,
+        equilibration=equilibration,  # type: ignore[arg-type]
+        return_diagnostics=True,
+    )
+    rtol, atol = tolerance(dtype)
+
+    assert iterative.diagnostics.method == "bicgstab"
+    assert iterative.diagnostics.converged
+    assert iterative.diagnostics.iterations > 0
+    assert iterative.diagnostics.equilibrated == (equilibration == "ruiz")
+    assert np.allclose(
+        iterative.displacement,
+        direct,
+        rtol=max(rtol, 5.0e-5),
+        atol=max(atol, 1.0e-8),
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
 @pytest.mark.parametrize("quadrature", QUADRATURES)
 def test_axisymmetric_model_reuses_factorization_across_load_cases(dtype: DType, quadrature: str) -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=4, nz=2, dtype=dtype)

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -941,7 +941,7 @@ def test_iterative_structural_solve_matches_direct_and_reports_diagnostics(
     )
 
     direct = model.solve(rhs)
-    solve_tolerance = 1e-3 if dtype is np.float32 else 1.0e-9
+    solve_tolerance = 1e-4 if dtype is np.float32 else 1.0e-9
     iterative = model.solve(
         rhs,
         method="bicgstab",

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -958,7 +958,7 @@ def test_iterative_structural_solve_matches_direct_and_reports_diagnostics(
     direct = model.solve(rhs)
     solve_tolerance = 1.0e-9
     if dtype is np.float32:
-        solve_tolerance = 1.0e-4
+        solve_tolerance = 1.0e-4 if equilibration == "ruiz" else 3.0e-6
     iterative = model.solve(
         rhs,
         method="bicgstab",


### PR DESCRIPTION
## 9.0.0 2026-06-05

* Rust
    * !Add thread-parallel stiffness matrix assembly for 2D FEM solver
    * Add direct/iterative solve selection for 2D FEM using BiCGSTAB with optional equilibration
    * Add optional iterative solve, equilibration, and preconditioning for 2D FEM solver
    * Run cargo-semver-checks during testing
* Python
    * Add bindings plumbing for iterative solver
    * Plumb parallel option into 2D FEM interface
    * Add 2D FEM solve diagnostics and BiCGSTAB options

