### PR TITLE
2D FEM speedups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 9.1.0 2026-06-08
+
+* Rust
+    * 2D FEM solver
+        * Build loads and recovery operators by row instead of via triplets to eliminate sorting overhead
+        * Sort chunks of stiffness matrix triplets on each worker thread, then merge sorted chunks on root thread
+        * Only export python operator copies if requested
+        * Roughly 4x speedup overall
+* Python
+    * Update 2D FEM bindings for lazy cached properties
+
 ## 9.0.0 2026-06-05
 
 * Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfsem"
-version = "9.0.0"
+version = "9.1.0"
 dependencies = [
  "criterion",
  "deimos_numerics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfsem"
-version = "9.0.0"
+version = "9.1.0"
 edition = "2024"
 authors = ["Commonwealth Fusion Systems <jlogan@cfs.energy>"]
 license = "MIT"

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -407,6 +407,14 @@ class Structural2DFEMModel:
         return self._input_elements
 
     def _temperature_elevation(self) -> sp.csr_matrix:
+        """Return the cached input-to-analysis temperature elevation operator.
+
+        Corner-node quad9 inputs are elevated inside the Rust backend before assembly, while the
+        Python API still accepts temperatures on the original input nodes.  This operator bridges
+        those two spaces for exported scipy operators.  It is cached because the input mesh and
+        inferred analysis mesh are immutable for the lifetime of the model.
+        """
+
         elevated = self._elevated
         assert elevated is not None, "temperature elevation is available only for inferred quad9 meshes"
         cache = self._temperature_elevation_cache
@@ -416,6 +424,12 @@ class Structural2DFEMModel:
         return cache
 
     def _cached_csc_export(self, attr: str, export: Callable[[], Any]) -> sp.csc_matrix:
+        """Export one Rust-owned CSC operator to scipy on first access.
+
+        The model is treated as immutable after assembly, so the cached scipy matrix remains valid
+        for every later access to the corresponding read-only property.
+        """
+
         cache = getattr(self, attr)
         if cache is None:
             cache = _csc_matrix_from_binding(export(), self.dtype)
@@ -423,6 +437,8 @@ class Structural2DFEMModel:
         return cast(sp.csc_matrix, cache)
 
     def _cached_csr_export(self, attr: str, export: Callable[[], Any]) -> sp.csr_matrix:
+        """Export one Rust-owned CSR operator to scipy on first access."""
+
         cache = getattr(self, attr)
         if cache is None:
             cache = _csr_matrix_from_binding(export(), self.dtype)
@@ -435,6 +451,13 @@ class Structural2DFEMModel:
         nrow: int,
         export: Callable[[], Any],
     ) -> sp.csr_matrix:
+        """Export a temperature-indexed CSR operator, including empty and elevated cases.
+
+        Models without thermal materials expose zero-column operators for shape consistency.
+        Inferred quad9 meshes export analysis-node operators from Rust, then postmultiply by the
+        cached elevation operator so the public scipy matrix acts on the original input nodes.
+        """
+
         cache = getattr(self, attr)
         if cache is not None:
             return cast(sp.csr_matrix, cache)

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -38,7 +38,7 @@ References:
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, overload, cast
 
@@ -278,7 +278,7 @@ class QuadMeshQuery:
 class Structural2DFEMModel:
     """Reusable 2D structural FEM model with sparse operators and reduced solve state.
 
-    The stored sparse operators are the primary reusable objects:
+    The sparse operators are exported from the Rust backend lazily:
     - `body_force_to_rhs`, `pressure_to_rhs`, `traction_to_rhs`, and `temperature_to_rhs`
       map load amplitudes to the reduced structural right-hand side,
     - `strain_operator`, `stress_operator`, `thermal_strain_operator`, and
@@ -286,8 +286,8 @@ class Structural2DFEMModel:
       fields.
 
     `build_rhs(...)`, `solve(...)`, `element_quadrature()`, `element_measures()`, and
-    `evaluate_quadrature(...)` are convenience methods layered on top of those stored operators
-    and the reduced stiffness matrix.
+    `evaluate_quadrature(...)` call the Rust backend directly and do not require these Python
+    sparse matrices to be materialized.
 
     Key public array shapes and units:
     - `stiffness` has shape `(ndof_reduced, ndof_reduced)` with entry units
@@ -318,17 +318,8 @@ class Structural2DFEMModel:
         formulation: str,
         thickness: float,
         element_type: str,
-        stiffness: sp.csc_matrix,
-        body_force_to_rhs: sp.csr_matrix,
-        pressure_to_rhs: sp.csr_matrix,
-        traction_to_rhs: sp.csr_matrix,
-        temperature_to_rhs: sp.csr_matrix,
         constant_rhs: npt.NDArray[np.floating[Any]],
         quadrature_points: npt.NDArray[np.floating[Any]],
-        strain_operator: sp.csr_matrix,
-        stress_operator: sp.csr_matrix,
-        thermal_strain_operator: sp.csr_matrix,
-        thermal_stress_operator: sp.csr_matrix,
         strain_constant: npt.NDArray[np.floating[Any]],
         stress_constant: npt.NDArray[np.floating[Any]],
         thermal_strain_constant: npt.NDArray[np.floating[Any]],
@@ -347,21 +338,12 @@ class Structural2DFEMModel:
         self._input_nodes = input_nodes
         self._input_elements = input_elements
         self._elevated = elevated
-        self.stiffness = stiffness
-        self.body_force_to_rhs = body_force_to_rhs
-        self.pressure_to_rhs = pressure_to_rhs
-        self.traction_to_rhs = traction_to_rhs
-        self.temperature_to_rhs = temperature_to_rhs
         self.constant_rhs = constant_rhs
         self.pressure_faces = pressure_faces
         self.traction_faces = traction_faces
         self.analysis_nodes = analysis_nodes
         self.analysis_elements = analysis_elements
         self.quadrature_points = quadrature_points
-        self.strain_operator = strain_operator
-        self.stress_operator = stress_operator
-        self.thermal_strain_operator = thermal_strain_operator
-        self.thermal_stress_operator = thermal_stress_operator
         self.strain_constant = strain_constant
         self.stress_constant = stress_constant
         self.thermal_strain_constant = thermal_strain_constant
@@ -389,10 +371,20 @@ class Structural2DFEMModel:
         self.n_temperature_nodes = int(n_temperature_nodes)
         self._element_quadrature_cache: ElementQuadrature | None = None
         self._element_measures_cache: ElementMeasures | None = None
+        self._temperature_elevation_cache: sp.csr_matrix | None = None
+        self._stiffness_cache: sp.csc_matrix | None = None
+        self._body_force_to_rhs_cache: sp.csr_matrix | None = None
+        self._pressure_to_rhs_cache: sp.csr_matrix | None = None
+        self._traction_to_rhs_cache: sp.csr_matrix | None = None
+        self._temperature_to_rhs_cache: sp.csr_matrix | None = None
+        self._strain_operator_cache: sp.csr_matrix | None = None
+        self._stress_operator_cache: sp.csr_matrix | None = None
+        self._thermal_strain_operator_cache: sp.csr_matrix | None = None
+        self._thermal_stress_operator_cache: sp.csr_matrix | None = None
 
     @property
     def dtype(self) -> np.dtype[Any]:
-        """Floating dtype used by all stored operators, arrays, and convenience-method outputs."""
+        """Floating dtype used by all exported operators, arrays, and convenience-method outputs."""
 
         return self._dtype
 
@@ -413,6 +405,151 @@ class Structural2DFEMModel:
         """Input mesh connectivity with shape `(nelem, 4)`."""
 
         return self._input_elements
+
+    def _temperature_elevation(self) -> sp.csr_matrix:
+        elevated = self._elevated
+        assert elevated is not None, "temperature elevation is available only for inferred quad9 meshes"
+        cache = self._temperature_elevation_cache
+        if cache is None:
+            cache = _temperature_elevation_operator(elevated, self.dtype)
+            self._temperature_elevation_cache = cache
+        return cache
+
+    def _cached_csc_export(self, attr: str, export: Callable[[], Any]) -> sp.csc_matrix:
+        cache = getattr(self, attr)
+        if cache is None:
+            cache = _csc_matrix_from_binding(export(), self.dtype)
+            setattr(self, attr, cache)
+        return cast(sp.csc_matrix, cache)
+
+    def _cached_csr_export(self, attr: str, export: Callable[[], Any]) -> sp.csr_matrix:
+        cache = getattr(self, attr)
+        if cache is None:
+            cache = _csr_matrix_from_binding(export(), self.dtype)
+            setattr(self, attr, cache)
+        return cast(sp.csr_matrix, cache)
+
+    def _cached_temperature_csr_export(
+        self,
+        attr: str,
+        nrow: int,
+        export: Callable[[], Any],
+    ) -> sp.csr_matrix:
+        cache = getattr(self, attr)
+        if cache is not None:
+            return cast(sp.csr_matrix, cache)
+        if self.n_temperature_nodes == 0:
+            cache = sp.csr_matrix((nrow, 0), dtype=self.dtype)
+        else:
+            analysis_operator = _csr_matrix_from_binding(export(), self.dtype)
+            cache = (
+                analysis_operator
+                if self._elevated is None
+                else _to_csr_matrix(analysis_operator @ self._temperature_elevation())
+            )
+        setattr(self, attr, cache)
+        return cache
+
+    @property
+    def stiffness(self) -> sp.csc_matrix:
+        """Reduced stiffness matrix with shape `(ndof_reduced, ndof_reduced)`.
+
+        Entries have units `[generalized force / displacement] = [energy / distance^2]`.
+        The SciPy matrix is exported from the Rust backend on first access and then cached.
+        """
+
+        return self._cached_csc_export("_stiffness_cache", self._backend.stiffness_csc)
+
+    @property
+    def body_force_to_rhs(self) -> sp.csr_matrix:
+        """Operator mapping per-element body-force density to the reduced RHS.
+
+        Shape is `(ndof_reduced, 2 * nelem)`. Entries have units `[volume]`.
+        """
+
+        return self._cached_csr_export("_body_force_to_rhs_cache", self._backend.body_force_to_rhs_csr)
+
+    @property
+    def pressure_to_rhs(self) -> sp.csr_matrix:
+        """Operator mapping scalar pressure amplitudes to the reduced RHS.
+
+        Shape is `(ndof_reduced, n_pressure_faces)`. Entries have units `[area]`.
+        """
+
+        return self._cached_csr_export("_pressure_to_rhs_cache", self._backend.pressure_to_rhs_csr)
+
+    @property
+    def traction_to_rhs(self) -> sp.csr_matrix:
+        """Operator mapping vector traction amplitudes to the reduced RHS.
+
+        Shape is `(ndof_reduced, 2 * n_traction_faces)`. Entries have units `[area]`.
+        """
+
+        return self._cached_csr_export("_traction_to_rhs_cache", self._backend.traction_to_rhs_csr)
+
+    @property
+    def temperature_to_rhs(self) -> sp.csr_matrix:
+        """Operator mapping input-node temperatures to the reduced RHS.
+
+        Shape is `(ndof_reduced, n_temperature_nodes)`. Entries have units
+        `[generalized force / temperature] = [energy / (distance * temperature)]`.
+        """
+
+        return self._cached_temperature_csr_export(
+            "_temperature_to_rhs_cache",
+            self.ndof_reduced,
+            self._backend.temperature_to_rhs_csr,
+        )
+
+    @property
+    def strain_operator(self) -> sp.csr_matrix:
+        """Operator mapping reduced displacement to quadrature-point total strain.
+
+        Shape is `(4 * nelem * nq_per_element, ndof_reduced)`. Entries have units
+        `[strain / displacement] = [1 / length]`.
+        """
+
+        return self._cached_csr_export("_strain_operator_cache", self._backend.strain_operator_csr)
+
+    @property
+    def stress_operator(self) -> sp.csr_matrix:
+        """Operator mapping reduced displacement to quadrature-point stress.
+
+        Shape is `(4 * nelem * nq_per_element, ndof_reduced)`. Entries have units
+        `[stress / displacement] = [pressure / length]`.
+        """
+
+        return self._cached_csr_export("_stress_operator_cache", self._backend.stress_operator_csr)
+
+    @property
+    def thermal_strain_operator(self) -> sp.csr_matrix:
+        """Operator mapping input-node temperatures to quadrature-point thermal strain.
+
+        Shape is `(4 * nelem * nq_per_element, n_temperature_nodes)`. Entries have units
+        `[strain / temperature]`.
+        """
+
+        nrow = self.nelem * self.nq_per_element * 4
+        return self._cached_temperature_csr_export(
+            "_thermal_strain_operator_cache",
+            nrow,
+            self._backend.thermal_strain_operator_csr,
+        )
+
+    @property
+    def thermal_stress_operator(self) -> sp.csr_matrix:
+        """Operator mapping input-node temperatures to quadrature-point thermal stress.
+
+        Shape is `(4 * nelem * nq_per_element, n_temperature_nodes)`. Entries have units
+        `[stress / temperature]`.
+        """
+
+        nrow = self.nelem * self.nq_per_element * 4
+        return self._cached_temperature_csr_export(
+            "_thermal_stress_operator_cache",
+            nrow,
+            self._backend.thermal_stress_operator_csr,
+        )
 
     def element_quadrature(self) -> ElementQuadrature:
         """Return physical quadrature points and mapped weights for each element.
@@ -515,12 +652,11 @@ class Structural2DFEMModel:
             if body_force is None
             else _normalize_body_force(body_force, self.nelem, self.dtype)
         )
-        _, nload = _sparse_shape(self.pressure_to_rhs)
-        pressure_arr = _normalize_pressure_values(pressure_values, nload, self.dtype)
-        _, ntraction_cols = _sparse_shape(self.traction_to_rhs)
+        npressure = int(self.pressure_faces.shape[0])
+        pressure_arr = _normalize_pressure_values(pressure_values, npressure, self.dtype)
         traction_arr = _normalize_traction_values(
             traction_values,
-            ntraction_cols // 2,
+            int(self.traction_faces.shape[0]),
             self.dtype,
         )
         temperature_arr = self._normalize_temperature_for_backend(nodal_temperature)
@@ -1596,8 +1732,8 @@ def assemble_structural_2d(
         par: Whether to assemble the stiffness matrix using threaded element batches.
 
     Returns:
-        Structural2DFEMModel: Reusable model storing the reduced stiffness matrix, sparse load
-        operators, sparse quadrature-recovery operators, and cached solve state.
+        Structural2DFEMModel: Reusable model with backend solve state and lazy Python sparse
+        operator exports.
 
     Raises:
         ValueError: If `quadrature` is unsupported.
@@ -1660,37 +1796,7 @@ def assemble_structural_2d(
         quadrature_code,
         par,
     )
-    stiffness = _csc_matrix_from_binding(backend.stiffness_csc(), dtype)
-    body_force_to_rhs = _csr_matrix_from_binding(backend.body_force_to_rhs_csr(), dtype)
-    pressure_to_rhs = _csr_matrix_from_binding(backend.pressure_to_rhs_csr(), dtype)
-    traction_to_rhs = _csr_matrix_from_binding(backend.traction_to_rhs_csr(), dtype)
-    analysis_temperature_to_rhs = _csr_matrix_from_binding(backend.temperature_to_rhs_csr(), dtype)
-    strain_operator = _csr_matrix_from_binding(backend.strain_operator_csr(), dtype)
-    stress_operator = _csr_matrix_from_binding(backend.stress_operator_csr(), dtype)
-    analysis_thermal_strain_operator = _csr_matrix_from_binding(
-        backend.thermal_strain_operator_csr(),
-        dtype,
-    )
-    analysis_thermal_stress_operator = _csr_matrix_from_binding(
-        backend.thermal_stress_operator_csr(),
-        dtype,
-    )
-    if thermal_material_table_arr is None:
-        temperature_to_rhs = sp.csr_matrix((int(backend.ndof_reduced), 0), dtype=dtype)
-        thermal_strain_operator = sp.csr_matrix((_sparse_shape(strain_operator)[0], 0), dtype=dtype)
-        thermal_stress_operator = sp.csr_matrix((_sparse_shape(stress_operator)[0], 0), dtype=dtype)
-        n_temperature_nodes = 0
-    else:
-        if elevated is None:
-            temperature_to_rhs = analysis_temperature_to_rhs
-            thermal_strain_operator = analysis_thermal_strain_operator
-            thermal_stress_operator = analysis_thermal_stress_operator
-        else:
-            temperature_elevation = _temperature_elevation_operator(elevated, dtype)
-            temperature_to_rhs = _to_csr_matrix(analysis_temperature_to_rhs @ temperature_elevation)
-            thermal_strain_operator = _to_csr_matrix(analysis_thermal_strain_operator @ temperature_elevation)
-            thermal_stress_operator = _to_csr_matrix(analysis_thermal_stress_operator @ temperature_elevation)
-        n_temperature_nodes = nodes_arr.shape[0]
+    n_temperature_nodes = 0 if thermal_material_table_arr is None else nodes_arr.shape[0]
 
     model = Structural2DFEMModel(
         backend=backend,
@@ -1705,20 +1811,11 @@ def assemble_structural_2d(
         formulation=normalized_formulation,
         thickness=thickness_value,
         element_type=normalized_element_type,
-        stiffness=stiffness,
-        body_force_to_rhs=body_force_to_rhs,
-        pressure_to_rhs=pressure_to_rhs,
-        traction_to_rhs=traction_to_rhs,
-        temperature_to_rhs=_to_csr_matrix(temperature_to_rhs),
         constant_rhs=np.asarray(backend.constant_rhs(), dtype=dtype),
         quadrature_points=np.asarray(
             backend.quadrature_points_flat(),
             dtype=dtype,
         ).reshape(analysis_elements.shape[0], int(backend.nq_per_element), 2),
-        strain_operator=strain_operator,
-        stress_operator=stress_operator,
-        thermal_strain_operator=_to_csr_matrix(thermal_strain_operator),
-        thermal_stress_operator=_to_csr_matrix(thermal_stress_operator),
         strain_constant=np.asarray(backend.strain_constant(), dtype=dtype),
         stress_constant=np.asarray(backend.stress_constant(), dtype=dtype),
         thermal_strain_constant=np.asarray(backend.thermal_strain_constant(), dtype=dtype),

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -38,8 +38,6 @@ References:
 
 from __future__ import annotations
 
-import os
-import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, overload, cast
@@ -93,17 +91,6 @@ _orthotropic_axisymmetric_thermal_material_f64 = (
 
 ArrayLike = npt.ArrayLike
 _QUAD_FACE_NODE_PAIRS: tuple[tuple[int, int], ...] = ((0, 1), (1, 2), (2, 3), (3, 0))
-
-
-def _timing_enabled() -> bool:
-    return os.environ.get("CFSEM_TIMING", "").lower() not in {"", "0", "false", "no", "off"}
-
-
-def _timing_log(label: str, elapsed_s: float, **metadata: int | str) -> None:
-    if not _timing_enabled():
-        return
-    suffix = " ".join(f"{key}={value}" for key, value in metadata.items())
-    print(f"[cfsem timing] {label}: {elapsed_s:.6f} s {suffix}".rstrip(), flush=True)
 
 
 def _to_csr_matrix(matrix: Any) -> sp.csr_matrix:
@@ -537,18 +524,11 @@ class Structural2DFEMModel:
             self.dtype,
         )
         temperature_arr = self._normalize_temperature_for_backend(nodal_temperature)
-        start = time.perf_counter()
         rhs = self._backend.build_rhs(
             body_force_arr.reshape(-1),
             pressure_arr if pressure_arr.size else None,
             traction_arr.reshape(-1) if traction_arr.size else None,
             temperature_arr,
-        )
-        _timing_log(
-            "Structural2DFEMModel.build_rhs",
-            time.perf_counter() - start,
-            nelem=self.nelem,
-            ndof_reduced=self.ndof_reduced,
         )
         return np.asarray(rhs, dtype=self.dtype)
 
@@ -641,7 +621,6 @@ class Structural2DFEMModel:
         assert (
             norm_floor is None or norm_ceil is None or norm_ceil > norm_floor
         ), "equilibration_norm_ceil must be greater than equilibration_norm_floor"
-        start = time.perf_counter()
         (
             displacement_raw,
             method_code,
@@ -661,12 +640,6 @@ class Structural2DFEMModel:
             norm_floor,
             norm_ceil,
             _bicgstab_initial_guess_code(initial_guess),
-        )
-        _timing_log(
-            "Structural2DFEMModel.solve",
-            time.perf_counter() - start,
-            method=method,
-            ndof_reduced=self.ndof_reduced,
         )
         displacement = np.asarray(displacement_raw, dtype=self.dtype)
         if not return_diagnostics:
@@ -737,7 +710,6 @@ class Structural2DFEMModel:
                 displacements, self.analysis_nodes.shape[0], self.dtype
             ).reshape(-1)
         temperature_arr = self._normalize_temperature_for_backend(nodal_temperature)
-        start = time.perf_counter()
         (
             points_flat,
             strain_flat,
@@ -746,12 +718,6 @@ class Structural2DFEMModel:
             stress_flat,
             nq,
         ) = self._backend.evaluate_quadrature(displacements_full, temperature_arr)
-        _timing_log(
-            "Structural2DFEMModel.evaluate_quadrature",
-            time.perf_counter() - start,
-            nelem=self.nelem,
-            ndof_full=self.ndof_full,
-        )
         nelem = self.analysis_elements.shape[0]
         nq = int(nq)
         return QuadratureFieldSamples(
@@ -993,7 +959,6 @@ def query_quad_mesh(
         and index arrays are unitless.
     """
 
-    total_start = time.perf_counter()
     dtype = _resolve_float_dtype(nodes, points)
     normalized_element_type = _normalize_element_type(element_type)
     nodes_arr = _normalize_nodes(nodes, dtype)
@@ -1003,7 +968,6 @@ def query_quad_mesh(
     )
     points_arr = _normalize_query_points(points, dtype)
     binding = _dispatch_pair(dtype, _quad_mesh_query_f32, _quad_mesh_query_f64)
-    binding_start = time.perf_counter()
     data = binding(
         nodes_arr,
         elements_arr,
@@ -1011,16 +975,8 @@ def query_quad_mesh(
         normalized_element_type,
         int(max_iterations),
     )
-    _timing_log(
-        "query_quad_mesh.low_level",
-        time.perf_counter() - binding_start,
-        nnode=nodes_arr.shape[0],
-        nelem=elements_arr.shape[0],
-        npoint=points_arr.shape[0],
-        element_type=normalized_element_type,
-    )
 
-    result = QuadMeshQuery(
+    return QuadMeshQuery(
         nodes=nodes_arr,
         elements=elements_arr,
         points=points_arr,
@@ -1044,15 +1000,6 @@ def query_quad_mesh(
         nearest_face_points=np.asarray(data["nearest_face_points"], dtype=dtype).reshape(-1, 2),
         nearest_face_distances=np.asarray(data["nearest_face_distances"], dtype=dtype),
     )
-    _timing_log(
-        "query_quad_mesh.total",
-        time.perf_counter() - total_start,
-        nnode=nodes_arr.shape[0],
-        nelem=elements_arr.shape[0],
-        npoint=points_arr.shape[0],
-        element_type=normalized_element_type,
-    )
-    return result
 
 
 def quad_mesh_interpolation_operator(
@@ -1658,8 +1605,6 @@ def assemble_structural_2d(
             instead of dense arrays.
     """
 
-    total_start = time.perf_counter()
-    normalize_start = time.perf_counter()
     dtype = _resolve_float_dtype(nodes, material_table, thermal_material_table)
     nodes_arr = _normalize_nodes(nodes, dtype)
     material_ids_arr, material_table_arr = _normalize_materials(material_ids, material_table, dtype)
@@ -1689,19 +1634,11 @@ def assemble_structural_2d(
         int(analysis_elements.shape[0]),
         dtype,
     )
-    _timing_log(
-        "assemble_structural_2d.normalize_inputs",
-        time.perf_counter() - normalize_start,
-        nnode=analysis_nodes.shape[0],
-        nelem=analysis_elements.shape[0],
-        element_type=normalized_element_type,
-    )
     low_level = _dispatch_pair(
         dtype,
         _assemble_model_2d_f32,
         _assemble_model_2d_f64,
     )
-    low_level_start = time.perf_counter()
     backend = low_level(
         analysis_nodes,
         analysis_elements,
@@ -1723,82 +1660,20 @@ def assemble_structural_2d(
         quadrature_code,
         par,
     )
-    _timing_log(
-        "assemble_structural_2d.low_level_rust",
-        time.perf_counter() - low_level_start,
-        nnode=analysis_nodes.shape[0],
-        nelem=analysis_elements.shape[0],
-        par=str(par),
-    )
-
-    convert_start = time.perf_counter()
     stiffness = _csc_matrix_from_binding(backend.stiffness_csc(), dtype)
-    _timing_log(
-        "assemble_structural_2d.export_stiffness_csc",
-        time.perf_counter() - convert_start,
-        nnz=stiffness.nnz,
-    )
-    convert_start = time.perf_counter()
     body_force_to_rhs = _csr_matrix_from_binding(backend.body_force_to_rhs_csr(), dtype)
-    _timing_log(
-        "assemble_structural_2d.export_body_force_to_rhs",
-        time.perf_counter() - convert_start,
-        nnz=body_force_to_rhs.nnz,
-    )
-    convert_start = time.perf_counter()
     pressure_to_rhs = _csr_matrix_from_binding(backend.pressure_to_rhs_csr(), dtype)
-    _timing_log(
-        "assemble_structural_2d.export_pressure_to_rhs",
-        time.perf_counter() - convert_start,
-        nnz=pressure_to_rhs.nnz,
-    )
-    convert_start = time.perf_counter()
     traction_to_rhs = _csr_matrix_from_binding(backend.traction_to_rhs_csr(), dtype)
-    _timing_log(
-        "assemble_structural_2d.export_traction_to_rhs",
-        time.perf_counter() - convert_start,
-        nnz=traction_to_rhs.nnz,
-    )
-    convert_start = time.perf_counter()
     analysis_temperature_to_rhs = _csr_matrix_from_binding(backend.temperature_to_rhs_csr(), dtype)
-    _timing_log(
-        "assemble_structural_2d.export_temperature_to_rhs",
-        time.perf_counter() - convert_start,
-        nnz=analysis_temperature_to_rhs.nnz,
-    )
-    convert_start = time.perf_counter()
     strain_operator = _csr_matrix_from_binding(backend.strain_operator_csr(), dtype)
-    _timing_log(
-        "assemble_structural_2d.export_strain_operator",
-        time.perf_counter() - convert_start,
-        nnz=strain_operator.nnz,
-    )
-    convert_start = time.perf_counter()
     stress_operator = _csr_matrix_from_binding(backend.stress_operator_csr(), dtype)
-    _timing_log(
-        "assemble_structural_2d.export_stress_operator",
-        time.perf_counter() - convert_start,
-        nnz=stress_operator.nnz,
-    )
-    convert_start = time.perf_counter()
     analysis_thermal_strain_operator = _csr_matrix_from_binding(
         backend.thermal_strain_operator_csr(),
         dtype,
     )
-    _timing_log(
-        "assemble_structural_2d.export_thermal_strain_operator",
-        time.perf_counter() - convert_start,
-        nnz=analysis_thermal_strain_operator.nnz,
-    )
-    convert_start = time.perf_counter()
     analysis_thermal_stress_operator = _csr_matrix_from_binding(
         backend.thermal_stress_operator_csr(),
         dtype,
-    )
-    _timing_log(
-        "assemble_structural_2d.export_thermal_stress_operator",
-        time.perf_counter() - convert_start,
-        nnz=analysis_thermal_stress_operator.nnz,
     )
     if thermal_material_table_arr is None:
         temperature_to_rhs = sp.csr_matrix((int(backend.ndof_reduced), 0), dtype=dtype)
@@ -1856,13 +1731,6 @@ def assemble_structural_2d(
         nelem=elements_arr.shape[0],
         nq_per_element=int(backend.nq_per_element),
         n_temperature_nodes=n_temperature_nodes,
-    )
-    _timing_log(
-        "assemble_structural_2d.total",
-        time.perf_counter() - total_start,
-        nnode=analysis_nodes.shape[0],
-        nelem=analysis_elements.shape[0],
-        ndof_reduced=int(backend.ndof_reduced),
     )
     return model
 

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -1752,7 +1752,8 @@ def assemble_structural_2d(
             value. Displacement units are `[length]`.
         quadrature: Quadrature rule selector, either `gl3`, `gl4`, `3`, or `4`.
         element_type: Analysis element family, either `quad4` or `quad9`.
-        par: Whether to assemble the stiffness matrix using threaded element batches.
+        par: Whether to assemble stiffness, load, and recovery operators using threaded
+            element batches.
 
     Returns:
         Structural2DFEMModel: Reusable model with backend solve state and lazy Python sparse

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -105,12 +105,6 @@ def _to_csc_matrix(matrix: Any) -> sp.csc_matrix:
     return cast(sp.csc_matrix, sp.csc_matrix(matrix))
 
 
-def _sparse_shape(matrix: Any) -> tuple[int, int]:
-    """Return a concrete 2D sparse shape for pyright and runtime callers."""
-
-    return cast(tuple[int, int], matrix.shape)
-
-
 def _as_float_array(data: Any, dtype: np.dtype[Any]) -> npt.NDArray[np.floating[Any]]:
     """Convert binding output to a NumPy floating array with an explicit static type."""
 
@@ -461,15 +455,12 @@ class Structural2DFEMModel:
         cache = getattr(self, attr)
         if cache is not None:
             return cast(sp.csr_matrix, cache)
-        if self.n_temperature_nodes == 0:
-            cache = sp.csr_matrix((nrow, 0), dtype=self.dtype)
-        else:
-            analysis_operator = _csr_matrix_from_binding(export(), self.dtype)
-            cache = (
-                analysis_operator
-                if self._elevated is None
-                else _to_csr_matrix(analysis_operator @ self._temperature_elevation())
-            )
+        analysis_operator = _csr_matrix_from_binding(export(), self.dtype)
+        cache = (
+            _to_csr_matrix(analysis_operator @ self._temperature_elevation())
+            if self._elevated is not None and self.n_temperature_nodes > 0
+            else analysis_operator
+        )
         setattr(self, attr, cache)
         return cache
 

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -38,6 +38,8 @@ References:
 
 from __future__ import annotations
 
+import os
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, overload, cast
@@ -91,6 +93,17 @@ _orthotropic_axisymmetric_thermal_material_f64 = (
 
 ArrayLike = npt.ArrayLike
 _QUAD_FACE_NODE_PAIRS: tuple[tuple[int, int], ...] = ((0, 1), (1, 2), (2, 3), (3, 0))
+
+
+def _timing_enabled() -> bool:
+    return os.environ.get("CFSEM_TIMING", "").lower() not in {"", "0", "false", "no", "off"}
+
+
+def _timing_log(label: str, elapsed_s: float, **metadata: int | str) -> None:
+    if not _timing_enabled():
+        return
+    suffix = " ".join(f"{key}={value}" for key, value in metadata.items())
+    print(f"[cfsem timing] {label}: {elapsed_s:.6f} s {suffix}".rstrip(), flush=True)
 
 
 def _to_csr_matrix(matrix: Any) -> sp.csr_matrix:
@@ -524,11 +537,18 @@ class Structural2DFEMModel:
             self.dtype,
         )
         temperature_arr = self._normalize_temperature_for_backend(nodal_temperature)
+        start = time.perf_counter()
         rhs = self._backend.build_rhs(
             body_force_arr.reshape(-1),
             pressure_arr if pressure_arr.size else None,
             traction_arr.reshape(-1) if traction_arr.size else None,
             temperature_arr,
+        )
+        _timing_log(
+            "Structural2DFEMModel.build_rhs",
+            time.perf_counter() - start,
+            nelem=self.nelem,
+            ndof_reduced=self.ndof_reduced,
         )
         return np.asarray(rhs, dtype=self.dtype)
 
@@ -621,6 +641,7 @@ class Structural2DFEMModel:
         assert (
             norm_floor is None or norm_ceil is None or norm_ceil > norm_floor
         ), "equilibration_norm_ceil must be greater than equilibration_norm_floor"
+        start = time.perf_counter()
         (
             displacement_raw,
             method_code,
@@ -640,6 +661,12 @@ class Structural2DFEMModel:
             norm_floor,
             norm_ceil,
             _bicgstab_initial_guess_code(initial_guess),
+        )
+        _timing_log(
+            "Structural2DFEMModel.solve",
+            time.perf_counter() - start,
+            method=method,
+            ndof_reduced=self.ndof_reduced,
         )
         displacement = np.asarray(displacement_raw, dtype=self.dtype)
         if not return_diagnostics:
@@ -710,6 +737,7 @@ class Structural2DFEMModel:
                 displacements, self.analysis_nodes.shape[0], self.dtype
             ).reshape(-1)
         temperature_arr = self._normalize_temperature_for_backend(nodal_temperature)
+        start = time.perf_counter()
         (
             points_flat,
             strain_flat,
@@ -718,6 +746,12 @@ class Structural2DFEMModel:
             stress_flat,
             nq,
         ) = self._backend.evaluate_quadrature(displacements_full, temperature_arr)
+        _timing_log(
+            "Structural2DFEMModel.evaluate_quadrature",
+            time.perf_counter() - start,
+            nelem=self.nelem,
+            ndof_full=self.ndof_full,
+        )
         nelem = self.analysis_elements.shape[0]
         nq = int(nq)
         return QuadratureFieldSamples(
@@ -959,6 +993,7 @@ def query_quad_mesh(
         and index arrays are unitless.
     """
 
+    total_start = time.perf_counter()
     dtype = _resolve_float_dtype(nodes, points)
     normalized_element_type = _normalize_element_type(element_type)
     nodes_arr = _normalize_nodes(nodes, dtype)
@@ -968,6 +1003,7 @@ def query_quad_mesh(
     )
     points_arr = _normalize_query_points(points, dtype)
     binding = _dispatch_pair(dtype, _quad_mesh_query_f32, _quad_mesh_query_f64)
+    binding_start = time.perf_counter()
     data = binding(
         nodes_arr,
         elements_arr,
@@ -975,8 +1011,16 @@ def query_quad_mesh(
         normalized_element_type,
         int(max_iterations),
     )
+    _timing_log(
+        "query_quad_mesh.low_level",
+        time.perf_counter() - binding_start,
+        nnode=nodes_arr.shape[0],
+        nelem=elements_arr.shape[0],
+        npoint=points_arr.shape[0],
+        element_type=normalized_element_type,
+    )
 
-    return QuadMeshQuery(
+    result = QuadMeshQuery(
         nodes=nodes_arr,
         elements=elements_arr,
         points=points_arr,
@@ -1000,6 +1044,15 @@ def query_quad_mesh(
         nearest_face_points=np.asarray(data["nearest_face_points"], dtype=dtype).reshape(-1, 2),
         nearest_face_distances=np.asarray(data["nearest_face_distances"], dtype=dtype),
     )
+    _timing_log(
+        "query_quad_mesh.total",
+        time.perf_counter() - total_start,
+        nnode=nodes_arr.shape[0],
+        nelem=elements_arr.shape[0],
+        npoint=points_arr.shape[0],
+        element_type=normalized_element_type,
+    )
+    return result
 
 
 def quad_mesh_interpolation_operator(
@@ -1605,6 +1658,8 @@ def assemble_structural_2d(
             instead of dense arrays.
     """
 
+    total_start = time.perf_counter()
+    normalize_start = time.perf_counter()
     dtype = _resolve_float_dtype(nodes, material_table, thermal_material_table)
     nodes_arr = _normalize_nodes(nodes, dtype)
     material_ids_arr, material_table_arr = _normalize_materials(material_ids, material_table, dtype)
@@ -1634,11 +1689,19 @@ def assemble_structural_2d(
         int(analysis_elements.shape[0]),
         dtype,
     )
+    _timing_log(
+        "assemble_structural_2d.normalize_inputs",
+        time.perf_counter() - normalize_start,
+        nnode=analysis_nodes.shape[0],
+        nelem=analysis_elements.shape[0],
+        element_type=normalized_element_type,
+    )
     low_level = _dispatch_pair(
         dtype,
         _assemble_model_2d_f32,
         _assemble_model_2d_f64,
     )
+    low_level_start = time.perf_counter()
     backend = low_level(
         analysis_nodes,
         analysis_elements,
@@ -1660,21 +1723,82 @@ def assemble_structural_2d(
         quadrature_code,
         par,
     )
+    _timing_log(
+        "assemble_structural_2d.low_level_rust",
+        time.perf_counter() - low_level_start,
+        nnode=analysis_nodes.shape[0],
+        nelem=analysis_elements.shape[0],
+        par=str(par),
+    )
 
+    convert_start = time.perf_counter()
     stiffness = _csc_matrix_from_binding(backend.stiffness_csc(), dtype)
+    _timing_log(
+        "assemble_structural_2d.export_stiffness_csc",
+        time.perf_counter() - convert_start,
+        nnz=stiffness.nnz,
+    )
+    convert_start = time.perf_counter()
     body_force_to_rhs = _csr_matrix_from_binding(backend.body_force_to_rhs_csr(), dtype)
+    _timing_log(
+        "assemble_structural_2d.export_body_force_to_rhs",
+        time.perf_counter() - convert_start,
+        nnz=body_force_to_rhs.nnz,
+    )
+    convert_start = time.perf_counter()
     pressure_to_rhs = _csr_matrix_from_binding(backend.pressure_to_rhs_csr(), dtype)
+    _timing_log(
+        "assemble_structural_2d.export_pressure_to_rhs",
+        time.perf_counter() - convert_start,
+        nnz=pressure_to_rhs.nnz,
+    )
+    convert_start = time.perf_counter()
     traction_to_rhs = _csr_matrix_from_binding(backend.traction_to_rhs_csr(), dtype)
+    _timing_log(
+        "assemble_structural_2d.export_traction_to_rhs",
+        time.perf_counter() - convert_start,
+        nnz=traction_to_rhs.nnz,
+    )
+    convert_start = time.perf_counter()
     analysis_temperature_to_rhs = _csr_matrix_from_binding(backend.temperature_to_rhs_csr(), dtype)
+    _timing_log(
+        "assemble_structural_2d.export_temperature_to_rhs",
+        time.perf_counter() - convert_start,
+        nnz=analysis_temperature_to_rhs.nnz,
+    )
+    convert_start = time.perf_counter()
     strain_operator = _csr_matrix_from_binding(backend.strain_operator_csr(), dtype)
+    _timing_log(
+        "assemble_structural_2d.export_strain_operator",
+        time.perf_counter() - convert_start,
+        nnz=strain_operator.nnz,
+    )
+    convert_start = time.perf_counter()
     stress_operator = _csr_matrix_from_binding(backend.stress_operator_csr(), dtype)
+    _timing_log(
+        "assemble_structural_2d.export_stress_operator",
+        time.perf_counter() - convert_start,
+        nnz=stress_operator.nnz,
+    )
+    convert_start = time.perf_counter()
     analysis_thermal_strain_operator = _csr_matrix_from_binding(
         backend.thermal_strain_operator_csr(),
         dtype,
     )
+    _timing_log(
+        "assemble_structural_2d.export_thermal_strain_operator",
+        time.perf_counter() - convert_start,
+        nnz=analysis_thermal_strain_operator.nnz,
+    )
+    convert_start = time.perf_counter()
     analysis_thermal_stress_operator = _csr_matrix_from_binding(
         backend.thermal_stress_operator_csr(),
         dtype,
+    )
+    _timing_log(
+        "assemble_structural_2d.export_thermal_stress_operator",
+        time.perf_counter() - convert_start,
+        nnz=analysis_thermal_stress_operator.nnz,
     )
     if thermal_material_table_arr is None:
         temperature_to_rhs = sp.csr_matrix((int(backend.ndof_reduced), 0), dtype=dtype)
@@ -1693,7 +1817,7 @@ def assemble_structural_2d(
             thermal_stress_operator = _to_csr_matrix(analysis_thermal_stress_operator @ temperature_elevation)
         n_temperature_nodes = nodes_arr.shape[0]
 
-    return Structural2DFEMModel(
+    model = Structural2DFEMModel(
         backend=backend,
         dtype=dtype,
         input_nodes=nodes_arr,
@@ -1733,6 +1857,14 @@ def assemble_structural_2d(
         nq_per_element=int(backend.nq_per_element),
         n_temperature_nodes=n_temperature_nodes,
     )
+    _timing_log(
+        "assemble_structural_2d.total",
+        time.perf_counter() - total_start,
+        nnode=analysis_nodes.shape[0],
+        nelem=analysis_elements.shape[0],
+        ndof_reduced=int(backend.ndof_reduced),
+    )
+    return model
 
 
 def isotropic_axisymmetric_material(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,18 @@ pub(crate) fn chunksize(nelem: usize) -> usize {
     (nelem / ncores).max(1)
 }
 
+/// Contiguous half-open ranges covering `0..len`.
+pub(crate) fn ranges_for_len(len: usize, chunk: usize) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::with_capacity(len.div_ceil(chunk));
+    let mut start = 0;
+    while start < len {
+        let end = (start + chunk).min(len);
+        ranges.push((start, end));
+        start = end;
+    }
+    ranges
+}
+
 #[macro_use]
 pub(crate) mod macros {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,10 @@ pub const MU_0: f64 = 0.999_999_999_87 * core::f64::consts::PI * 4e-7; // [H/m]
 /// (H/m) Recurring constant multiple of `mu_0`
 pub const MU0_OVER_4PI: f64 = MU_0 / (4.0 * core::f64::consts::PI);
 
-/// Chunk size for parallelism
+/// Chunk size for Rayon-parallel FEM assembly loops.
+///
+/// The heuristic aims for one chunk per physical core.  It intentionally returns at least one so
+/// small meshes keep the same code path without special-case empty chunk handling.
 pub(crate) fn chunksize(nelem: usize) -> usize {
     let ncores = std::thread::available_parallelism()
         .unwrap_or(NonZeroUsize::MIN)
@@ -39,6 +42,9 @@ pub(crate) fn chunksize(nelem: usize) -> usize {
 }
 
 /// Contiguous half-open ranges covering `0..len`.
+///
+/// The returned ranges preserve source ordering, which lets callers concatenate independently
+/// assembled chunks without reindexing rows or columns.
 pub(crate) fn ranges_for_len(len: usize, chunk: usize) -> Vec<(usize, usize)> {
     let mut ranges = Vec::with_capacity(len.div_ceil(chunk));
     let mut start = 0;

--- a/src/physics/solenoid_stress/assembly.rs
+++ b/src/physics/solenoid_stress/assembly.rs
@@ -60,6 +60,7 @@ where
 /// Each worker owns an independent triplet buffer, so the element kernel has no shared mutable
 /// state.  The per-range triplets are concatenated in element order before the existing
 /// constrained-system reduction and sparse compression stages consume them.
+#[cfg(test)]
 pub(crate) fn assemble_stiffness_for_family_par<
     F: Real,
     Family,
@@ -73,6 +74,39 @@ pub(crate) fn assemble_stiffness_for_family_par<
     formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
 ) -> Result<StiffnessTriplets<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    let chunks =
+        assemble_stiffness_chunks_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            material_ids,
+            material_table,
+            material_orientation_angles,
+            formulation,
+            quadrature,
+        )?;
+
+    Ok(concat_stiffness_triplets(
+        chunks,
+        mesh.num_elements() * DOF_PER_ELEMENT * DOF_PER_ELEMENT,
+    ))
+}
+
+/// Assemble full-space stiffness triplet chunks with element ranges split across Rayon workers.
+pub(crate) fn assemble_stiffness_chunks_for_family_par<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+) -> Result<Vec<StiffnessTriplets<F>>, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -92,7 +126,7 @@ where
         start = end;
     }
 
-    let chunks = ranges
+    ranges
         .into_par_iter()
         .map(|(start, end)| {
             assemble_stiffness_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
@@ -106,12 +140,7 @@ where
                 end,
             )
         })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(concat_stiffness_triplets(
-        chunks,
-        nelem * DOF_PER_ELEMENT * DOF_PER_ELEMENT,
-    ))
+        .collect()
 }
 
 /// Validate shape and material inputs shared by serial and threaded stiffness assembly.
@@ -203,6 +232,7 @@ where
 }
 
 /// Concatenate independently assembled triplet chunks without changing element order.
+#[cfg(test)]
 fn concat_stiffness_triplets<F: Real>(
     chunks: Vec<StiffnessTriplets<F>>,
     capacity: usize,

--- a/src/physics/solenoid_stress/assembly.rs
+++ b/src/physics/solenoid_stress/assembly.rs
@@ -5,7 +5,6 @@
 
 use rayon::prelude::*;
 
-use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::axisym::{accumulate_stiffness, build_b_matrix};
 use crate::physics::solenoid_stress::convenience::rotate_material_in_plane;
@@ -15,6 +14,7 @@ use crate::physics::solenoid_stress::types::{
     DOF_PER_NODE, Real, StiffnessTriplets, Structural2dFormulation, local_dofs,
     validate_element_material_inputs,
 };
+use crate::{chunksize, ranges_for_len};
 
 /// Assemble the full unconstrained stiffness matrix for one quadrilateral family.
 ///
@@ -117,16 +117,8 @@ where
         formulation,
     )?;
     let nelem = mesh.num_elements();
-    let chunk = chunksize(nelem);
-    let mut ranges = Vec::with_capacity(nelem.div_ceil(chunk));
-    let mut start = 0;
-    while start < nelem {
-        let end = (start + chunk).min(nelem);
-        ranges.push((start, end));
-        start = end;
-    }
 
-    ranges
+    ranges_for_len(nelem, chunksize(nelem))
         .into_par_iter()
         .map(|(start, end)| {
             assemble_stiffness_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(

--- a/src/physics/solenoid_stress/loads/body_force.rs
+++ b/src/physics/solenoid_stress/loads/body_force.rs
@@ -1,3 +1,6 @@
+use rayon::prelude::*;
+
+use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
@@ -5,7 +8,7 @@ use crate::physics::solenoid_stress::types::{
     DOF_PER_NODE, Real, Structural2dFormulation, local_dofs, scatter_local_matrix,
 };
 
-use super::SparseOperator;
+use super::{SparseOperator, concat_sparse_operators, ranges_for_len};
 
 /// Build the local dense body-force operator for one element.
 ///
@@ -73,13 +76,79 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
+    body_force_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        mesh,
+        formulation,
+        quadrature,
+        0,
+        mesh.num_elements(),
+    )
+}
+
+/// Assemble the global body-force-to-RHS operator using element ranges split across Rayon workers.
+pub(crate) fn body_force_operator_for_family_par<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+) -> Result<SparseOperator<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    const {
+        assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
+    }
+    validate_structural_2d_mesh(mesh, formulation)?;
+    let nelem = mesh.num_elements();
+    let ranges = ranges_for_len(nelem, chunksize(nelem));
+    let chunks = ranges
+        .into_par_iter()
+        .map(|(start, end)| {
+            body_force_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                formulation,
+                quadrature,
+                start,
+                end,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(concat_sparse_operators(
+        chunks,
+        mesh.num_nodes() * 2,
+        2 * nelem,
+        nelem * DOF_PER_ELEMENT * 2,
+    ))
+}
+
+fn body_force_operator_range_for_family<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+    element_start: usize,
+    element_end: usize,
+) -> Result<SparseOperator<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
     let ndof = mesh.num_nodes() * 2;
     let ncol = 2 * mesh.num_elements();
-    let mut rows = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * 2);
-    let mut cols = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * 2);
-    let mut vals = Vec::with_capacity(mesh.num_elements() * DOF_PER_ELEMENT * 2);
+    let nelem = element_end - element_start;
+    let mut rows = Vec::with_capacity(nelem * DOF_PER_ELEMENT * 2);
+    let mut cols = Vec::with_capacity(nelem * DOF_PER_ELEMENT * 2);
+    let mut vals = Vec::with_capacity(nelem * DOF_PER_ELEMENT * 2);
 
-    for element_index in 0..mesh.num_elements() {
+    for element_index in element_start..element_end {
         let coords = mesh.element_coords(element_index)?;
         let nodes = mesh.element_nodes(element_index)?;
         let samples = Family::volume_samples::<F>(&coords, quadrature)?;

--- a/src/physics/solenoid_stress/loads/body_force.rs
+++ b/src/physics/solenoid_stress/loads/body_force.rs
@@ -1,6 +1,3 @@
-use rayon::prelude::*;
-
-use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
@@ -8,7 +5,7 @@ use crate::physics::solenoid_stress::types::{
     DOF_PER_NODE, Real, Structural2dFormulation, local_dofs, scatter_local_matrix,
 };
 
-use super::{SparseOperator, concat_sparse_operators, ranges_for_len};
+use super::{SparseOperator, collect_sparse_operator_chunks, concat_sparse_operators};
 
 /// Build the local dense body-force operator for one element.
 ///
@@ -104,19 +101,15 @@ where
     }
     validate_structural_2d_mesh(mesh, formulation)?;
     let nelem = mesh.num_elements();
-    let ranges = ranges_for_len(nelem, chunksize(nelem));
-    let chunks = ranges
-        .into_par_iter()
-        .map(|(start, end)| {
-            body_force_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                formulation,
-                quadrature,
-                start,
-                end,
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let chunks = collect_sparse_operator_chunks(nelem, |start, end| {
+        body_force_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            formulation,
+            quadrature,
+            start,
+            end,
+        )
+    })?;
 
     Ok(concat_sparse_operators(
         chunks,

--- a/src/physics/solenoid_stress/loads/mod.rs
+++ b/src/physics/solenoid_stress/loads/mod.rs
@@ -9,7 +9,10 @@
 //! each stored coefficient has units
 //! `[output units / input units]`.
 
+use rayon::prelude::*;
+
 use crate::physics::solenoid_stress::types::Real;
+use crate::{chunksize, ranges_for_len};
 
 mod body_force;
 mod pressure;
@@ -107,15 +110,24 @@ fn concat_thermal_load_operators<F: Real>(
     }
 }
 
-fn ranges_for_len(len: usize, chunk: usize) -> Vec<(usize, usize)> {
-    let mut ranges = Vec::with_capacity(len.div_ceil(chunk));
-    let mut start = 0;
-    while start < len {
-        let end = (start + chunk).min(len);
-        ranges.push((start, end));
-        start = end;
-    }
-    ranges
+fn collect_sparse_operator_chunks<F: Real>(
+    len: usize,
+    build: impl Fn(usize, usize) -> Result<SparseOperator<F>, String> + Sync,
+) -> Result<Vec<SparseOperator<F>>, String> {
+    ranges_for_len(len, chunksize(len))
+        .into_par_iter()
+        .map(|(start, end)| build(start, end))
+        .collect()
+}
+
+fn collect_thermal_load_operator_chunks<F: Real>(
+    len: usize,
+    build: impl Fn(usize, usize) -> Result<ThermalLoadOperator<F>, String> + Sync,
+) -> Result<Vec<ThermalLoadOperator<F>>, String> {
+    ranges_for_len(len, chunksize(len))
+        .into_par_iter()
+        .map(|(start, end)| build(start, end))
+        .collect()
 }
 
 pub(crate) use body_force::{body_force_operator_for_family, body_force_operator_for_family_par};

--- a/src/physics/solenoid_stress/loads/mod.rs
+++ b/src/physics/solenoid_stress/loads/mod.rs
@@ -66,6 +66,9 @@ fn concat_sparse_operators<F: Real>(
     ncol: usize,
     capacity: usize,
 ) -> SparseOperator<F> {
+    // Worker chunks are emitted in the same order as `ranges_for_len`, so appending their triplet
+    // buffers preserves the serial load ordering.  Any duplicate structural rows are handled later
+    // by the CSR reduction/compression code.
     let mut rows = Vec::with_capacity(capacity);
     let mut cols = Vec::with_capacity(capacity);
     let mut vals = Vec::with_capacity(capacity);
@@ -93,6 +96,9 @@ fn concat_thermal_load_operators<F: Real>(
     ncol: usize,
     capacity: usize,
 ) -> ThermalLoadOperator<F> {
+    // Thermal loads have one sparse temperature operator plus a dense reference-temperature RHS.
+    // The sparse part can be concatenated like other loads; the dense offsets must be summed over
+    // all worker chunks because every element contributes to the same global RHS vector.
     let mut reference_rhs = vec![F::zero(); ndof];
     let sparse_chunks = chunks
         .into_iter()
@@ -114,6 +120,8 @@ fn collect_sparse_operator_chunks<F: Real>(
     len: usize,
     build: impl Fn(usize, usize) -> Result<SparseOperator<F>, String> + Sync,
 ) -> Result<Vec<SparseOperator<F>>, String> {
+    // Parallel wrappers differ only in the unit of work they split over: elements for body force
+    // and thermal loads, boundary load records for pressure and traction.
     ranges_for_len(len, chunksize(len))
         .into_par_iter()
         .map(|(start, end)| build(start, end))
@@ -124,6 +132,8 @@ fn collect_thermal_load_operator_chunks<F: Real>(
     len: usize,
     build: impl Fn(usize, usize) -> Result<ThermalLoadOperator<F>, String> + Sync,
 ) -> Result<Vec<ThermalLoadOperator<F>>, String> {
+    // Keep thermal chunks typed separately so the reference-temperature RHS cannot be accidentally
+    // discarded by a generic sparse-only collector.
     ranges_for_len(len, chunksize(len))
         .into_par_iter()
         .map(|(start, end)| build(start, end))

--- a/src/physics/solenoid_stress/loads/mod.rs
+++ b/src/physics/solenoid_stress/loads/mod.rs
@@ -57,7 +57,68 @@ pub struct ThermalLoadOperator<F: Real> {
     pub reference_rhs: Vec<F>,
 }
 
-pub(crate) use body_force::body_force_operator_for_family;
-pub(crate) use pressure::pressure_operator_for_family;
-pub(crate) use thermal::temperature_operator_for_family;
-pub(crate) use traction::traction_operator_for_family;
+fn concat_sparse_operators<F: Real>(
+    chunks: Vec<SparseOperator<F>>,
+    nrow: usize,
+    ncol: usize,
+    capacity: usize,
+) -> SparseOperator<F> {
+    let mut rows = Vec::with_capacity(capacity);
+    let mut cols = Vec::with_capacity(capacity);
+    let mut vals = Vec::with_capacity(capacity);
+
+    for chunk in chunks {
+        debug_assert_eq!(chunk.nrow, nrow);
+        debug_assert_eq!(chunk.ncol, ncol);
+        rows.extend(chunk.rows);
+        cols.extend(chunk.cols);
+        vals.extend(chunk.vals);
+    }
+
+    SparseOperator {
+        rows,
+        cols,
+        vals,
+        nrow,
+        ncol,
+    }
+}
+
+fn concat_thermal_load_operators<F: Real>(
+    chunks: Vec<ThermalLoadOperator<F>>,
+    ndof: usize,
+    ncol: usize,
+    capacity: usize,
+) -> ThermalLoadOperator<F> {
+    let mut reference_rhs = vec![F::zero(); ndof];
+    let sparse_chunks = chunks
+        .into_iter()
+        .map(|chunk| {
+            for (dst, src) in reference_rhs.iter_mut().zip(chunk.reference_rhs) {
+                *dst = *dst + src;
+            }
+            chunk.temperature_to_rhs
+        })
+        .collect::<Vec<_>>();
+
+    ThermalLoadOperator {
+        temperature_to_rhs: concat_sparse_operators(sparse_chunks, ndof, ncol, capacity),
+        reference_rhs,
+    }
+}
+
+fn ranges_for_len(len: usize, chunk: usize) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::with_capacity(len.div_ceil(chunk));
+    let mut start = 0;
+    while start < len {
+        let end = (start + chunk).min(len);
+        ranges.push((start, end));
+        start = end;
+    }
+    ranges
+}
+
+pub(crate) use body_force::{body_force_operator_for_family, body_force_operator_for_family_par};
+pub(crate) use pressure::{pressure_operator_for_family, pressure_operator_for_family_par};
+pub(crate) use thermal::{temperature_operator_for_family, temperature_operator_for_family_par};
+pub(crate) use traction::{traction_operator_for_family, traction_operator_for_family_par};

--- a/src/physics/solenoid_stress/loads/pressure.rs
+++ b/src/physics/solenoid_stress/loads/pressure.rs
@@ -1,6 +1,3 @@
-use rayon::prelude::*;
-
-use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
@@ -8,7 +5,7 @@ use crate::physics::solenoid_stress::types::{
     DOF_PER_NODE, PressureLoad, Real, Structural2dFormulation, local_dofs, scatter_local_vector,
 };
 
-use super::{SparseOperator, concat_sparse_operators, ranges_for_len};
+use super::{SparseOperator, collect_sparse_operator_chunks, concat_sparse_operators};
 
 /// Build the local dense pressure-load vector for one loaded face.
 ///
@@ -101,20 +98,16 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
-    let ranges = ranges_for_len(pressure_faces.len(), chunksize(pressure_faces.len()));
-    let chunks = ranges
-        .into_par_iter()
-        .map(|(start, end)| {
-            pressure_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                pressure_faces,
-                formulation,
-                quadrature,
-                start,
-                end,
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let chunks = collect_sparse_operator_chunks(pressure_faces.len(), |start, end| {
+        pressure_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            pressure_faces,
+            formulation,
+            quadrature,
+            start,
+            end,
+        )
+    })?;
 
     Ok(concat_sparse_operators(
         chunks,

--- a/src/physics/solenoid_stress/loads/pressure.rs
+++ b/src/physics/solenoid_stress/loads/pressure.rs
@@ -1,3 +1,6 @@
+use rayon::prelude::*;
+
+use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
@@ -5,7 +8,7 @@ use crate::physics::solenoid_stress::types::{
     DOF_PER_NODE, PressureLoad, Real, Structural2dFormulation, local_dofs, scatter_local_vector,
 };
 
-use super::SparseOperator;
+use super::{SparseOperator, concat_sparse_operators, ranges_for_len};
 
 /// Build the local dense pressure-load vector for one loaded face.
 ///
@@ -69,13 +72,87 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
+    pressure_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        mesh,
+        pressure_faces,
+        formulation,
+        quadrature,
+        0,
+        pressure_faces.len(),
+    )
+}
+
+/// Assemble pressure loads using pressure-face ranges split across Rayon workers.
+pub(crate) fn pressure_operator_for_family_par<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    pressure_faces: &[PressureLoad],
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+) -> Result<SparseOperator<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    const {
+        assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
+    }
+    validate_structural_2d_mesh(mesh, formulation)?;
+    let ranges = ranges_for_len(pressure_faces.len(), chunksize(pressure_faces.len()));
+    let chunks = ranges
+        .into_par_iter()
+        .map(|(start, end)| {
+            pressure_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                pressure_faces,
+                formulation,
+                quadrature,
+                start,
+                end,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(concat_sparse_operators(
+        chunks,
+        mesh.num_nodes() * 2,
+        pressure_faces.len(),
+        pressure_faces.len() * DOF_PER_ELEMENT,
+    ))
+}
+
+fn pressure_operator_range_for_family<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    pressure_faces: &[PressureLoad],
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+    load_start: usize,
+    load_end: usize,
+) -> Result<SparseOperator<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
     let ndof = mesh.num_nodes() * 2;
     let ncol = pressure_faces.len();
-    let mut rows = Vec::with_capacity(pressure_faces.len() * DOF_PER_ELEMENT);
-    let mut cols = Vec::with_capacity(pressure_faces.len() * DOF_PER_ELEMENT);
-    let mut vals = Vec::with_capacity(pressure_faces.len() * DOF_PER_ELEMENT);
+    let nloads = load_end - load_start;
+    let mut rows = Vec::with_capacity(nloads * DOF_PER_ELEMENT);
+    let mut cols = Vec::with_capacity(nloads * DOF_PER_ELEMENT);
+    let mut vals = Vec::with_capacity(nloads * DOF_PER_ELEMENT);
 
-    for (load_index, load) in pressure_faces.iter().enumerate() {
+    for (load_index, load) in pressure_faces
+        .iter()
+        .enumerate()
+        .skip(load_start)
+        .take(nloads)
+    {
         if load.element >= mesh.num_elements() {
             return Err(format!(
                 "pressure load references element {}, but mesh has only {} elements",

--- a/src/physics/solenoid_stress/loads/thermal.rs
+++ b/src/physics/solenoid_stress/loads/thermal.rs
@@ -1,3 +1,6 @@
+use rayon::prelude::*;
+
+use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::axisym::{
     accumulate_b_transpose_vector, build_b_matrix, constitutive_times_strain,
@@ -12,7 +15,7 @@ use crate::physics::solenoid_stress::types::{
     validate_element_material_inputs,
 };
 
-use super::{SparseOperator, ThermalLoadOperator};
+use super::{SparseOperator, ThermalLoadOperator, concat_thermal_load_operators, ranges_for_len};
 
 /// Local thermal operator data for one element.
 ///
@@ -125,6 +128,93 @@ where
         material_ids,
         material_orientation_angles,
     )?;
+    temperature_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        mesh,
+        material_ids,
+        material_table,
+        thermal_material_table,
+        material_orientation_angles,
+        formulation,
+        quadrature,
+        0,
+        mesh.num_elements(),
+    )
+}
+
+/// Assemble thermal load operators using element ranges split across Rayon workers.
+pub(crate) fn temperature_operator_for_family_par<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    thermal_material_table: &[ThermalMaterial<F>],
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+) -> Result<ThermalLoadOperator<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    const {
+        assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
+    }
+    validate_structural_2d_mesh(mesh, formulation)?;
+    validate_element_material_inputs(
+        mesh.num_elements(),
+        material_ids,
+        material_orientation_angles,
+    )?;
+    let nelem = mesh.num_elements();
+    let ranges = ranges_for_len(nelem, chunksize(nelem));
+    let chunks = ranges
+        .into_par_iter()
+        .map(|(start, end)| {
+            temperature_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                material_ids,
+                material_table,
+                thermal_material_table,
+                material_orientation_angles,
+                formulation,
+                quadrature,
+                start,
+                end,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(concat_thermal_load_operators(
+        chunks,
+        mesh.num_nodes() * 2,
+        mesh.num_nodes(),
+        nelem * DOF_PER_ELEMENT * NODES_PER_ELEMENT,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn temperature_operator_range_for_family<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    thermal_material_table: &[ThermalMaterial<F>],
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+    element_start: usize,
+    element_end: usize,
+) -> Result<ThermalLoadOperator<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
     let ndof = mesh.num_nodes() * 2;
     let ncol = mesh.num_nodes();
     let mut rows = Vec::new();
@@ -132,7 +222,7 @@ where
     let mut vals = Vec::new();
     let mut reference_rhs = vec![F::zero(); ndof];
 
-    for element_index in 0..mesh.num_elements() {
+    for element_index in element_start..element_end {
         let coords = mesh.element_coords(element_index)?;
         let nodes = mesh.element_nodes(element_index)?;
         let material_id = material_ids[element_index];

--- a/src/physics/solenoid_stress/loads/thermal.rs
+++ b/src/physics/solenoid_stress/loads/thermal.rs
@@ -1,6 +1,3 @@
-use rayon::prelude::*;
-
-use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::axisym::{
     accumulate_b_transpose_vector, build_b_matrix, constitutive_times_strain,
@@ -15,7 +12,10 @@ use crate::physics::solenoid_stress::types::{
     validate_element_material_inputs,
 };
 
-use super::{SparseOperator, ThermalLoadOperator, concat_thermal_load_operators, ranges_for_len};
+use super::{
+    SparseOperator, ThermalLoadOperator, collect_thermal_load_operator_chunks,
+    concat_thermal_load_operators,
+};
 
 /// Local thermal operator data for one element.
 ///
@@ -169,23 +169,19 @@ where
         material_orientation_angles,
     )?;
     let nelem = mesh.num_elements();
-    let ranges = ranges_for_len(nelem, chunksize(nelem));
-    let chunks = ranges
-        .into_par_iter()
-        .map(|(start, end)| {
-            temperature_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                material_ids,
-                material_table,
-                thermal_material_table,
-                material_orientation_angles,
-                formulation,
-                quadrature,
-                start,
-                end,
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let chunks = collect_thermal_load_operator_chunks(nelem, |start, end| {
+        temperature_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            material_ids,
+            material_table,
+            thermal_material_table,
+            material_orientation_angles,
+            formulation,
+            quadrature,
+            start,
+            end,
+        )
+    })?;
 
     Ok(concat_thermal_load_operators(
         chunks,

--- a/src/physics/solenoid_stress/loads/traction.rs
+++ b/src/physics/solenoid_stress/loads/traction.rs
@@ -1,6 +1,3 @@
-use rayon::prelude::*;
-
-use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
@@ -8,7 +5,7 @@ use crate::physics::solenoid_stress::types::{
     DOF_PER_NODE, Real, Structural2dFormulation, TractionLoad, local_dofs, scatter_local_matrix,
 };
 
-use super::{SparseOperator, concat_sparse_operators, ranges_for_len};
+use super::{SparseOperator, collect_sparse_operator_chunks, concat_sparse_operators};
 
 /// Build the local dense traction operator for one loaded face.
 ///
@@ -106,20 +103,16 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
-    let ranges = ranges_for_len(traction_faces.len(), chunksize(traction_faces.len()));
-    let chunks = ranges
-        .into_par_iter()
-        .map(|(start, end)| {
-            traction_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                traction_faces,
-                formulation,
-                quadrature,
-                start,
-                end,
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let chunks = collect_sparse_operator_chunks(traction_faces.len(), |start, end| {
+        traction_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            traction_faces,
+            formulation,
+            quadrature,
+            start,
+            end,
+        )
+    })?;
 
     Ok(concat_sparse_operators(
         chunks,

--- a/src/physics/solenoid_stress/loads/traction.rs
+++ b/src/physics/solenoid_stress/loads/traction.rs
@@ -1,3 +1,6 @@
+use rayon::prelude::*;
+
+use crate::chunksize;
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
@@ -5,7 +8,7 @@ use crate::physics::solenoid_stress::types::{
     DOF_PER_NODE, Real, Structural2dFormulation, TractionLoad, local_dofs, scatter_local_matrix,
 };
 
-use super::SparseOperator;
+use super::{SparseOperator, concat_sparse_operators, ranges_for_len};
 
 /// Build the local dense traction operator for one loaded face.
 ///
@@ -74,13 +77,87 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
+    traction_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        mesh,
+        traction_faces,
+        formulation,
+        quadrature,
+        0,
+        traction_faces.len(),
+    )
+}
+
+/// Assemble traction loads using traction-face ranges split across Rayon workers.
+pub(crate) fn traction_operator_for_family_par<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    traction_faces: &[TractionLoad],
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+) -> Result<SparseOperator<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    const {
+        assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
+    }
+    validate_structural_2d_mesh(mesh, formulation)?;
+    let ranges = ranges_for_len(traction_faces.len(), chunksize(traction_faces.len()));
+    let chunks = ranges
+        .into_par_iter()
+        .map(|(start, end)| {
+            traction_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                traction_faces,
+                formulation,
+                quadrature,
+                start,
+                end,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(concat_sparse_operators(
+        chunks,
+        mesh.num_nodes() * 2,
+        2 * traction_faces.len(),
+        traction_faces.len() * DOF_PER_ELEMENT * 2,
+    ))
+}
+
+fn traction_operator_range_for_family<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    traction_faces: &[TractionLoad],
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+    load_start: usize,
+    load_end: usize,
+) -> Result<SparseOperator<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
     let ndof = mesh.num_nodes() * 2;
     let ncol = 2 * traction_faces.len();
-    let mut rows = Vec::with_capacity(traction_faces.len() * DOF_PER_ELEMENT * 2);
-    let mut cols = Vec::with_capacity(traction_faces.len() * DOF_PER_ELEMENT * 2);
-    let mut vals = Vec::with_capacity(traction_faces.len() * DOF_PER_ELEMENT * 2);
+    let nloads = load_end - load_start;
+    let mut rows = Vec::with_capacity(nloads * DOF_PER_ELEMENT * 2);
+    let mut cols = Vec::with_capacity(nloads * DOF_PER_ELEMENT * 2);
+    let mut vals = Vec::with_capacity(nloads * DOF_PER_ELEMENT * 2);
 
-    for (load_index, load) in traction_faces.iter().enumerate() {
+    for (load_index, load) in traction_faces
+        .iter()
+        .enumerate()
+        .skip(load_start)
+        .take(nloads)
+    {
         if load.element >= mesh.num_elements() {
             return Err(format!(
                 "traction load references element {}, but mesh has only {} elements",

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -7,7 +7,7 @@ use deimos_numerics::sparse::{
 use faer::linalg::solvers::Solve;
 use faer::sparse::linalg::matmul::sparse_dense_matmul;
 use faer::sparse::linalg::solvers::Lu;
-use faer::sparse::{SparseColMat, SparseColMatRef, SparseRowMat, Triplet};
+use faer::sparse::{SparseColMat, SparseColMatRef, SparseRowMat, SymbolicSparseRowMat, Triplet};
 use faer::{Accum, Col, Par};
 
 use crate::mesh::elements::quad2d::{quad4, quad9};
@@ -20,13 +20,35 @@ use crate::physics::solenoid_stress::convenience::{
 };
 use crate::physics::solenoid_stress::family::{Quad4Family, Quad9Family, QuadElementFamily};
 use crate::physics::solenoid_stress::loads::{
-    SparseOperator, body_force_operator_for_family, pressure_operator_for_family,
-    temperature_operator_for_family, traction_operator_for_family,
+    SparseOperator, body_force_operator_for_family, body_force_operator_for_family_par,
+    pressure_operator_for_family, pressure_operator_for_family_par,
+    temperature_operator_for_family, temperature_operator_for_family_par,
+    traction_operator_for_family, traction_operator_for_family_par,
 };
-use crate::physics::solenoid_stress::recovery::quadrature_field_operators_for_family;
+use crate::physics::solenoid_stress::recovery::{
+    CsrOperatorParts, reduced_quadrature_field_operators_for_family,
+    reduced_quadrature_field_operators_for_family_par,
+};
 use crate::physics::solenoid_stress::types::{
     PressureLoad, Real, Structural2dFormulation, ThermalMaterial, TractionLoad, dof_per_element,
 };
+
+macro_rules! timed_stage {
+    ($enabled:expr, $label:expr, $body:block) => {{
+        if $enabled {
+            let start = std::time::Instant::now();
+            let result = (|| $body)();
+            eprintln!(
+                "[cfsem timing] {}: {:.6} s",
+                $label,
+                start.elapsed().as_secs_f64()
+            );
+            result
+        } else {
+            (|| $body)()
+        }
+    }};
+}
 
 mod private {
     use super::{CompensatedField, Real};
@@ -1144,6 +1166,16 @@ fn build_model_for_family<
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
+    let timing_enabled = std::env::var_os("CFSEM_TIMING").is_some();
+    let total_start = std::time::Instant::now();
+    if timing_enabled {
+        eprintln!(
+            "[cfsem timing] rust.build_model.start: nnode={} nelem={} par={}",
+            nodes_rz.len(),
+            elements.len(),
+            par
+        );
+    }
     let mesh = QuadMeshView2d { nodes_rz, elements };
     let ndof_full = nodes_rz.len() * 2;
     let nelem = elements.len();
@@ -1151,41 +1183,55 @@ where
     // live in the constrained reduced system, while `fixed_lookup` carries the prescribed values
     // needed to fold eliminated DOFs back into constant RHS terms.
     let (free_dofs, fixed_dofs, fixed_values, global_to_reduced, fixed_lookup) =
-        reduce_layout(ndof_full, prescribed)?;
+        timed_stage!(timing_enabled, "rust.build_model.reduce_layout", {
+            reduce_layout(ndof_full, prescribed)
+        })?;
     let ndof_reduced = free_dofs.len();
 
     // Assemble stiffness in the full displacement space first, then apply Dirichlet reduction.
     // This keeps the element kernels simple and pushes all constraint handling into the common
     // reduction helpers below.
-    let stiffness_full = if par {
-        assemble_stiffness_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-            mesh,
-            material_ids,
-            material_table,
-            material_orientation_angles,
-            formulation,
-            quadrature,
-        )?
-    } else {
-        assemble_stiffness_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-            mesh,
-            material_ids,
-            material_table,
-            material_orientation_angles,
-            formulation,
-            quadrature,
-        )?
-    };
+    let stiffness_full = timed_stage!(timing_enabled, "rust.build_model.stiffness_triplets", {
+        if par {
+            assemble_stiffness_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                material_ids,
+                material_table,
+                material_orientation_angles,
+                formulation,
+                quadrature,
+            )
+        } else {
+            assemble_stiffness_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                material_ids,
+                material_table,
+                material_orientation_angles,
+                formulation,
+                quadrature,
+            )
+        }
+    })?;
     let mut constant_rhs = vec![F::zero(); ndof_reduced];
-    let stiffness_reduced = reduce_square_triplets(
-        &stiffness_full.rows,
-        &stiffness_full.cols,
-        &stiffness_full.vals,
-        &global_to_reduced,
-        &fixed_lookup,
-        &mut constant_rhs,
-    );
-    let stiffness = csc_from_triplets(ndof_reduced, ndof_reduced, stiffness_reduced)?;
+    let stiffness_reduced = timed_stage!(timing_enabled, "rust.build_model.reduce_stiffness", {
+        reduce_square_triplets(
+            &stiffness_full.rows,
+            &stiffness_full.cols,
+            &stiffness_full.vals,
+            &global_to_reduced,
+            &fixed_lookup,
+            &mut constant_rhs,
+        )
+    });
+    let stiffness = timed_stage!(timing_enabled, "rust.build_model.stiffness_csc", {
+        csc_from_triplets(ndof_reduced, ndof_reduced, stiffness_reduced)
+    })?;
+    if timing_enabled {
+        eprintln!(
+            "[cfsem timing] rust.build_model.stiffness_csc.nnz: {}",
+            stiffness.val().len()
+        );
+    }
     // Most load operators are naturally assembled in full nodal space and then reduced by
     // dropping rows associated with prescribed displacement DOFs.
     let reduce_operator =
@@ -1196,7 +1242,140 @@ where
             // Thermal loading has both a temperature-dependent operator and a constant offset from
             // per-material reference temperature, so keep those two pieces separate until the end.
             let thermal_full =
-                temperature_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                timed_stage!(timing_enabled, "rust.build_model.thermal_operator", {
+                    if par {
+                        temperature_operator_for_family_par::<
+                            F,
+                            Family,
+                            NODES_PER_ELEMENT,
+                            DOF_PER_ELEMENT,
+                        >(
+                            mesh,
+                            material_ids,
+                            material_table,
+                            thermal_material_table,
+                            material_orientation_angles,
+                            formulation,
+                            quadrature,
+                        )
+                    } else {
+                        temperature_operator_for_family::<
+                            F,
+                            Family,
+                            NODES_PER_ELEMENT,
+                            DOF_PER_ELEMENT,
+                        >(
+                            mesh,
+                            material_ids,
+                            material_table,
+                            thermal_material_table,
+                            material_orientation_angles,
+                            formulation,
+                            quadrature,
+                        )
+                    }
+                })?;
+            let reduced_reference_rhs = timed_stage!(
+                timing_enabled,
+                "rust.build_model.thermal_reference_reduce",
+                {
+                    free_dofs
+                        .iter()
+                        .map(|&dof| thermal_full.reference_rhs[dof])
+                        .collect::<Vec<_>>()
+                }
+            );
+            (
+                timed_stage!(timing_enabled, "rust.build_model.thermal_reduce_csr", {
+                    reduce_operator(thermal_full.temperature_to_rhs)
+                })?,
+                reduced_reference_rhs,
+                nodes_rz.len(),
+            )
+        } else {
+            (
+                timed_stage!(timing_enabled, "rust.build_model.empty_temperature_csr", {
+                    csr_from_parts(ndof_reduced, 0, Vec::new(), Vec::new(), Vec::new())
+                })?,
+                vec![F::zero(); ndof_reduced],
+                0,
+            )
+        };
+    // `constant_rhs` already contains the Dirichlet offset from stiffness reduction. Add the
+    // reference-temperature contribution so all load-independent terms live in one vector.
+    timed_stage!(timing_enabled, "rust.build_model.constant_rhs_merge", {
+        for (dst, src) in constant_rhs.iter_mut().zip(&thermal_reference_rhs) {
+            *dst = *dst + *src;
+        }
+    });
+
+    // These operators are stored directly in reduced row space because `build_rhs(...)` and
+    // `solve(...)` work only with the constrained system.
+    let body_force_to_rhs =
+        timed_stage!(timing_enabled, "rust.build_model.body_force_operator", {
+            let operator = if par {
+                body_force_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                    mesh,
+                    formulation,
+                    quadrature,
+                )?
+            } else {
+                body_force_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                    mesh,
+                    formulation,
+                    quadrature,
+                )?
+            };
+            reduce_operator(operator)
+        })?;
+    let pressure_to_rhs = timed_stage!(timing_enabled, "rust.build_model.pressure_operator", {
+        let operator = if par {
+            pressure_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                pressure_faces,
+                formulation,
+                quadrature,
+            )?
+        } else {
+            pressure_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                pressure_faces,
+                formulation,
+                quadrature,
+            )?
+        };
+        reduce_operator(operator)
+    })?;
+    let traction_to_rhs = timed_stage!(timing_enabled, "rust.build_model.traction_operator", {
+        let operator = if par {
+            traction_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                traction_faces,
+                formulation,
+                quadrature,
+            )?
+        } else {
+            traction_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                traction_faces,
+                formulation,
+                quadrature,
+            )?
+        };
+        reduce_operator(operator)
+    })?;
+
+    // Recovery rows are disjoint by quadrature point, so assemble directly in reduced CSR form
+    // instead of building full-space triplets and reducing them afterwards.
+    let recovery_reduced =
+        timed_stage!(timing_enabled, "rust.build_model.recovery_reduced_csr", {
+            if par {
+                reduced_quadrature_field_operators_for_family_par::<
+                    F,
+                    Family,
+                    NODES_PER_ELEMENT,
+                    DOF_PER_ELEMENT,
+                >(
                     mesh,
                     material_ids,
                     material_table,
@@ -1204,97 +1383,48 @@ where
                     material_orientation_angles,
                     formulation,
                     quadrature,
-                )?;
-            let reduced_reference_rhs = free_dofs
-                .iter()
-                .map(|&dof| thermal_full.reference_rhs[dof])
-                .collect::<Vec<_>>();
-            (
-                reduce_operator(thermal_full.temperature_to_rhs)?,
-                reduced_reference_rhs,
-                nodes_rz.len(),
-            )
-        } else {
-            (
-                csr_from_parts(ndof_reduced, 0, Vec::new(), Vec::new(), Vec::new())?,
-                vec![F::zero(); ndof_reduced],
-                0,
-            )
-        };
-    // `constant_rhs` already contains the Dirichlet offset from stiffness reduction. Add the
-    // reference-temperature contribution so all load-independent terms live in one vector.
-    for (dst, src) in constant_rhs.iter_mut().zip(&thermal_reference_rhs) {
-        *dst = *dst + *src;
-    }
+                    &global_to_reduced,
+                    &fixed_lookup,
+                    ndof_reduced,
+                )
+            } else {
+                reduced_quadrature_field_operators_for_family::<
+                    F,
+                    Family,
+                    NODES_PER_ELEMENT,
+                    DOF_PER_ELEMENT,
+                >(
+                    mesh,
+                    material_ids,
+                    material_table,
+                    thermal_material_table,
+                    material_orientation_angles,
+                    formulation,
+                    quadrature,
+                    &global_to_reduced,
+                    &fixed_lookup,
+                    ndof_reduced,
+                )
+            }
+        })?;
+    let strain_operator = timed_stage!(timing_enabled, "rust.build_model.strain_csr_wrap", {
+        csr_from_canonical_parts(recovery_reduced.strain_operator)
+    });
+    let stress_operator = timed_stage!(timing_enabled, "rust.build_model.stress_csr_wrap", {
+        csr_from_canonical_parts(recovery_reduced.stress_operator)
+    });
+    let thermal_strain_operator = timed_stage!(
+        timing_enabled,
+        "rust.build_model.thermal_strain_csr_wrap",
+        { csr_from_canonical_parts(recovery_reduced.thermal_strain_operator) }
+    );
+    let thermal_stress_operator = timed_stage!(
+        timing_enabled,
+        "rust.build_model.thermal_stress_csr_wrap",
+        { csr_from_canonical_parts(recovery_reduced.thermal_stress_operator) }
+    );
 
-    // These operators are stored directly in reduced row space because `build_rhs(...)` and
-    // `solve(...)` work only with the constrained system.
-    let body_force_to_rhs = reduce_operator(body_force_operator_for_family::<
-        F,
-        Family,
-        NODES_PER_ELEMENT,
-        DOF_PER_ELEMENT,
-    >(mesh, formulation, quadrature)?)?;
-    let pressure_to_rhs = reduce_operator(pressure_operator_for_family::<
-        F,
-        Family,
-        NODES_PER_ELEMENT,
-        DOF_PER_ELEMENT,
-    >(mesh, pressure_faces, formulation, quadrature)?)?;
-    let traction_to_rhs = reduce_operator(traction_operator_for_family::<
-        F,
-        Family,
-        NODES_PER_ELEMENT,
-        DOF_PER_ELEMENT,
-    >(mesh, traction_faces, formulation, quadrature)?)?;
-
-    // Recovery is assembled in full displacement space, then its displacement columns are reduced.
-    // Eliminated fixed-displacement columns become constant strain/stress offsets.
-    let recovery_full =
-        quadrature_field_operators_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-            mesh,
-            material_ids,
-            material_table,
-            thermal_material_table,
-            material_orientation_angles,
-            formulation,
-            quadrature,
-        )?;
-    let nq_row_count = recovery_full.points.len() * 4;
-    let (strain_operator, strain_constant) = reduce_column_operator(
-        recovery_full.strain_rows,
-        recovery_full.strain_cols,
-        recovery_full.strain_vals,
-        nq_row_count,
-        ndof_reduced,
-        &global_to_reduced,
-        &fixed_lookup,
-    )?;
-    let (stress_operator, stress_constant) = reduce_column_operator(
-        recovery_full.stress_rows,
-        recovery_full.stress_cols,
-        recovery_full.stress_vals,
-        nq_row_count,
-        ndof_reduced,
-        &global_to_reduced,
-        &fixed_lookup,
-    )?;
-    let thermal_strain_operator = csr_from_parts(
-        recovery_full.points.len() * 4,
-        recovery_full.ntemp,
-        recovery_full.thermal_strain_rows,
-        recovery_full.thermal_strain_cols,
-        recovery_full.thermal_strain_vals,
-    )?;
-    let thermal_stress_operator = csr_from_parts(
-        recovery_full.points.len() * 4,
-        recovery_full.ntemp,
-        recovery_full.thermal_stress_rows,
-        recovery_full.thermal_stress_cols,
-        recovery_full.thermal_stress_vals,
-    )?;
-
-    Ok(Structural2dModel {
+    let model = Structural2dModel {
         stiffness,
         body_force_to_rhs,
         pressure_to_rhs,
@@ -1302,16 +1432,16 @@ where
         temperature_to_rhs,
         constant_rhs,
         recovery: ReducedRecoveryOperators {
-            points: recovery_full.points,
+            points: recovery_reduced.points,
             strain_operator,
             stress_operator,
             thermal_strain_operator,
             thermal_stress_operator,
-            strain_constant,
-            stress_constant,
-            thermal_strain_constant: recovery_full.thermal_strain_constant,
-            thermal_stress_constant: recovery_full.thermal_stress_constant,
-            nq_per_element: recovery_full.nq_per_element,
+            strain_constant: recovery_reduced.strain_constant,
+            stress_constant: recovery_reduced.stress_constant,
+            thermal_strain_constant: recovery_reduced.thermal_strain_constant,
+            thermal_stress_constant: recovery_reduced.thermal_stress_constant,
+            nq_per_element: recovery_reduced.nq_per_element,
             n_temperature_nodes,
         },
         pressure_faces: pressure_faces
@@ -1341,7 +1471,14 @@ where
         equilibrated_stiffness: None,
         equilibrated_diagonal_preconditioner: None,
         previous_bicgstab_solution: None,
-    })
+    };
+    if timing_enabled {
+        eprintln!(
+            "[cfsem timing] rust.build_model.total: {:.6} s",
+            total_start.elapsed().as_secs_f64()
+        );
+    }
+    Ok(model)
 }
 
 /// Partition full-system displacement DOFs into free and fixed sets for Dirichlet reduction.
@@ -1466,38 +1603,6 @@ fn reduce_row_operator_to_csr<F: Real>(
     )
 }
 
-/// Reduce a full-space recovery operator by eliminating fixed displacement columns.
-///
-/// The eliminated fixed-value contributions are accumulated into the returned constant vector.
-fn reduce_column_operator<F: Real>(
-    rows: Vec<usize>,
-    cols: Vec<usize>,
-    vals: Vec<F>,
-    nrow: usize,
-    ncol: usize,
-    global_to_reduced: &[usize],
-    fixed_lookup: &[Option<F>],
-) -> Result<(SparseRowMat<usize, F>, Vec<F>), String> {
-    let mut constant = vec![F::zero(); nrow];
-    let mut reduced_rows = Vec::with_capacity(vals.len());
-    let mut reduced_cols = Vec::with_capacity(vals.len());
-    let mut reduced_vals = Vec::with_capacity(vals.len());
-    for ((row, col), value) in rows.into_iter().zip(cols.into_iter()).zip(vals.into_iter()) {
-        let reduced_col = global_to_reduced[col];
-        if reduced_col != usize::MAX {
-            reduced_rows.push(row);
-            reduced_cols.push(reduced_col);
-            reduced_vals.push(value);
-        } else if let Some(fixed_value) = fixed_lookup[col] {
-            constant[row] = constant[row] + value * fixed_value;
-        }
-    }
-    Ok((
-        csr_from_parts(nrow, ncol, reduced_rows, reduced_cols, reduced_vals)?,
-        constant,
-    ))
-}
-
 /// Compress triplet data into a CSR matrix with checked shape and index validity.
 fn csr_from_parts<F: Real>(
     nrow: usize,
@@ -1514,6 +1619,18 @@ fn csr_from_parts<F: Real>(
         .collect::<Vec<_>>();
     SparseRowMat::try_new_from_triplets(nrow, ncol, &triplets)
         .map_err(|err| format!("failed to build CSR operator: {err:?}"))
+}
+
+/// Build a CSR matrix from already canonical row pointers, column indices, and values.
+fn csr_from_canonical_parts<F: Real>(parts: CsrOperatorParts<F>) -> SparseRowMat<usize, F> {
+    let symbolic = SymbolicSparseRowMat::new_checked(
+        parts.nrow,
+        parts.ncol,
+        parts.row_ptr,
+        None,
+        parts.col_idx,
+    );
+    SparseRowMat::new(symbolic, parts.vals)
 }
 
 /// Compress stiffness triplets into the CSC format used by the cached sparse LU factorization.

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -1484,6 +1484,11 @@ fn reduce_square_triplets<F: Real>(
 }
 
 /// Reduce, sort, and coalesce each stiffness chunk independently.
+///
+/// Each Rayon worker returns full-system triplets for a disjoint element range.  Reduction can
+/// still create duplicate `(row, col)` entries inside a chunk, so this function canonicalizes each
+/// chunk before the final k-way merge.  The Dirichlet RHS offsets are accumulated per chunk to
+/// avoid shared mutable state during the parallel pass.
 fn reduce_sort_stiffness_chunks<F: Real>(
     chunks: Vec<StiffnessTriplets<F>>,
     global_to_reduced: &[usize],
@@ -1643,14 +1648,20 @@ fn csc_from_triplets<F: Real>(
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct TripletCursor {
+    /// Current triplet column in a sorted chunk.
     col: usize,
+    /// Current triplet row in a sorted chunk.
     row: usize,
+    /// Index of the source chunk in the outer chunk slice.
     chunk: usize,
+    /// Index of the current triplet inside that source chunk.
     index: usize,
 }
 
 impl Ord for TripletCursor {
     fn cmp(&self, other: &Self) -> Ordering {
+        // `BinaryHeap` is a max-heap, so reverse the ordering to pop the smallest `(col, row)`
+        // cursor first during the k-way merge.
         other
             .col
             .cmp(&self.col)
@@ -1667,16 +1678,24 @@ impl PartialOrd for TripletCursor {
 }
 
 struct CscPartsBuilder<F: Real> {
+    /// Number of matrix rows.
     nrow: usize,
+    /// Number of matrix columns.
     ncol: usize,
+    /// CSC column offsets under construction.
     col_ptr: Vec<usize>,
+    /// Row index for each stored value.
     row_idx: Vec<usize>,
+    /// Nonzero values in column-major CSC order.
     vals: Vec<F>,
+    /// First column whose pointer has not yet been finalized.
     next_col: usize,
+    /// Most recent sorted entry, held back so duplicates can be coalesced before writing.
     pending: Option<Triplet<usize, usize, F>>,
 }
 
 impl<F: Real> CscPartsBuilder<F> {
+    /// Start a CSC builder that accepts triplets sorted by `(column, row)`.
     fn new(nrow: usize, ncol: usize, capacity: usize) -> Self {
         let mut col_ptr = Vec::with_capacity(ncol + 1);
         col_ptr.push(0);
@@ -1691,6 +1710,7 @@ impl<F: Real> CscPartsBuilder<F> {
         }
     }
 
+    /// Append one sorted triplet, coalescing duplicates and skipping exact zeros.
     fn push_sorted(&mut self, triplet: Triplet<usize, usize, F>) {
         debug_assert!(triplet.row < self.nrow);
         debug_assert!(triplet.col < self.ncol);
@@ -1710,6 +1730,7 @@ impl<F: Real> CscPartsBuilder<F> {
         }
     }
 
+    /// Finalize pending entries and close all remaining column pointers.
     fn finish(mut self) -> (Vec<usize>, Vec<usize>, Vec<F>) {
         if let Some(current) = self.pending.take() {
             self.push_entry(current);
@@ -1722,6 +1743,7 @@ impl<F: Real> CscPartsBuilder<F> {
         (self.col_ptr, self.row_idx, self.vals)
     }
 
+    /// Write one already coalesced CSC entry and fill empty-column pointers before it.
     fn push_entry(&mut self, entry: Triplet<usize, usize, F>) {
         while self.next_col < entry.col {
             self.col_ptr.push(self.row_idx.len());
@@ -1753,6 +1775,8 @@ fn merge_sorted_triplet_chunks_to_csc<F: Real>(
     let capacity = chunks.iter().map(Vec::len).sum::<usize>();
     let mut builder = CscPartsBuilder::new(nrow, ncol, capacity);
     let mut heap = BinaryHeap::with_capacity(chunks.len());
+    // Seed the heap with the first triplet from each sorted chunk.  Every pop advances only that
+    // source chunk, giving a k-way merge without flattening and sorting all triplets again.
     for (chunk_index, chunk) in chunks.iter().enumerate() {
         if let Some(first) = chunk.first() {
             heap.push(TripletCursor {

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -1483,11 +1483,6 @@ fn reduce_square_triplets<F: Real>(
     triplets
 }
 
-struct ReducedStiffnessChunk<F: Real> {
-    triplets: Vec<Triplet<usize, usize, F>>,
-    constant_rhs: Vec<F>,
-}
-
 /// Reduce, sort, and coalesce each stiffness chunk independently.
 fn reduce_sort_stiffness_chunks<F: Real>(
     chunks: Vec<StiffnessTriplets<F>>,
@@ -1508,19 +1503,16 @@ fn reduce_sort_stiffness_chunks<F: Real>(
                 fixed_lookup,
                 &mut local_rhs,
             );
-            ReducedStiffnessChunk {
-                triplets: sort_coalesce_triplets(triplets),
-                constant_rhs: local_rhs,
-            }
+            (sort_coalesce_triplets(triplets), local_rhs)
         })
         .collect::<Vec<_>>();
 
     let mut sorted_chunks = Vec::with_capacity(reduced_chunks.len());
-    for chunk in reduced_chunks {
-        for (dst, src) in constant_rhs.iter_mut().zip(chunk.constant_rhs) {
+    for (triplets, local_rhs) in reduced_chunks {
+        for (dst, src) in constant_rhs.iter_mut().zip(local_rhs) {
             *dst = *dst + src;
         }
-        sorted_chunks.push(chunk.triplets);
+        sorted_chunks.push(triplets);
     }
     sorted_chunks
 }
@@ -1674,6 +1666,74 @@ impl PartialOrd for TripletCursor {
     }
 }
 
+struct CscPartsBuilder<F: Real> {
+    nrow: usize,
+    ncol: usize,
+    col_ptr: Vec<usize>,
+    row_idx: Vec<usize>,
+    vals: Vec<F>,
+    next_col: usize,
+    pending: Option<Triplet<usize, usize, F>>,
+}
+
+impl<F: Real> CscPartsBuilder<F> {
+    fn new(nrow: usize, ncol: usize, capacity: usize) -> Self {
+        let mut col_ptr = Vec::with_capacity(ncol + 1);
+        col_ptr.push(0);
+        Self {
+            nrow,
+            ncol,
+            col_ptr,
+            row_idx: Vec::with_capacity(capacity),
+            vals: Vec::with_capacity(capacity),
+            next_col: 0,
+            pending: None,
+        }
+    }
+
+    fn push_sorted(&mut self, triplet: Triplet<usize, usize, F>) {
+        debug_assert!(triplet.row < self.nrow);
+        debug_assert!(triplet.col < self.ncol);
+        if triplet.val == F::zero() {
+            return;
+        }
+        match self.pending {
+            Some(mut current) if current.col == triplet.col && current.row == triplet.row => {
+                current.val = current.val + triplet.val;
+                self.pending = Some(current);
+            }
+            Some(current) => {
+                self.push_entry(current);
+                self.pending = Some(triplet);
+            }
+            None => self.pending = Some(triplet),
+        }
+    }
+
+    fn finish(mut self) -> (Vec<usize>, Vec<usize>, Vec<F>) {
+        if let Some(current) = self.pending.take() {
+            self.push_entry(current);
+        }
+        while self.next_col < self.ncol {
+            self.col_ptr.push(self.row_idx.len());
+            self.next_col += 1;
+        }
+        debug_assert_eq!(self.col_ptr.len(), self.ncol + 1);
+        (self.col_ptr, self.row_idx, self.vals)
+    }
+
+    fn push_entry(&mut self, entry: Triplet<usize, usize, F>) {
+        while self.next_col < entry.col {
+            self.col_ptr.push(self.row_idx.len());
+            self.next_col += 1;
+        }
+        if entry.val != F::zero() {
+            self.row_idx.push(entry.row);
+            self.vals.push(entry.val);
+        }
+    }
+}
+
 /// Merge already sorted/coalesced triplet chunks into the CSC format used by sparse LU.
 fn csc_from_sorted_triplet_chunks<F: Real>(
     nrow: usize,
@@ -1691,6 +1751,7 @@ fn merge_sorted_triplet_chunks_to_csc<F: Real>(
     chunks: &[Vec<Triplet<usize, usize, F>>],
 ) -> (Vec<usize>, Vec<usize>, Vec<F>) {
     let capacity = chunks.iter().map(Vec::len).sum::<usize>();
+    let mut builder = CscPartsBuilder::new(nrow, ncol, capacity);
     let mut heap = BinaryHeap::with_capacity(chunks.len());
     for (chunk_index, chunk) in chunks.iter().enumerate() {
         if let Some(first) = chunk.first() {
@@ -1703,35 +1764,9 @@ fn merge_sorted_triplet_chunks_to_csc<F: Real>(
         }
     }
 
-    let mut col_ptr = Vec::with_capacity(ncol + 1);
-    let mut row_idx = Vec::with_capacity(capacity);
-    let mut vals = Vec::with_capacity(capacity);
-    let mut next_col = 0usize;
-    let mut pending: Option<Triplet<usize, usize, F>> = None;
-    col_ptr.push(0);
-
     while let Some(cursor) = heap.pop() {
         let triplet = chunks[cursor.chunk][cursor.index];
-        debug_assert!(triplet.row < nrow);
-        debug_assert!(triplet.col < ncol);
-
-        match pending {
-            Some(mut current) if current.col == triplet.col && current.row == triplet.row => {
-                current.val = current.val + triplet.val;
-                pending = Some(current);
-            }
-            Some(current) => {
-                push_csc_entry(
-                    current,
-                    &mut next_col,
-                    &mut col_ptr,
-                    &mut row_idx,
-                    &mut vals,
-                );
-                pending = Some(triplet);
-            }
-            None => pending = Some(triplet),
-        }
+        builder.push_sorted(triplet);
 
         let next_index = cursor.index + 1;
         if next_index < chunks[cursor.chunk].len() {
@@ -1745,21 +1780,7 @@ fn merge_sorted_triplet_chunks_to_csc<F: Real>(
         }
     }
 
-    if let Some(current) = pending {
-        push_csc_entry(
-            current,
-            &mut next_col,
-            &mut col_ptr,
-            &mut row_idx,
-            &mut vals,
-        );
-    }
-    while next_col < ncol {
-        col_ptr.push(row_idx.len());
-        next_col += 1;
-    }
-    debug_assert_eq!(col_ptr.len(), ncol + 1);
-    (col_ptr, row_idx, vals)
+    builder.finish()
 }
 
 /// Pack triplets sorted by `(column, row)` into canonical CSC arrays.
@@ -1768,69 +1789,11 @@ fn pack_sorted_triplets_to_csc<F: Real>(
     ncol: usize,
     triplets: Vec<Triplet<usize, usize, F>>,
 ) -> (Vec<usize>, Vec<usize>, Vec<F>) {
-    let mut col_ptr = Vec::with_capacity(ncol + 1);
-    let mut row_idx = Vec::with_capacity(triplets.len());
-    let mut vals = Vec::with_capacity(triplets.len());
-    let mut next_col = 0usize;
-    col_ptr.push(0);
-
-    let mut pending: Option<Triplet<usize, usize, F>> = None;
+    let mut builder = CscPartsBuilder::new(nrow, ncol, triplets.len());
     for triplet in triplets {
-        debug_assert!(triplet.row < nrow);
-        debug_assert!(triplet.col < ncol);
-        if triplet.val == F::zero() {
-            continue;
-        }
-        match pending {
-            Some(mut current) if current.col == triplet.col && current.row == triplet.row => {
-                current.val = current.val + triplet.val;
-                pending = Some(current);
-            }
-            Some(current) => {
-                push_csc_entry(
-                    current,
-                    &mut next_col,
-                    &mut col_ptr,
-                    &mut row_idx,
-                    &mut vals,
-                );
-                pending = Some(triplet);
-            }
-            None => pending = Some(triplet),
-        }
+        builder.push_sorted(triplet);
     }
-    if let Some(current) = pending {
-        push_csc_entry(
-            current,
-            &mut next_col,
-            &mut col_ptr,
-            &mut row_idx,
-            &mut vals,
-        );
-    }
-    while next_col < ncol {
-        col_ptr.push(row_idx.len());
-        next_col += 1;
-    }
-    debug_assert_eq!(col_ptr.len(), ncol + 1);
-    (col_ptr, row_idx, vals)
-}
-
-fn push_csc_entry<F: Real>(
-    entry: Triplet<usize, usize, F>,
-    next_col: &mut usize,
-    col_ptr: &mut Vec<usize>,
-    row_idx: &mut Vec<usize>,
-    vals: &mut Vec<F>,
-) {
-    while *next_col < entry.col {
-        col_ptr.push(row_idx.len());
-        *next_col += 1;
-    }
-    if entry.val != F::zero() {
-        row_idx.push(entry.row);
-        vals.push(entry.val);
-    }
+    builder.finish()
 }
 
 /// Apply one reduced CSR load operator to a dense load-amplitude vector and accumulate the result.

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -1,5 +1,8 @@
 //! Reduced-model assembly and solve wrapper for the 2D structural FEM.
 
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
 use deimos_numerics::sparse::{
     BiCGSTAB, BiCGSTABSolveError, CompensatedField, DiagonalPrecond, Equilibration,
     EquilibrationParams, Precond, SparseMatVec,
@@ -7,13 +10,17 @@ use deimos_numerics::sparse::{
 use faer::linalg::solvers::Solve;
 use faer::sparse::linalg::matmul::sparse_dense_matmul;
 use faer::sparse::linalg::solvers::Lu;
-use faer::sparse::{SparseColMat, SparseColMatRef, SparseRowMat, SymbolicSparseRowMat, Triplet};
+use faer::sparse::{
+    SparseColMat, SparseColMatRef, SparseRowMat, SymbolicSparseColMat, SymbolicSparseRowMat,
+    Triplet,
+};
 use faer::{Accum, Col, Par};
+use rayon::prelude::*;
 
 use crate::mesh::elements::quad2d::{quad4, quad9};
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::assembly::{
-    assemble_stiffness_for_family, assemble_stiffness_for_family_par,
+    assemble_stiffness_chunks_for_family_par, assemble_stiffness_for_family,
 };
 use crate::physics::solenoid_stress::convenience::{
     QuadratureFieldSamples, Structural2dElementMeasures, Structural2dElementQuadrature,
@@ -30,7 +37,8 @@ use crate::physics::solenoid_stress::recovery::{
     reduced_quadrature_field_operators_for_family_par,
 };
 use crate::physics::solenoid_stress::types::{
-    PressureLoad, Real, Structural2dFormulation, ThermalMaterial, TractionLoad, dof_per_element,
+    PressureLoad, Real, StiffnessTriplets, Structural2dFormulation, ThermalMaterial, TractionLoad,
+    dof_per_element,
 };
 
 macro_rules! timed_stage {
@@ -1188,44 +1196,80 @@ where
         })?;
     let ndof_reduced = free_dofs.len();
 
-    // Assemble stiffness in the full displacement space first, then apply Dirichlet reduction.
-    // This keeps the element kernels simple and pushes all constraint handling into the common
-    // reduction helpers below.
-    let stiffness_full = timed_stage!(timing_enabled, "rust.build_model.stiffness_triplets", {
-        if par {
-            assemble_stiffness_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                material_ids,
-                material_table,
-                material_orientation_angles,
-                formulation,
-                quadrature,
-            )
-        } else {
-            assemble_stiffness_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                material_ids,
-                material_table,
-                material_orientation_angles,
-                formulation,
-                quadrature,
-            )
-        }
-    })?;
     let mut constant_rhs = vec![F::zero(); ndof_reduced];
-    let stiffness_reduced = timed_stage!(timing_enabled, "rust.build_model.reduce_stiffness", {
-        reduce_square_triplets(
-            &stiffness_full.rows,
-            &stiffness_full.cols,
-            &stiffness_full.vals,
-            &global_to_reduced,
-            &fixed_lookup,
-            &mut constant_rhs,
-        )
-    });
-    let stiffness = timed_stage!(timing_enabled, "rust.build_model.stiffness_csc", {
-        csc_from_triplets(ndof_reduced, ndof_reduced, stiffness_reduced)
-    })?;
+    // Assemble stiffness in the full displacement space first, then apply Dirichlet reduction.
+    // The parallel path keeps worker chunks separate so each chunk can be reduced and sorted
+    // independently before a k-way merge builds the canonical CSC structure.
+    let stiffness = if par {
+        let stiffness_chunks =
+            timed_stage!(timing_enabled, "rust.build_model.stiffness_triplets", {
+                assemble_stiffness_chunks_for_family_par::<
+                    F,
+                    Family,
+                    NODES_PER_ELEMENT,
+                    DOF_PER_ELEMENT,
+                >(
+                    mesh,
+                    material_ids,
+                    material_table,
+                    material_orientation_angles,
+                    formulation,
+                    quadrature,
+                )
+            })?;
+        let sorted_chunks = timed_stage!(
+            timing_enabled,
+            "rust.build_model.reduce_stiffness_chunk_sort",
+            {
+                reduce_sort_stiffness_chunks(
+                    stiffness_chunks,
+                    &global_to_reduced,
+                    &fixed_lookup,
+                    &mut constant_rhs,
+                    ndof_reduced,
+                )
+            }
+        );
+        timed_stage!(timing_enabled, "rust.build_model.stiffness_csc", {
+            csc_from_sorted_triplet_chunks(
+                ndof_reduced,
+                ndof_reduced,
+                sorted_chunks,
+                timing_enabled,
+            )
+        })
+    } else {
+        let stiffness_full =
+            timed_stage!(timing_enabled, "rust.build_model.stiffness_triplets", {
+                assemble_stiffness_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                    mesh,
+                    material_ids,
+                    material_table,
+                    material_orientation_angles,
+                    formulation,
+                    quadrature,
+                )
+            })?;
+        let stiffness_reduced =
+            timed_stage!(timing_enabled, "rust.build_model.reduce_stiffness", {
+                reduce_square_triplets(
+                    &stiffness_full.rows,
+                    &stiffness_full.cols,
+                    &stiffness_full.vals,
+                    &global_to_reduced,
+                    &fixed_lookup,
+                    &mut constant_rhs,
+                )
+            });
+        timed_stage!(timing_enabled, "rust.build_model.stiffness_csc", {
+            csc_from_triplets(
+                ndof_reduced,
+                ndof_reduced,
+                stiffness_reduced,
+                timing_enabled,
+            )
+        })
+    };
     if timing_enabled {
         eprintln!(
             "[cfsem timing] rust.build_model.stiffness_csc.nnz: {}",
@@ -1556,6 +1600,82 @@ fn reduce_square_triplets<F: Real>(
     triplets
 }
 
+struct ReducedStiffnessChunk<F: Real> {
+    triplets: Vec<Triplet<usize, usize, F>>,
+    constant_rhs: Vec<F>,
+}
+
+/// Reduce, sort, and coalesce each stiffness chunk independently.
+fn reduce_sort_stiffness_chunks<F: Real>(
+    chunks: Vec<StiffnessTriplets<F>>,
+    global_to_reduced: &[usize],
+    fixed_lookup: &[Option<F>],
+    constant_rhs: &mut [F],
+    ndof_reduced: usize,
+) -> Vec<Vec<Triplet<usize, usize, F>>> {
+    let reduced_chunks = chunks
+        .into_par_iter()
+        .map(|chunk| {
+            let mut local_rhs = vec![F::zero(); ndof_reduced];
+            let triplets = reduce_square_triplets(
+                &chunk.rows,
+                &chunk.cols,
+                &chunk.vals,
+                global_to_reduced,
+                fixed_lookup,
+                &mut local_rhs,
+            );
+            ReducedStiffnessChunk {
+                triplets: sort_coalesce_triplets(triplets),
+                constant_rhs: local_rhs,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut sorted_chunks = Vec::with_capacity(reduced_chunks.len());
+    for chunk in reduced_chunks {
+        for (dst, src) in constant_rhs.iter_mut().zip(chunk.constant_rhs) {
+            *dst = *dst + src;
+        }
+        sorted_chunks.push(chunk.triplets);
+    }
+    sorted_chunks
+}
+
+/// Return triplets in canonical CSC order with duplicate `(column, row)` entries coalesced.
+fn sort_coalesce_triplets<F: Real>(
+    mut triplets: Vec<Triplet<usize, usize, F>>,
+) -> Vec<Triplet<usize, usize, F>> {
+    triplets.sort_by(|a, b| a.col.cmp(&b.col).then_with(|| a.row.cmp(&b.row)));
+
+    let mut coalesced = Vec::with_capacity(triplets.len());
+    let mut pending: Option<Triplet<usize, usize, F>> = None;
+    for triplet in triplets {
+        if triplet.val == F::zero() {
+            continue;
+        }
+        match pending {
+            Some(mut current) if current.col == triplet.col && current.row == triplet.row => {
+                current.val = current.val + triplet.val;
+                pending = Some(current);
+            }
+            Some(current) => {
+                if current.val != F::zero() {
+                    coalesced.push(current);
+                }
+                pending = Some(triplet);
+            }
+            None => pending = Some(triplet),
+        }
+    }
+    if let Some(current) = pending
+        && current.val != F::zero()
+    {
+        coalesced.push(current);
+    }
+    coalesced
+}
+
 /// Drop rows belonging to fixed displacement DOFs from one full-system load operator.
 fn reduce_row_operator<F: Real>(
     operator: SparseOperator<F>,
@@ -1637,10 +1757,211 @@ fn csr_from_canonical_parts<F: Real>(parts: CsrOperatorParts<F>) -> SparseRowMat
 fn csc_from_triplets<F: Real>(
     nrow: usize,
     ncol: usize,
+    mut triplets: Vec<Triplet<usize, usize, F>>,
+    timing_enabled: bool,
+) -> SparseColMat<usize, F> {
+    timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.sort", {
+        triplets.sort_by(|a, b| a.col.cmp(&b.col).then_with(|| a.row.cmp(&b.row)));
+    });
+
+    let (col_ptr, row_idx, vals) =
+        timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.pack", {
+            pack_sorted_triplets_to_csc(nrow, ncol, triplets)
+        });
+    timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.wrap", {
+        let symbolic = SymbolicSparseColMat::new_checked(nrow, ncol, col_ptr, None, row_idx);
+        SparseColMat::new(symbolic, vals)
+    })
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct TripletCursor {
+    col: usize,
+    row: usize,
+    chunk: usize,
+    index: usize,
+}
+
+impl Ord for TripletCursor {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .col
+            .cmp(&self.col)
+            .then_with(|| other.row.cmp(&self.row))
+            .then_with(|| other.chunk.cmp(&self.chunk))
+            .then_with(|| other.index.cmp(&self.index))
+    }
+}
+
+impl PartialOrd for TripletCursor {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Merge already sorted/coalesced triplet chunks into the CSC format used by sparse LU.
+fn csc_from_sorted_triplet_chunks<F: Real>(
+    nrow: usize,
+    ncol: usize,
+    chunks: Vec<Vec<Triplet<usize, usize, F>>>,
+    timing_enabled: bool,
+) -> SparseColMat<usize, F> {
+    let (col_ptr, row_idx, vals) =
+        timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.merge", {
+            merge_sorted_triplet_chunks_to_csc(nrow, ncol, &chunks)
+        });
+    timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.wrap", {
+        let symbolic = SymbolicSparseColMat::new_checked(nrow, ncol, col_ptr, None, row_idx);
+        SparseColMat::new(symbolic, vals)
+    })
+}
+
+fn merge_sorted_triplet_chunks_to_csc<F: Real>(
+    nrow: usize,
+    ncol: usize,
+    chunks: &[Vec<Triplet<usize, usize, F>>],
+) -> (Vec<usize>, Vec<usize>, Vec<F>) {
+    let capacity = chunks.iter().map(Vec::len).sum::<usize>();
+    let mut heap = BinaryHeap::with_capacity(chunks.len());
+    for (chunk_index, chunk) in chunks.iter().enumerate() {
+        if let Some(first) = chunk.first() {
+            heap.push(TripletCursor {
+                col: first.col,
+                row: first.row,
+                chunk: chunk_index,
+                index: 0,
+            });
+        }
+    }
+
+    let mut col_ptr = Vec::with_capacity(ncol + 1);
+    let mut row_idx = Vec::with_capacity(capacity);
+    let mut vals = Vec::with_capacity(capacity);
+    let mut next_col = 0usize;
+    let mut pending: Option<Triplet<usize, usize, F>> = None;
+    col_ptr.push(0);
+
+    while let Some(cursor) = heap.pop() {
+        let triplet = chunks[cursor.chunk][cursor.index];
+        debug_assert!(triplet.row < nrow);
+        debug_assert!(triplet.col < ncol);
+
+        match pending {
+            Some(mut current) if current.col == triplet.col && current.row == triplet.row => {
+                current.val = current.val + triplet.val;
+                pending = Some(current);
+            }
+            Some(current) => {
+                push_csc_entry(
+                    current,
+                    &mut next_col,
+                    &mut col_ptr,
+                    &mut row_idx,
+                    &mut vals,
+                );
+                pending = Some(triplet);
+            }
+            None => pending = Some(triplet),
+        }
+
+        let next_index = cursor.index + 1;
+        if next_index < chunks[cursor.chunk].len() {
+            let next = chunks[cursor.chunk][next_index];
+            heap.push(TripletCursor {
+                col: next.col,
+                row: next.row,
+                chunk: cursor.chunk,
+                index: next_index,
+            });
+        }
+    }
+
+    if let Some(current) = pending {
+        push_csc_entry(
+            current,
+            &mut next_col,
+            &mut col_ptr,
+            &mut row_idx,
+            &mut vals,
+        );
+    }
+    while next_col < ncol {
+        col_ptr.push(row_idx.len());
+        next_col += 1;
+    }
+    debug_assert_eq!(col_ptr.len(), ncol + 1);
+    (col_ptr, row_idx, vals)
+}
+
+/// Pack triplets sorted by `(column, row)` into canonical CSC arrays.
+fn pack_sorted_triplets_to_csc<F: Real>(
+    nrow: usize,
+    ncol: usize,
     triplets: Vec<Triplet<usize, usize, F>>,
-) -> Result<SparseColMat<usize, F>, String> {
-    SparseColMat::try_new_from_triplets(nrow, ncol, &triplets)
-        .map_err(|err| format!("failed to build CSC operator: {err:?}"))
+) -> (Vec<usize>, Vec<usize>, Vec<F>) {
+    let mut col_ptr = Vec::with_capacity(ncol + 1);
+    let mut row_idx = Vec::with_capacity(triplets.len());
+    let mut vals = Vec::with_capacity(triplets.len());
+    let mut next_col = 0usize;
+    col_ptr.push(0);
+
+    let mut pending: Option<Triplet<usize, usize, F>> = None;
+    for triplet in triplets {
+        debug_assert!(triplet.row < nrow);
+        debug_assert!(triplet.col < ncol);
+        if triplet.val == F::zero() {
+            continue;
+        }
+        match pending {
+            Some(mut current) if current.col == triplet.col && current.row == triplet.row => {
+                current.val = current.val + triplet.val;
+                pending = Some(current);
+            }
+            Some(current) => {
+                push_csc_entry(
+                    current,
+                    &mut next_col,
+                    &mut col_ptr,
+                    &mut row_idx,
+                    &mut vals,
+                );
+                pending = Some(triplet);
+            }
+            None => pending = Some(triplet),
+        }
+    }
+    if let Some(current) = pending {
+        push_csc_entry(
+            current,
+            &mut next_col,
+            &mut col_ptr,
+            &mut row_idx,
+            &mut vals,
+        );
+    }
+    while next_col < ncol {
+        col_ptr.push(row_idx.len());
+        next_col += 1;
+    }
+    debug_assert_eq!(col_ptr.len(), ncol + 1);
+    (col_ptr, row_idx, vals)
+}
+
+fn push_csc_entry<F: Real>(
+    entry: Triplet<usize, usize, F>,
+    next_col: &mut usize,
+    col_ptr: &mut Vec<usize>,
+    row_idx: &mut Vec<usize>,
+    vals: &mut Vec<F>,
+) {
+    while *next_col < entry.col {
+        col_ptr.push(row_idx.len());
+        *next_col += 1;
+    }
+    if entry.val != F::zero() {
+        row_idx.push(entry.row);
+        vals.push(entry.val);
+    }
 }
 
 /// Apply one reduced CSR load operator to a dense load-amplitude vector and accumulate the result.

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -41,23 +41,6 @@ use crate::physics::solenoid_stress::types::{
     dof_per_element,
 };
 
-macro_rules! timed_stage {
-    ($enabled:expr, $label:expr, $body:block) => {{
-        if $enabled {
-            let start = std::time::Instant::now();
-            let result = (|| $body)();
-            eprintln!(
-                "[cfsem timing] {}: {:.6} s",
-                $label,
-                start.elapsed().as_secs_f64()
-            );
-            result
-        } else {
-            (|| $body)()
-        }
-    }};
-}
-
 mod private {
     use super::{CompensatedField, Real};
 
@@ -1174,16 +1157,6 @@ fn build_model_for_family<
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
-    let timing_enabled = std::env::var_os("CFSEM_TIMING").is_some();
-    let total_start = std::time::Instant::now();
-    if timing_enabled {
-        eprintln!(
-            "[cfsem timing] rust.build_model.start: nnode={} nelem={} par={}",
-            nodes_rz.len(),
-            elements.len(),
-            par
-        );
-    }
     let mesh = QuadMeshView2d { nodes_rz, elements };
     let ndof_full = nodes_rz.len() * 2;
     let nelem = elements.len();
@@ -1191,9 +1164,7 @@ where
     // live in the constrained reduced system, while `fixed_lookup` carries the prescribed values
     // needed to fold eliminated DOFs back into constant RHS terms.
     let (free_dofs, fixed_dofs, fixed_values, global_to_reduced, fixed_lookup) =
-        timed_stage!(timing_enabled, "rust.build_model.reduce_layout", {
-            reduce_layout(ndof_full, prescribed)
-        })?;
+        reduce_layout(ndof_full, prescribed)?;
     let ndof_reduced = free_dofs.len();
 
     let mut constant_rhs = vec![F::zero(); ndof_reduced];
@@ -1201,274 +1172,193 @@ where
     // The parallel path keeps worker chunks separate so each chunk can be reduced and sorted
     // independently before a k-way merge builds the canonical CSC structure.
     let stiffness = if par {
-        let stiffness_chunks =
-            timed_stage!(timing_enabled, "rust.build_model.stiffness_triplets", {
-                assemble_stiffness_chunks_for_family_par::<
-                    F,
-                    Family,
-                    NODES_PER_ELEMENT,
-                    DOF_PER_ELEMENT,
-                >(
-                    mesh,
-                    material_ids,
-                    material_table,
-                    material_orientation_angles,
-                    formulation,
-                    quadrature,
-                )
-            })?;
-        let sorted_chunks = timed_stage!(
-            timing_enabled,
-            "rust.build_model.reduce_stiffness_chunk_sort",
-            {
-                reduce_sort_stiffness_chunks(
-                    stiffness_chunks,
-                    &global_to_reduced,
-                    &fixed_lookup,
-                    &mut constant_rhs,
-                    ndof_reduced,
-                )
-            }
+        let stiffness_chunks = assemble_stiffness_chunks_for_family_par::<
+            F,
+            Family,
+            NODES_PER_ELEMENT,
+            DOF_PER_ELEMENT,
+        >(
+            mesh,
+            material_ids,
+            material_table,
+            material_orientation_angles,
+            formulation,
+            quadrature,
+        )?;
+        let sorted_chunks = reduce_sort_stiffness_chunks(
+            stiffness_chunks,
+            &global_to_reduced,
+            &fixed_lookup,
+            &mut constant_rhs,
+            ndof_reduced,
         );
-        timed_stage!(timing_enabled, "rust.build_model.stiffness_csc", {
-            csc_from_sorted_triplet_chunks(
-                ndof_reduced,
-                ndof_reduced,
-                sorted_chunks,
-                timing_enabled,
-            )
-        })
+        csc_from_sorted_triplet_chunks(ndof_reduced, ndof_reduced, sorted_chunks)
     } else {
         let stiffness_full =
-            timed_stage!(timing_enabled, "rust.build_model.stiffness_triplets", {
-                assemble_stiffness_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                    mesh,
-                    material_ids,
-                    material_table,
-                    material_orientation_angles,
-                    formulation,
-                    quadrature,
-                )
-            })?;
-        let stiffness_reduced =
-            timed_stage!(timing_enabled, "rust.build_model.reduce_stiffness", {
-                reduce_square_triplets(
-                    &stiffness_full.rows,
-                    &stiffness_full.cols,
-                    &stiffness_full.vals,
-                    &global_to_reduced,
-                    &fixed_lookup,
-                    &mut constant_rhs,
-                )
-            });
-        timed_stage!(timing_enabled, "rust.build_model.stiffness_csc", {
-            csc_from_triplets(
-                ndof_reduced,
-                ndof_reduced,
-                stiffness_reduced,
-                timing_enabled,
-            )
-        })
-    };
-    if timing_enabled {
-        eprintln!(
-            "[cfsem timing] rust.build_model.stiffness_csc.nnz: {}",
-            stiffness.val().len()
+            assemble_stiffness_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                material_ids,
+                material_table,
+                material_orientation_angles,
+                formulation,
+                quadrature,
+            )?;
+        let stiffness_reduced = reduce_square_triplets(
+            &stiffness_full.rows,
+            &stiffness_full.cols,
+            &stiffness_full.vals,
+            &global_to_reduced,
+            &fixed_lookup,
+            &mut constant_rhs,
         );
-    }
+        csc_from_triplets(ndof_reduced, ndof_reduced, stiffness_reduced)
+    };
     // Most load operators are naturally assembled in full nodal space and then reduced by
     // dropping rows associated with prescribed displacement DOFs.
     let reduce_operator =
         |operator| reduce_row_operator_to_csr(operator, &global_to_reduced, ndof_reduced);
 
-    let (temperature_to_rhs, thermal_reference_rhs, n_temperature_nodes) =
-        if let Some(thermal_material_table) = thermal_material_table {
-            // Thermal loading has both a temperature-dependent operator and a constant offset from
-            // per-material reference temperature, so keep those two pieces separate until the end.
-            let thermal_full =
-                timed_stage!(timing_enabled, "rust.build_model.thermal_operator", {
-                    if par {
-                        temperature_operator_for_family_par::<
-                            F,
-                            Family,
-                            NODES_PER_ELEMENT,
-                            DOF_PER_ELEMENT,
-                        >(
-                            mesh,
-                            material_ids,
-                            material_table,
-                            thermal_material_table,
-                            material_orientation_angles,
-                            formulation,
-                            quadrature,
-                        )
-                    } else {
-                        temperature_operator_for_family::<
-                            F,
-                            Family,
-                            NODES_PER_ELEMENT,
-                            DOF_PER_ELEMENT,
-                        >(
-                            mesh,
-                            material_ids,
-                            material_table,
-                            thermal_material_table,
-                            material_orientation_angles,
-                            formulation,
-                            quadrature,
-                        )
-                    }
-                })?;
-            let reduced_reference_rhs = timed_stage!(
-                timing_enabled,
-                "rust.build_model.thermal_reference_reduce",
-                {
-                    free_dofs
-                        .iter()
-                        .map(|&dof| thermal_full.reference_rhs[dof])
-                        .collect::<Vec<_>>()
-                }
-            );
-            (
-                timed_stage!(timing_enabled, "rust.build_model.thermal_reduce_csr", {
-                    reduce_operator(thermal_full.temperature_to_rhs)
-                })?,
-                reduced_reference_rhs,
-                nodes_rz.len(),
+    let (temperature_to_rhs, thermal_reference_rhs, n_temperature_nodes) = if let Some(
+        thermal_material_table,
+    ) =
+        thermal_material_table
+    {
+        // Thermal loading has both a temperature-dependent operator and a constant offset from
+        // per-material reference temperature, so keep those two pieces separate until the end.
+        let thermal_full = if par {
+            temperature_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                material_ids,
+                material_table,
+                thermal_material_table,
+                material_orientation_angles,
+                formulation,
+                quadrature,
             )
         } else {
-            (
-                timed_stage!(timing_enabled, "rust.build_model.empty_temperature_csr", {
-                    csr_from_parts(ndof_reduced, 0, Vec::new(), Vec::new(), Vec::new())
-                })?,
-                vec![F::zero(); ndof_reduced],
-                0,
+            temperature_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                material_ids,
+                material_table,
+                thermal_material_table,
+                material_orientation_angles,
+                formulation,
+                quadrature,
             )
-        };
+        }?;
+        let reduced_reference_rhs = free_dofs
+            .iter()
+            .map(|&dof| thermal_full.reference_rhs[dof])
+            .collect::<Vec<_>>();
+        (
+            reduce_operator(thermal_full.temperature_to_rhs)?,
+            reduced_reference_rhs,
+            nodes_rz.len(),
+        )
+    } else {
+        (
+            csr_from_parts(ndof_reduced, 0, Vec::new(), Vec::new(), Vec::new())?,
+            vec![F::zero(); ndof_reduced],
+            0,
+        )
+    };
     // `constant_rhs` already contains the Dirichlet offset from stiffness reduction. Add the
     // reference-temperature contribution so all load-independent terms live in one vector.
-    timed_stage!(timing_enabled, "rust.build_model.constant_rhs_merge", {
-        for (dst, src) in constant_rhs.iter_mut().zip(&thermal_reference_rhs) {
-            *dst = *dst + *src;
-        }
-    });
+    for (dst, src) in constant_rhs.iter_mut().zip(&thermal_reference_rhs) {
+        *dst = *dst + *src;
+    }
 
     // These operators are stored directly in reduced row space because `build_rhs(...)` and
     // `solve(...)` work only with the constrained system.
-    let body_force_to_rhs =
-        timed_stage!(timing_enabled, "rust.build_model.body_force_operator", {
-            let operator = if par {
-                body_force_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                    mesh,
-                    formulation,
-                    quadrature,
-                )?
-            } else {
-                body_force_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                    mesh,
-                    formulation,
-                    quadrature,
-                )?
-            };
-            reduce_operator(operator)
-        })?;
-    let pressure_to_rhs = timed_stage!(timing_enabled, "rust.build_model.pressure_operator", {
-        let operator = if par {
-            pressure_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                pressure_faces,
-                formulation,
-                quadrature,
-            )?
-        } else {
-            pressure_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                pressure_faces,
-                formulation,
-                quadrature,
-            )?
-        };
-        reduce_operator(operator)
-    })?;
-    let traction_to_rhs = timed_stage!(timing_enabled, "rust.build_model.traction_operator", {
-        let operator = if par {
-            traction_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                traction_faces,
-                formulation,
-                quadrature,
-            )?
-        } else {
-            traction_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                traction_faces,
-                formulation,
-                quadrature,
-            )?
-        };
-        reduce_operator(operator)
-    })?;
+    let body_force_operator = if par {
+        body_force_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            formulation,
+            quadrature,
+        )?
+    } else {
+        body_force_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            formulation,
+            quadrature,
+        )?
+    };
+    let body_force_to_rhs = reduce_operator(body_force_operator)?;
+    let pressure_operator = if par {
+        pressure_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            pressure_faces,
+            formulation,
+            quadrature,
+        )?
+    } else {
+        pressure_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            pressure_faces,
+            formulation,
+            quadrature,
+        )?
+    };
+    let pressure_to_rhs = reduce_operator(pressure_operator)?;
+    let traction_operator = if par {
+        traction_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            traction_faces,
+            formulation,
+            quadrature,
+        )?
+    } else {
+        traction_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            traction_faces,
+            formulation,
+            quadrature,
+        )?
+    };
+    let traction_to_rhs = reduce_operator(traction_operator)?;
 
     // Recovery rows are disjoint by quadrature point, so assemble directly in reduced CSR form
     // instead of building full-space triplets and reducing them afterwards.
-    let recovery_reduced =
-        timed_stage!(timing_enabled, "rust.build_model.recovery_reduced_csr", {
-            if par {
-                reduced_quadrature_field_operators_for_family_par::<
-                    F,
-                    Family,
-                    NODES_PER_ELEMENT,
-                    DOF_PER_ELEMENT,
-                >(
-                    mesh,
-                    material_ids,
-                    material_table,
-                    thermal_material_table,
-                    material_orientation_angles,
-                    formulation,
-                    quadrature,
-                    &global_to_reduced,
-                    &fixed_lookup,
-                    ndof_reduced,
-                )
-            } else {
-                reduced_quadrature_field_operators_for_family::<
-                    F,
-                    Family,
-                    NODES_PER_ELEMENT,
-                    DOF_PER_ELEMENT,
-                >(
-                    mesh,
-                    material_ids,
-                    material_table,
-                    thermal_material_table,
-                    material_orientation_angles,
-                    formulation,
-                    quadrature,
-                    &global_to_reduced,
-                    &fixed_lookup,
-                    ndof_reduced,
-                )
-            }
-        })?;
-    let strain_operator = timed_stage!(timing_enabled, "rust.build_model.strain_csr_wrap", {
-        csr_from_canonical_parts(recovery_reduced.strain_operator)
-    });
-    let stress_operator = timed_stage!(timing_enabled, "rust.build_model.stress_csr_wrap", {
-        csr_from_canonical_parts(recovery_reduced.stress_operator)
-    });
-    let thermal_strain_operator = timed_stage!(
-        timing_enabled,
-        "rust.build_model.thermal_strain_csr_wrap",
-        { csr_from_canonical_parts(recovery_reduced.thermal_strain_operator) }
-    );
-    let thermal_stress_operator = timed_stage!(
-        timing_enabled,
-        "rust.build_model.thermal_stress_csr_wrap",
-        { csr_from_canonical_parts(recovery_reduced.thermal_stress_operator) }
-    );
+    let recovery_reduced = if par {
+        reduced_quadrature_field_operators_for_family_par::<
+            F,
+            Family,
+            NODES_PER_ELEMENT,
+            DOF_PER_ELEMENT,
+        >(
+            mesh,
+            material_ids,
+            material_table,
+            thermal_material_table,
+            material_orientation_angles,
+            formulation,
+            quadrature,
+            &global_to_reduced,
+            &fixed_lookup,
+            ndof_reduced,
+        )
+    } else {
+        reduced_quadrature_field_operators_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            material_ids,
+            material_table,
+            thermal_material_table,
+            material_orientation_angles,
+            formulation,
+            quadrature,
+            &global_to_reduced,
+            &fixed_lookup,
+            ndof_reduced,
+        )
+    }?;
+    let strain_operator = csr_from_canonical_parts(recovery_reduced.strain_operator);
+    let stress_operator = csr_from_canonical_parts(recovery_reduced.stress_operator);
+    let thermal_strain_operator =
+        csr_from_canonical_parts(recovery_reduced.thermal_strain_operator);
+    let thermal_stress_operator =
+        csr_from_canonical_parts(recovery_reduced.thermal_stress_operator);
 
-    let model = Structural2dModel {
+    Ok(Structural2dModel {
         stiffness,
         body_force_to_rhs,
         pressure_to_rhs,
@@ -1515,14 +1405,7 @@ where
         equilibrated_stiffness: None,
         equilibrated_diagonal_preconditioner: None,
         previous_bicgstab_solution: None,
-    };
-    if timing_enabled {
-        eprintln!(
-            "[cfsem timing] rust.build_model.total: {:.6} s",
-            total_start.elapsed().as_secs_f64()
-        );
-    }
-    Ok(model)
+    })
 }
 
 /// Partition full-system displacement DOFs into free and fixed sets for Dirichlet reduction.
@@ -1758,20 +1641,12 @@ fn csc_from_triplets<F: Real>(
     nrow: usize,
     ncol: usize,
     mut triplets: Vec<Triplet<usize, usize, F>>,
-    timing_enabled: bool,
 ) -> SparseColMat<usize, F> {
-    timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.sort", {
-        triplets.sort_by(|a, b| a.col.cmp(&b.col).then_with(|| a.row.cmp(&b.row)));
-    });
+    triplets.sort_by(|a, b| a.col.cmp(&b.col).then_with(|| a.row.cmp(&b.row)));
 
-    let (col_ptr, row_idx, vals) =
-        timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.pack", {
-            pack_sorted_triplets_to_csc(nrow, ncol, triplets)
-        });
-    timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.wrap", {
-        let symbolic = SymbolicSparseColMat::new_checked(nrow, ncol, col_ptr, None, row_idx);
-        SparseColMat::new(symbolic, vals)
-    })
+    let (col_ptr, row_idx, vals) = pack_sorted_triplets_to_csc(nrow, ncol, triplets);
+    let symbolic = SymbolicSparseColMat::new_checked(nrow, ncol, col_ptr, None, row_idx);
+    SparseColMat::new(symbolic, vals)
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -1804,16 +1679,10 @@ fn csc_from_sorted_triplet_chunks<F: Real>(
     nrow: usize,
     ncol: usize,
     chunks: Vec<Vec<Triplet<usize, usize, F>>>,
-    timing_enabled: bool,
 ) -> SparseColMat<usize, F> {
-    let (col_ptr, row_idx, vals) =
-        timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.merge", {
-            merge_sorted_triplet_chunks_to_csc(nrow, ncol, &chunks)
-        });
-    timed_stage!(timing_enabled, "rust.build_model.stiffness_csc.wrap", {
-        let symbolic = SymbolicSparseColMat::new_checked(nrow, ncol, col_ptr, None, row_idx);
-        SparseColMat::new(symbolic, vals)
-    })
+    let (col_ptr, row_idx, vals) = merge_sorted_triplet_chunks_to_csc(nrow, ncol, &chunks);
+    let symbolic = SymbolicSparseColMat::new_checked(nrow, ncol, col_ptr, None, row_idx);
+    SparseColMat::new(symbolic, vals)
 }
 
 fn merge_sorted_triplet_chunks_to_csc<F: Real>(

--- a/src/physics/solenoid_stress/recovery.rs
+++ b/src/physics/solenoid_stress/recovery.rs
@@ -36,7 +36,12 @@
 //! Thermal recovery remains quadrature-specific because it maps nodal temperatures and material
 //! reference temperatures to thermal strain/stress offsets.
 
+use rayon::prelude::*;
+
+use crate::chunksize;
+#[cfg(test)]
 use crate::mesh::elements::quad2d::quadrature::gauss_volume;
+#[cfg(test)]
 use crate::mesh::quad2d::{quad_mesh_strain_operator, quad_mesh_stress_operator};
 use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::axisym::constitutive_times_strain;
@@ -45,15 +50,18 @@ use crate::physics::solenoid_stress::convenience::{
 };
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
+#[cfg(test)]
+use crate::physics::solenoid_stress::types::scatter_local_matrix;
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, scatter_local_matrix,
-    validate_element_material_inputs,
+    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, validate_element_material_inputs,
 };
 
 /// Sparse quadrature-point recovery operators before reduction into the model-owned CSR form.
 ///
 /// Rows are stored in quadrature-point-major order with axisymmetric component ordering
 /// `[rr, zz, tt, rz]`, so rows `4*q .. 4*q + 3` correspond to one quadrature point.
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct QuadratureFieldOperators<F: Real> {
     /// Quadrature-point coordinates `(r, z)` in element-major order.
@@ -114,6 +122,32 @@ pub struct QuadratureFieldOperators<F: Real> {
     pub ntemp: usize,
 }
 
+/// Canonical CSR operator parts with strictly increasing column indices in each row.
+#[derive(Debug, Clone)]
+pub struct CsrOperatorParts<F: Real> {
+    pub nrow: usize,
+    pub ncol: usize,
+    pub row_ptr: Vec<usize>,
+    pub col_idx: Vec<usize>,
+    pub vals: Vec<F>,
+}
+
+/// Reduced-space quadrature recovery operators in direct CSR form.
+#[derive(Debug, Clone)]
+pub struct ReducedQuadratureFieldOperators<F: Real> {
+    pub points: Vec<[F; 2]>,
+    pub strain_operator: CsrOperatorParts<F>,
+    pub stress_operator: CsrOperatorParts<F>,
+    pub thermal_strain_operator: CsrOperatorParts<F>,
+    pub thermal_stress_operator: CsrOperatorParts<F>,
+    pub strain_constant: Vec<F>,
+    pub stress_constant: Vec<F>,
+    pub thermal_strain_constant: Vec<F>,
+    pub thermal_stress_constant: Vec<F>,
+    pub nq_per_element: usize,
+    pub ntemp: usize,
+}
+
 /// Dense thermal recovery operators for one quadrature point.
 ///
 /// Units:
@@ -167,20 +201,168 @@ fn thermal_sample_kernel<F: Real, const NODES_PER_ELEMENT: usize>(
 /// Quadrature recovery already knows which element owns each point. These arrays have the same
 /// shape expected by the query-coordinate strain/stress operators, but avoid the `O(nquery *
 /// nelem)` nearest-element search that `query_quad_mesh` performs for arbitrary physical points.
-fn element_major_reference_points<F: Real>(
-    nelem: usize,
+#[cfg(test)]
+fn element_major_reference_points_range<F: Real>(
+    element_start: usize,
+    element_end: usize,
     quadrature: QuadratureRule,
 ) -> (Vec<usize>, Vec<[F; 2]>) {
     let references = gauss_volume::<F>(quadrature);
+    let nelem = element_end - element_start;
     let mut element_indices = Vec::with_capacity(nelem * references.len());
     let mut reference_points = Vec::with_capacity(nelem * references.len());
-    for element_index in 0..nelem {
+    for element_index in element_start..element_end {
         for &(reference, _) in &references {
             element_indices.push(element_index);
             reference_points.push(reference);
         }
     }
     (element_indices, reference_points)
+}
+
+fn push_canonical_row<F: Real>(
+    entries: &mut Vec<(usize, F)>,
+    row_ptr: &mut Vec<usize>,
+    col_idx: &mut Vec<usize>,
+    vals: &mut Vec<F>,
+) {
+    entries.sort_unstable_by_key(|(col, _)| *col);
+    let mut pending: Option<(usize, F)> = None;
+    for (col, value) in entries.drain(..) {
+        if value == F::zero() {
+            continue;
+        }
+        match pending {
+            Some((pending_col, pending_value)) if pending_col == col => {
+                pending = Some((pending_col, pending_value + value));
+            }
+            Some((pending_col, pending_value)) => {
+                if pending_value != F::zero() {
+                    col_idx.push(pending_col);
+                    vals.push(pending_value);
+                }
+                pending = Some((col, value));
+            }
+            None => pending = Some((col, value)),
+        }
+    }
+    if let Some((col, value)) = pending
+        && value != F::zero()
+    {
+        col_idx.push(col);
+        vals.push(value);
+    }
+    row_ptr.push(col_idx.len());
+}
+
+fn append_reduced_displacement_entry<F: Real>(
+    entries: &mut Vec<(usize, F)>,
+    constant: &mut [F],
+    row: usize,
+    full_col: usize,
+    value: F,
+    global_to_reduced: &[usize],
+    fixed_lookup: &[Option<F>],
+) {
+    if value == F::zero() {
+        return;
+    }
+    let reduced_col = global_to_reduced[full_col];
+    if reduced_col != usize::MAX {
+        entries.push((reduced_col, value));
+    } else if let Some(fixed_value) = fixed_lookup[full_col] {
+        constant[row] = constant[row] + value * fixed_value;
+    }
+}
+
+fn append_temperature_entry<F: Real>(entries: &mut Vec<(usize, F)>, col: usize, value: F) {
+    if value != F::zero() {
+        entries.push((col, value));
+    }
+}
+
+fn concat_csr_chunks<F: Real>(
+    chunks: Vec<CsrOperatorParts<F>>,
+    nrow: usize,
+    ncol: usize,
+) -> CsrOperatorParts<F> {
+    let nnz = chunks.iter().map(|chunk| chunk.vals.len()).sum::<usize>();
+    let mut row_ptr = Vec::with_capacity(nrow + 1);
+    let mut col_idx = Vec::with_capacity(nnz);
+    let mut vals = Vec::with_capacity(nnz);
+    row_ptr.push(0);
+    for chunk in chunks {
+        debug_assert_eq!(chunk.ncol, ncol);
+        let offset = col_idx.len();
+        col_idx.extend(chunk.col_idx);
+        vals.extend(chunk.vals);
+        row_ptr.extend(chunk.row_ptr.into_iter().skip(1).map(|ptr| ptr + offset));
+    }
+    debug_assert_eq!(row_ptr.len(), nrow + 1);
+    CsrOperatorParts {
+        nrow,
+        ncol,
+        row_ptr,
+        col_idx,
+        vals,
+    }
+}
+
+fn concat_reduced_quadrature_chunks<F: Real>(
+    chunks: Vec<ReducedQuadratureFieldOperators<F>>,
+    nq_per_element: usize,
+    ntemp: usize,
+    ndof_reduced: usize,
+    n_temperature_nodes: usize,
+) -> ReducedQuadratureFieldOperators<F> {
+    let total_points = chunks.iter().map(|chunk| chunk.points.len()).sum::<usize>();
+    let nrow = total_points * 4;
+
+    let mut points = Vec::with_capacity(total_points);
+    let mut strain_chunks = Vec::with_capacity(chunks.len());
+    let mut stress_chunks = Vec::with_capacity(chunks.len());
+    let mut thermal_strain_chunks = Vec::with_capacity(chunks.len());
+    let mut thermal_stress_chunks = Vec::with_capacity(chunks.len());
+    let mut strain_constant = Vec::with_capacity(nrow);
+    let mut stress_constant = Vec::with_capacity(nrow);
+    let mut thermal_strain_constant = Vec::with_capacity(nrow);
+    let mut thermal_stress_constant = Vec::with_capacity(nrow);
+
+    for chunk in chunks {
+        debug_assert_eq!(chunk.nq_per_element, nq_per_element);
+        debug_assert_eq!(chunk.ntemp, ntemp);
+        points.extend(chunk.points);
+        strain_chunks.push(chunk.strain_operator);
+        stress_chunks.push(chunk.stress_operator);
+        thermal_strain_chunks.push(chunk.thermal_strain_operator);
+        thermal_stress_chunks.push(chunk.thermal_stress_operator);
+        strain_constant.extend(chunk.strain_constant);
+        stress_constant.extend(chunk.stress_constant);
+        thermal_strain_constant.extend(chunk.thermal_strain_constant);
+        thermal_stress_constant.extend(chunk.thermal_stress_constant);
+    }
+
+    ReducedQuadratureFieldOperators {
+        points,
+        strain_operator: concat_csr_chunks(strain_chunks, nrow, ndof_reduced),
+        stress_operator: concat_csr_chunks(stress_chunks, nrow, ndof_reduced),
+        thermal_strain_operator: concat_csr_chunks(
+            thermal_strain_chunks,
+            nrow,
+            n_temperature_nodes,
+        ),
+        thermal_stress_operator: concat_csr_chunks(
+            thermal_stress_chunks,
+            nrow,
+            n_temperature_nodes,
+        ),
+        strain_constant,
+        stress_constant,
+        thermal_strain_constant,
+        thermal_stress_constant,
+        nq_per_element,
+        ntemp,
+    }
 }
 
 /// Assemble quadrature-point strain/stress recovery operators for one quadrilateral family.
@@ -193,6 +375,7 @@ fn element_major_reference_points<F: Real>(
 /// Row meaning:
 /// - rows `4*q .. 4*q + 3` correspond to quadrature point `q` in element-major order,
 /// - within each quadrature point the row components are ordered `[rr, zz, tt, rz]`.
+#[cfg(test)]
 pub(crate) fn quadrature_field_operators_for_family<
     F: Real,
     Family,
@@ -220,42 +403,207 @@ where
         material_orientation_angles,
     )?;
 
-    let nq_per_element = quadrature.points_per_element();
-    let nsamples = mesh.num_elements() * nq_per_element;
-    let (element_indices, reference_points) =
-        element_major_reference_points::<F>(mesh.num_elements(), quadrature);
-    let strain_operator = quad_mesh_strain_operator::<
-        Family::ReferenceElement,
+    quadrature_field_operators_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        mesh,
+        material_ids,
+        material_table,
+        thermal_material_table,
+        material_orientation_angles,
+        formulation,
+        quadrature,
+        0,
+        mesh.num_elements(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn reduced_quadrature_field_operators_for_family<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    thermal_material_table: Option<&[ThermalMaterial<F>]>,
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+    global_to_reduced: &[usize],
+    fixed_lookup: &[Option<F>],
+    ndof_reduced: usize,
+) -> Result<ReducedQuadratureFieldOperators<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    const {
+        assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
+    }
+    validate_structural_2d_mesh(mesh, formulation)?;
+    validate_element_material_inputs(
+        mesh.num_elements(),
+        material_ids,
+        material_orientation_angles,
+    )?;
+    reduced_quadrature_field_operators_range_for_family::<
         F,
-        NODES_PER_ELEMENT,
-        DOF_PER_ELEMENT,
-    >(mesh, &element_indices, &reference_points, formulation)?;
-    let stress_operator = quad_mesh_stress_operator::<
-        Family::ReferenceElement,
-        F,
+        Family,
         NODES_PER_ELEMENT,
         DOF_PER_ELEMENT,
     >(
         mesh,
-        &element_indices,
-        &reference_points,
         material_ids,
         material_table,
+        thermal_material_table,
         material_orientation_angles,
         formulation,
+        quadrature,
+        global_to_reduced,
+        fixed_lookup,
+        ndof_reduced,
+        0,
+        mesh.num_elements(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn reduced_quadrature_field_operators_for_family_par<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    thermal_material_table: Option<&[ThermalMaterial<F>]>,
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+    global_to_reduced: &[usize],
+    fixed_lookup: &[Option<F>],
+    ndof_reduced: usize,
+) -> Result<ReducedQuadratureFieldOperators<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    const {
+        assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
+    }
+    validate_structural_2d_mesh(mesh, formulation)?;
+    validate_element_material_inputs(
+        mesh.num_elements(),
+        material_ids,
+        material_orientation_angles,
     )?;
+    let nelem = mesh.num_elements();
+    let nq_per_element = quadrature.points_per_element();
+    let ntemp = thermal_material_table.map_or(0, |_| mesh.num_nodes());
+    let n_temperature_nodes = if thermal_material_table.is_some() {
+        mesh.num_nodes()
+    } else {
+        0
+    };
+    let chunk = chunksize(nelem);
+    let mut ranges = Vec::with_capacity(nelem.div_ceil(chunk));
+    let mut start = 0;
+    while start < nelem {
+        let end = (start + chunk).min(nelem);
+        ranges.push((start, end));
+        start = end;
+    }
 
-    let mut points = Vec::with_capacity(nsamples);
-    let mut thermal_strain_rows = Vec::new();
-    let mut thermal_strain_cols = Vec::new();
+    let chunks = ranges
+        .into_par_iter()
+        .map(|(start, end)| {
+            reduced_quadrature_field_operators_range_for_family::<
+                F,
+                Family,
+                NODES_PER_ELEMENT,
+                DOF_PER_ELEMENT,
+            >(
+                mesh,
+                material_ids,
+                material_table,
+                thermal_material_table,
+                material_orientation_angles,
+                formulation,
+                quadrature,
+                global_to_reduced,
+                fixed_lookup,
+                ndof_reduced,
+                start,
+                end,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(concat_reduced_quadrature_chunks(
+        chunks,
+        nq_per_element,
+        ntemp,
+        ndof_reduced,
+        n_temperature_nodes,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn reduced_quadrature_field_operators_range_for_family<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    thermal_material_table: Option<&[ThermalMaterial<F>]>,
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+    global_to_reduced: &[usize],
+    fixed_lookup: &[Option<F>],
+    ndof_reduced: usize,
+    element_start: usize,
+    element_end: usize,
+) -> Result<ReducedQuadratureFieldOperators<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    let nq_per_element = quadrature.points_per_element();
+    let n_elements = element_end - element_start;
+    let nrows = n_elements * nq_per_element * 4;
+    let n_temperature_nodes = if thermal_material_table.is_some() {
+        mesh.num_nodes()
+    } else {
+        0
+    };
+    let mut points = Vec::with_capacity(n_elements * nq_per_element);
+    let mut strain_row_ptr = Vec::with_capacity(nrows + 1);
+    let mut strain_col_idx = Vec::new();
+    let mut strain_vals = Vec::new();
+    let mut stress_row_ptr = Vec::with_capacity(nrows + 1);
+    let mut stress_col_idx = Vec::new();
+    let mut stress_vals = Vec::new();
+    let mut thermal_strain_row_ptr = Vec::with_capacity(nrows + 1);
+    let mut thermal_strain_col_idx = Vec::new();
     let mut thermal_strain_vals = Vec::new();
-    let mut thermal_stress_rows = Vec::new();
-    let mut thermal_stress_cols = Vec::new();
+    let mut thermal_stress_row_ptr = Vec::with_capacity(nrows + 1);
+    let mut thermal_stress_col_idx = Vec::new();
     let mut thermal_stress_vals = Vec::new();
-    let mut thermal_strain_constant = vec![F::zero(); nsamples * 4];
-    let mut thermal_stress_constant = vec![F::zero(); nsamples * 4];
+    let mut strain_constant = vec![F::zero(); nrows];
+    let mut stress_constant = vec![F::zero(); nrows];
+    let mut thermal_strain_constant = vec![F::zero(); nrows];
+    let mut thermal_stress_constant = vec![F::zero(); nrows];
+    let mut row_entries = Vec::with_capacity(DOF_PER_ELEMENT);
 
-    for element_index in 0..mesh.num_elements() {
+    strain_row_ptr.push(0);
+    stress_row_ptr.push(0);
+    thermal_strain_row_ptr.push(0);
+    thermal_stress_row_ptr.push(0);
+
+    for element_index in element_start..element_end {
         let coords = mesh.element_coords(element_index)?;
         let nodes = mesh.element_nodes(element_index)?;
         let material_id = material_ids[element_index];
@@ -288,7 +636,248 @@ where
             .into_iter()
             .enumerate()
         {
-            let row_base = 4 * (element_index * nq_per_element + q_local);
+            let local_element_index = element_index - element_start;
+            let row_base = 4 * (local_element_index * nq_per_element + q_local);
+            points.push(sample.point);
+            let b = crate::physics::solenoid_stress::axisym::build_b_matrix::<
+                F,
+                NODES_PER_ELEMENT,
+                DOF_PER_ELEMENT,
+            >(formulation, &sample.n, &sample.grad_phys, sample.point)?;
+
+            for component in 0..4 {
+                row_entries.clear();
+                let row = row_base + component;
+                for local_node in 0..NODES_PER_ELEMENT {
+                    for dof_component in 0..DOF_PER_NODE {
+                        let local_dof = DOF_PER_NODE * local_node + dof_component;
+                        let full_col = DOF_PER_NODE * nodes[local_node] + dof_component;
+                        append_reduced_displacement_entry(
+                            &mut row_entries,
+                            &mut strain_constant,
+                            row,
+                            full_col,
+                            b[component][local_dof],
+                            global_to_reduced,
+                            fixed_lookup,
+                        );
+                    }
+                }
+                push_canonical_row(
+                    &mut row_entries,
+                    &mut strain_row_ptr,
+                    &mut strain_col_idx,
+                    &mut strain_vals,
+                );
+
+                row_entries.clear();
+                for local_node in 0..NODES_PER_ELEMENT {
+                    for dof_component in 0..DOF_PER_NODE {
+                        let local_dof = DOF_PER_NODE * local_node + dof_component;
+                        let full_col = DOF_PER_NODE * nodes[local_node] + dof_component;
+                        let mut value = F::zero();
+                        for strain_component in 0..4 {
+                            value = value
+                                + material[component][strain_component]
+                                    * b[strain_component][local_dof];
+                        }
+                        append_reduced_displacement_entry(
+                            &mut row_entries,
+                            &mut stress_constant,
+                            row,
+                            full_col,
+                            value,
+                            global_to_reduced,
+                            fixed_lookup,
+                        );
+                    }
+                }
+                push_canonical_row(
+                    &mut row_entries,
+                    &mut stress_row_ptr,
+                    &mut stress_col_idx,
+                    &mut stress_vals,
+                );
+            }
+
+            if let (Some(thermal_material), Some(thermal_stress_unit)) =
+                (thermal_material, thermal_stress_unit.as_ref())
+            {
+                let local = thermal_sample_kernel(&sample, thermal_material, thermal_stress_unit);
+                for component in 0..4 {
+                    let row = row_base + component;
+                    thermal_strain_constant[row] = local.thermal_strain_constant[component];
+                    thermal_stress_constant[row] = local.thermal_stress_constant[component];
+
+                    row_entries.clear();
+                    for local_temp_node in 0..NODES_PER_ELEMENT {
+                        append_temperature_entry(
+                            &mut row_entries,
+                            nodes[local_temp_node],
+                            local.thermal_strain[component][local_temp_node],
+                        );
+                    }
+                    push_canonical_row(
+                        &mut row_entries,
+                        &mut thermal_strain_row_ptr,
+                        &mut thermal_strain_col_idx,
+                        &mut thermal_strain_vals,
+                    );
+
+                    row_entries.clear();
+                    for local_temp_node in 0..NODES_PER_ELEMENT {
+                        append_temperature_entry(
+                            &mut row_entries,
+                            nodes[local_temp_node],
+                            local.thermal_stress[component][local_temp_node],
+                        );
+                    }
+                    push_canonical_row(
+                        &mut row_entries,
+                        &mut thermal_stress_row_ptr,
+                        &mut thermal_stress_col_idx,
+                        &mut thermal_stress_vals,
+                    );
+                }
+            } else {
+                for _ in 0..4 {
+                    thermal_strain_row_ptr.push(thermal_strain_col_idx.len());
+                    thermal_stress_row_ptr.push(thermal_stress_col_idx.len());
+                }
+            }
+        }
+    }
+
+    Ok(ReducedQuadratureFieldOperators {
+        points,
+        strain_operator: CsrOperatorParts {
+            nrow: nrows,
+            ncol: ndof_reduced,
+            row_ptr: strain_row_ptr,
+            col_idx: strain_col_idx,
+            vals: strain_vals,
+        },
+        stress_operator: CsrOperatorParts {
+            nrow: nrows,
+            ncol: ndof_reduced,
+            row_ptr: stress_row_ptr,
+            col_idx: stress_col_idx,
+            vals: stress_vals,
+        },
+        thermal_strain_operator: CsrOperatorParts {
+            nrow: nrows,
+            ncol: n_temperature_nodes,
+            row_ptr: thermal_strain_row_ptr,
+            col_idx: thermal_strain_col_idx,
+            vals: thermal_strain_vals,
+        },
+        thermal_stress_operator: CsrOperatorParts {
+            nrow: nrows,
+            ncol: n_temperature_nodes,
+            row_ptr: thermal_stress_row_ptr,
+            col_idx: thermal_stress_col_idx,
+            vals: thermal_stress_vals,
+        },
+        strain_constant,
+        stress_constant,
+        thermal_strain_constant,
+        thermal_stress_constant,
+        nq_per_element,
+        ntemp: thermal_material_table.map_or(0, |_| mesh.num_nodes()),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+#[cfg(test)]
+fn quadrature_field_operators_range_for_family<
+    F: Real,
+    Family,
+    const NODES_PER_ELEMENT: usize,
+    const DOF_PER_ELEMENT: usize,
+>(
+    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    material_ids: &[usize],
+    material_table: &[[[F; 4]; 4]],
+    thermal_material_table: Option<&[ThermalMaterial<F>]>,
+    material_orientation_angles: Option<&[F]>,
+    formulation: Structural2dFormulation<F>,
+    quadrature: QuadratureRule,
+    element_start: usize,
+    element_end: usize,
+) -> Result<QuadratureFieldOperators<F>, String>
+where
+    Family: QuadElementFamily<NODES_PER_ELEMENT>,
+{
+    let nq_per_element = quadrature.points_per_element();
+    let nsamples = (element_end - element_start) * nq_per_element;
+    let (element_indices, reference_points) =
+        element_major_reference_points_range::<F>(element_start, element_end, quadrature);
+    let strain_operator = quad_mesh_strain_operator::<
+        Family::ReferenceElement,
+        F,
+        NODES_PER_ELEMENT,
+        DOF_PER_ELEMENT,
+    >(mesh, &element_indices, &reference_points, formulation)?;
+    let stress_operator = quad_mesh_stress_operator::<
+        Family::ReferenceElement,
+        F,
+        NODES_PER_ELEMENT,
+        DOF_PER_ELEMENT,
+    >(
+        mesh,
+        &element_indices,
+        &reference_points,
+        material_ids,
+        material_table,
+        material_orientation_angles,
+        formulation,
+    )?;
+
+    let mut points = Vec::with_capacity(nsamples);
+    let mut thermal_strain_rows = Vec::new();
+    let mut thermal_strain_cols = Vec::new();
+    let mut thermal_strain_vals = Vec::new();
+    let mut thermal_stress_rows = Vec::new();
+    let mut thermal_stress_cols = Vec::new();
+    let mut thermal_stress_vals = Vec::new();
+    let mut thermal_strain_constant = vec![F::zero(); nsamples * 4];
+    let mut thermal_stress_constant = vec![F::zero(); nsamples * 4];
+
+    for element_index in element_start..element_end {
+        let coords = mesh.element_coords(element_index)?;
+        let nodes = mesh.element_nodes(element_index)?;
+        let material_id = material_ids[element_index];
+        let material = material_table.get(material_id).ok_or_else(|| {
+            format!("material_id {material_id} on element {element_index} is out of range")
+        })?;
+        let thermal_material_base = thermal_material_table
+            .map(|table| {
+                table.get(material_id).ok_or_else(|| {
+                    format!(
+                        "thermal material_id {material_id} on element {element_index} is out of range"
+                    )
+                })
+            })
+            .transpose()?;
+        let material_storage;
+        let thermal_storage;
+        let (material, thermal_material) = if let Some(angles) = material_orientation_angles {
+            material_storage = rotate_material_in_plane(material, angles[element_index]);
+            thermal_storage = thermal_material_base
+                .map(|thermal| rotate_thermal_material_in_plane(thermal, angles[element_index]));
+            (&material_storage, thermal_storage.as_ref())
+        } else {
+            (material, thermal_material_base)
+        };
+        let thermal_stress_unit =
+            thermal_material.map(|thermal| constitutive_times_strain(material, &thermal.alpha));
+
+        for (q_local, sample) in Family::volume_samples::<F>(&coords, quadrature)?
+            .into_iter()
+            .enumerate()
+        {
+            let local_element_index = element_index - element_start;
+            let row_base = 4 * (local_element_index * nq_per_element + q_local);
             let global_rows = [row_base, row_base + 1, row_base + 2, row_base + 3];
             points.push(sample.point);
             if let (Some(thermal_material), Some(thermal_stress_unit)) =

--- a/src/physics/solenoid_stress/recovery.rs
+++ b/src/physics/solenoid_stress/recovery.rs
@@ -38,7 +38,6 @@
 
 use rayon::prelude::*;
 
-use crate::chunksize;
 #[cfg(test)]
 use crate::mesh::elements::quad2d::quadrature::gauss_volume;
 #[cfg(test)]
@@ -55,6 +54,7 @@ use crate::physics::solenoid_stress::types::scatter_local_matrix;
 use crate::physics::solenoid_stress::types::{
     DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, validate_element_material_inputs,
 };
+use crate::{chunksize, ranges_for_len};
 
 /// Sparse quadrature-point recovery operators before reduction into the model-owned CSR form.
 ///
@@ -130,6 +130,73 @@ pub struct CsrOperatorParts<F: Real> {
     pub row_ptr: Vec<usize>,
     pub col_idx: Vec<usize>,
     pub vals: Vec<F>,
+}
+
+struct CsrPartsBuilder<F: Real> {
+    nrow: usize,
+    ncol: usize,
+    row_ptr: Vec<usize>,
+    col_idx: Vec<usize>,
+    vals: Vec<F>,
+}
+
+impl<F: Real> CsrPartsBuilder<F> {
+    fn new(nrow: usize, ncol: usize) -> Self {
+        let mut row_ptr = Vec::with_capacity(nrow + 1);
+        row_ptr.push(0);
+        Self {
+            nrow,
+            ncol,
+            row_ptr,
+            col_idx: Vec::new(),
+            vals: Vec::new(),
+        }
+    }
+
+    fn push_canonical_row(&mut self, entries: &mut Vec<(usize, F)>) {
+        entries.sort_unstable_by_key(|(col, _)| *col);
+        let mut pending: Option<(usize, F)> = None;
+        for (col, value) in entries.drain(..) {
+            if value == F::zero() {
+                continue;
+            }
+            match pending {
+                Some((pending_col, pending_value)) if pending_col == col => {
+                    pending = Some((pending_col, pending_value + value));
+                }
+                Some((pending_col, pending_value)) => {
+                    if pending_value != F::zero() {
+                        self.col_idx.push(pending_col);
+                        self.vals.push(pending_value);
+                    }
+                    pending = Some((col, value));
+                }
+                None => pending = Some((col, value)),
+            }
+        }
+        if let Some((col, value)) = pending
+            && value != F::zero()
+        {
+            self.col_idx.push(col);
+            self.vals.push(value);
+        }
+        self.push_empty_row();
+    }
+
+    fn push_empty_row(&mut self) {
+        self.row_ptr.push(self.col_idx.len());
+    }
+
+    fn finish(self) -> CsrOperatorParts<F> {
+        debug_assert_eq!(self.row_ptr.len(), self.nrow + 1);
+        CsrOperatorParts {
+            nrow: self.nrow,
+            ncol: self.ncol,
+            row_ptr: self.row_ptr,
+            col_idx: self.col_idx,
+            vals: self.vals,
+        }
+    }
 }
 
 /// Reduced-space quadrature recovery operators in direct CSR form.
@@ -218,41 +285,6 @@ fn element_major_reference_points_range<F: Real>(
         }
     }
     (element_indices, reference_points)
-}
-
-fn push_canonical_row<F: Real>(
-    entries: &mut Vec<(usize, F)>,
-    row_ptr: &mut Vec<usize>,
-    col_idx: &mut Vec<usize>,
-    vals: &mut Vec<F>,
-) {
-    entries.sort_unstable_by_key(|(col, _)| *col);
-    let mut pending: Option<(usize, F)> = None;
-    for (col, value) in entries.drain(..) {
-        if value == F::zero() {
-            continue;
-        }
-        match pending {
-            Some((pending_col, pending_value)) if pending_col == col => {
-                pending = Some((pending_col, pending_value + value));
-            }
-            Some((pending_col, pending_value)) => {
-                if pending_value != F::zero() {
-                    col_idx.push(pending_col);
-                    vals.push(pending_value);
-                }
-                pending = Some((col, value));
-            }
-            None => pending = Some((col, value)),
-        }
-    }
-    if let Some((col, value)) = pending
-        && value != F::zero()
-    {
-        col_idx.push(col);
-        vals.push(value);
-    }
-    row_ptr.push(col_idx.len());
 }
 
 fn append_reduced_displacement_entry<F: Real>(
@@ -505,16 +537,7 @@ where
     } else {
         0
     };
-    let chunk = chunksize(nelem);
-    let mut ranges = Vec::with_capacity(nelem.div_ceil(chunk));
-    let mut start = 0;
-    while start < nelem {
-        let end = (start + chunk).min(nelem);
-        ranges.push((start, end));
-        start = end;
-    }
-
-    let chunks = ranges
+    let chunks = ranges_for_len(nelem, chunksize(nelem))
         .into_par_iter()
         .map(|(start, end)| {
             reduced_quadrature_field_operators_range_for_family::<
@@ -580,28 +603,15 @@ where
         0
     };
     let mut points = Vec::with_capacity(n_elements * nq_per_element);
-    let mut strain_row_ptr = Vec::with_capacity(nrows + 1);
-    let mut strain_col_idx = Vec::new();
-    let mut strain_vals = Vec::new();
-    let mut stress_row_ptr = Vec::with_capacity(nrows + 1);
-    let mut stress_col_idx = Vec::new();
-    let mut stress_vals = Vec::new();
-    let mut thermal_strain_row_ptr = Vec::with_capacity(nrows + 1);
-    let mut thermal_strain_col_idx = Vec::new();
-    let mut thermal_strain_vals = Vec::new();
-    let mut thermal_stress_row_ptr = Vec::with_capacity(nrows + 1);
-    let mut thermal_stress_col_idx = Vec::new();
-    let mut thermal_stress_vals = Vec::new();
+    let mut strain_operator = CsrPartsBuilder::new(nrows, ndof_reduced);
+    let mut stress_operator = CsrPartsBuilder::new(nrows, ndof_reduced);
+    let mut thermal_strain_operator = CsrPartsBuilder::new(nrows, n_temperature_nodes);
+    let mut thermal_stress_operator = CsrPartsBuilder::new(nrows, n_temperature_nodes);
     let mut strain_constant = vec![F::zero(); nrows];
     let mut stress_constant = vec![F::zero(); nrows];
     let mut thermal_strain_constant = vec![F::zero(); nrows];
     let mut thermal_stress_constant = vec![F::zero(); nrows];
     let mut row_entries = Vec::with_capacity(DOF_PER_ELEMENT);
-
-    strain_row_ptr.push(0);
-    stress_row_ptr.push(0);
-    thermal_strain_row_ptr.push(0);
-    thermal_stress_row_ptr.push(0);
 
     for element_index in element_start..element_end {
         let coords = mesh.element_coords(element_index)?;
@@ -663,12 +673,7 @@ where
                         );
                     }
                 }
-                push_canonical_row(
-                    &mut row_entries,
-                    &mut strain_row_ptr,
-                    &mut strain_col_idx,
-                    &mut strain_vals,
-                );
+                strain_operator.push_canonical_row(&mut row_entries);
 
                 row_entries.clear();
                 for local_node in 0..NODES_PER_ELEMENT {
@@ -692,12 +697,7 @@ where
                         );
                     }
                 }
-                push_canonical_row(
-                    &mut row_entries,
-                    &mut stress_row_ptr,
-                    &mut stress_col_idx,
-                    &mut stress_vals,
-                );
+                stress_operator.push_canonical_row(&mut row_entries);
             }
 
             if let (Some(thermal_material), Some(thermal_stress_unit)) =
@@ -717,12 +717,7 @@ where
                             local.thermal_strain[component][local_temp_node],
                         );
                     }
-                    push_canonical_row(
-                        &mut row_entries,
-                        &mut thermal_strain_row_ptr,
-                        &mut thermal_strain_col_idx,
-                        &mut thermal_strain_vals,
-                    );
+                    thermal_strain_operator.push_canonical_row(&mut row_entries);
 
                     row_entries.clear();
                     for local_temp_node in 0..NODES_PER_ELEMENT {
@@ -732,17 +727,12 @@ where
                             local.thermal_stress[component][local_temp_node],
                         );
                     }
-                    push_canonical_row(
-                        &mut row_entries,
-                        &mut thermal_stress_row_ptr,
-                        &mut thermal_stress_col_idx,
-                        &mut thermal_stress_vals,
-                    );
+                    thermal_stress_operator.push_canonical_row(&mut row_entries);
                 }
             } else {
                 for _ in 0..4 {
-                    thermal_strain_row_ptr.push(thermal_strain_col_idx.len());
-                    thermal_stress_row_ptr.push(thermal_stress_col_idx.len());
+                    thermal_strain_operator.push_empty_row();
+                    thermal_stress_operator.push_empty_row();
                 }
             }
         }
@@ -750,34 +740,10 @@ where
 
     Ok(ReducedQuadratureFieldOperators {
         points,
-        strain_operator: CsrOperatorParts {
-            nrow: nrows,
-            ncol: ndof_reduced,
-            row_ptr: strain_row_ptr,
-            col_idx: strain_col_idx,
-            vals: strain_vals,
-        },
-        stress_operator: CsrOperatorParts {
-            nrow: nrows,
-            ncol: ndof_reduced,
-            row_ptr: stress_row_ptr,
-            col_idx: stress_col_idx,
-            vals: stress_vals,
-        },
-        thermal_strain_operator: CsrOperatorParts {
-            nrow: nrows,
-            ncol: n_temperature_nodes,
-            row_ptr: thermal_strain_row_ptr,
-            col_idx: thermal_strain_col_idx,
-            vals: thermal_strain_vals,
-        },
-        thermal_stress_operator: CsrOperatorParts {
-            nrow: nrows,
-            ncol: n_temperature_nodes,
-            row_ptr: thermal_stress_row_ptr,
-            col_idx: thermal_stress_col_idx,
-            vals: thermal_stress_vals,
-        },
+        strain_operator: strain_operator.finish(),
+        stress_operator: stress_operator.finish(),
+        thermal_strain_operator: thermal_strain_operator.finish(),
+        thermal_stress_operator: thermal_stress_operator.finish(),
         strain_constant,
         stress_constant,
         thermal_strain_constant,

--- a/src/physics/solenoid_stress/recovery.rs
+++ b/src/physics/solenoid_stress/recovery.rs
@@ -125,10 +125,15 @@ pub struct QuadratureFieldOperators<F: Real> {
 /// Canonical CSR operator parts with strictly increasing column indices in each row.
 #[derive(Debug, Clone)]
 pub struct CsrOperatorParts<F: Real> {
+    /// Number of matrix rows.
     pub nrow: usize,
+    /// Number of matrix columns.
     pub ncol: usize,
+    /// CSR row offsets with length `nrow + 1`.
     pub row_ptr: Vec<usize>,
+    /// Column index for each stored value.
     pub col_idx: Vec<usize>,
+    /// Nonzero values in row-major CSR order.
     pub vals: Vec<F>,
 }
 
@@ -141,6 +146,7 @@ struct CsrPartsBuilder<F: Real> {
 }
 
 impl<F: Real> CsrPartsBuilder<F> {
+    /// Start a CSR builder whose rows must be appended in increasing row order.
     fn new(nrow: usize, ncol: usize) -> Self {
         let mut row_ptr = Vec::with_capacity(nrow + 1);
         row_ptr.push(0);
@@ -153,6 +159,11 @@ impl<F: Real> CsrPartsBuilder<F> {
         }
     }
 
+    /// Sort, coalesce, and append one row of `(column, value)` entries.
+    ///
+    /// Recovery assembly naturally emits a small unsorted row from local shape-function
+    /// contributions.  Canonicalizing one row at a time avoids a global triplet sort and makes the
+    /// finished parts directly suitable for faer's CSR constructor.
     fn push_canonical_row(&mut self, entries: &mut Vec<(usize, F)>) {
         entries.sort_unstable_by_key(|(col, _)| *col);
         let mut pending: Option<(usize, F)> = None;
@@ -183,10 +194,12 @@ impl<F: Real> CsrPartsBuilder<F> {
         self.push_empty_row();
     }
 
+    /// Append a row with no stored entries.
     fn push_empty_row(&mut self) {
         self.row_ptr.push(self.col_idx.len());
     }
 
+    /// Finish the builder after exactly `nrow` rows have been appended.
     fn finish(self) -> CsrOperatorParts<F> {
         debug_assert_eq!(self.row_ptr.len(), self.nrow + 1);
         CsrOperatorParts {
@@ -202,16 +215,27 @@ impl<F: Real> CsrPartsBuilder<F> {
 /// Reduced-space quadrature recovery operators in direct CSR form.
 #[derive(Debug, Clone)]
 pub struct ReducedQuadratureFieldOperators<F: Real> {
+    /// Quadrature-point coordinates `(r, z)` in element-major order.
     pub points: Vec<[F; 2]>,
+    /// Reduced displacement-to-strain operator.
     pub strain_operator: CsrOperatorParts<F>,
+    /// Reduced displacement-to-stress operator.
     pub stress_operator: CsrOperatorParts<F>,
+    /// Input-temperature-to-thermal-strain operator.
     pub thermal_strain_operator: CsrOperatorParts<F>,
+    /// Input-temperature-to-thermal-stress operator.
     pub thermal_stress_operator: CsrOperatorParts<F>,
+    /// Strain contribution from prescribed displacement DOFs.
     pub strain_constant: Vec<F>,
+    /// Stress contribution from prescribed displacement DOFs.
     pub stress_constant: Vec<F>,
+    /// Thermal strain contribution from material reference temperatures.
     pub thermal_strain_constant: Vec<F>,
+    /// Thermal stress contribution from material reference temperatures.
     pub thermal_stress_constant: Vec<F>,
+    /// Number of quadrature points contributed by each element.
     pub nq_per_element: usize,
+    /// Number of nodal temperature inputs, or zero when no thermal material table is present.
     pub ntemp: usize,
 }
 
@@ -296,6 +320,8 @@ fn append_reduced_displacement_entry<F: Real>(
     global_to_reduced: &[usize],
     fixed_lookup: &[Option<F>],
 ) {
+    // Fixed displacement columns are eliminated from the operator and folded into the additive
+    // recovery constant. Free columns are remapped into reduced-system column indices.
     if value == F::zero() {
         return;
     }
@@ -308,6 +334,8 @@ fn append_reduced_displacement_entry<F: Real>(
 }
 
 fn append_temperature_entry<F: Real>(entries: &mut Vec<(usize, F)>, col: usize, value: F) {
+    // Temperature is not part of the structural Dirichlet reduction, so thermal recovery columns
+    // remain indexed by the input temperature node.
     if value != F::zero() {
         entries.push((col, value));
     }
@@ -318,6 +346,9 @@ fn concat_csr_chunks<F: Real>(
     nrow: usize,
     ncol: usize,
 ) -> CsrOperatorParts<F> {
+    // Each chunk covers a contiguous element range and therefore a contiguous row range.  The
+    // per-row column order is already canonical, so concatenation only needs to offset row
+    // pointers by the number of stored entries seen so far.
     let nnz = chunks.iter().map(|chunk| chunk.vals.len()).sum::<usize>();
     let mut row_ptr = Vec::with_capacity(nrow + 1);
     let mut col_idx = Vec::with_capacity(nnz);
@@ -347,6 +378,8 @@ fn concat_reduced_quadrature_chunks<F: Real>(
     ndof_reduced: usize,
     n_temperature_nodes: usize,
 ) -> ReducedQuadratureFieldOperators<F> {
+    // Reduced recovery chunks are independent by quadrature row.  Constants and points concatenate
+    // in the same row order as the CSR chunks, preserving element-major quadrature ordering.
     let total_points = chunks.iter().map(|chunk| chunk.points.len()).sum::<usize>();
     let nrow = total_points * 4;
 

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -924,6 +924,63 @@ def test_parallel_structural_assembly_matches_serial(dtype: DType, element_type:
     assert np.allclose(parallel.stiffness.toarray(), serial.stiffness.toarray(), rtol=rtol, atol=atol)
 
 
+def test_structural_sparse_operators_export_lazily_and_are_cached() -> None:
+    dtype = np.float64
+    nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=dtype)
+    _inner_faces, outer_faces = pressure_faces_for_strip(nr=2, nz=1)
+    _bottom_faces, top_faces = horizontal_faces_for_strip(nr=2, nz=1)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
+    thermal = fem.isotropic_axisymmetric_thermal_material(1.2e-5, reference_temperature=293.15, dtype=dtype)
+    model = fem.assemble_structural_2d(
+        nodes=nodes,
+        elements=elements,
+        material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
+        material_table=np.asarray([material]),
+        pressure_faces=outer_faces,
+        traction_faces=top_faces,
+        thermal_material_table=np.asarray([thermal]),
+        element_type="quad9",
+    )
+    cache_names = (
+        "_stiffness_cache",
+        "_body_force_to_rhs_cache",
+        "_pressure_to_rhs_cache",
+        "_traction_to_rhs_cache",
+        "_temperature_to_rhs_cache",
+        "_strain_operator_cache",
+        "_stress_operator_cache",
+        "_thermal_strain_operator_cache",
+        "_thermal_stress_operator_cache",
+    )
+    for name in cache_names:
+        assert getattr(model, name) is None
+
+    _rhs = model.build_rhs(
+        body_force=np.array([1.0e3, -2.0e3], dtype=dtype),
+        pressure_values=np.full(outer_faces.shape[0], 2.5e5, dtype=dtype),
+        traction_values=np.full((top_faces.shape[0], 2), [1.0e4, -3.0e4], dtype=dtype),
+        nodal_temperature=np.full(nodes.shape[0], 300.0, dtype=dtype),
+    )
+    for name in cache_names:
+        assert getattr(model, name) is None
+
+    for public_name, cache_name in (
+        ("stiffness", "_stiffness_cache"),
+        ("body_force_to_rhs", "_body_force_to_rhs_cache"),
+        ("pressure_to_rhs", "_pressure_to_rhs_cache"),
+        ("traction_to_rhs", "_traction_to_rhs_cache"),
+        ("temperature_to_rhs", "_temperature_to_rhs_cache"),
+        ("strain_operator", "_strain_operator_cache"),
+        ("stress_operator", "_stress_operator_cache"),
+        ("thermal_strain_operator", "_thermal_strain_operator_cache"),
+        ("thermal_stress_operator", "_thermal_stress_operator_cache"),
+    ):
+        first = getattr(model, public_name)
+        second = getattr(model, public_name)
+        assert first is second
+        assert getattr(model, cache_name) is first
+
+
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
 @pytest.mark.parametrize("equilibration", ["ruiz", "none"])
 def test_iterative_structural_solve_matches_direct_and_reports_diagnostics(

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import numpy as np
 import pytest
@@ -634,6 +634,16 @@ def tolerance(dtype: DType) -> tuple[float, float]:
     return 1.0e-12, 1.0e-12
 
 
+def assert_sparse_allclose(
+    actual: Any,
+    expected: Any,
+    *,
+    rtol: float,
+    atol: float,
+) -> None:
+    np.testing.assert_allclose(actual.toarray(), expected.toarray(), rtol=rtol, atol=atol)
+
+
 def solve_with_factorized_model(
     model: fem.Structural2DFEMModel,
     rhs: np.ndarray,
@@ -902,12 +912,22 @@ def test_model_dtype_resolution_includes_material_tables() -> None:
 def test_parallel_structural_assembly_matches_serial(dtype: DType, element_type: str) -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=3, nz=2, dtype=dtype)
     material = np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)])
+    thermal = np.asarray(
+        [fem.isotropic_axisymmetric_thermal_material(1.2e-5, reference_temperature=293.15, dtype=dtype)]
+    )
     material_ids = np.zeros(elements.shape[0], dtype=np.uint64)
+    _inner_faces, outer_faces = pressure_faces_for_strip(nr=3, nz=2)
+    _bottom_faces, top_faces = horizontal_faces_for_strip(nr=3, nz=2)
+    prescribed = {0: 1.0e-6, 1: -2.0e-6}
     serial = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=material_ids,
         material_table=material,
+        pressure_faces=outer_faces,
+        traction_faces=top_faces,
+        thermal_material_table=thermal,
+        prescribed=prescribed,
         element_type=element_type,
         par=False,
     )
@@ -916,12 +936,50 @@ def test_parallel_structural_assembly_matches_serial(dtype: DType, element_type:
         elements=elements,
         material_ids=material_ids,
         material_table=material,
+        pressure_faces=outer_faces,
+        traction_faces=top_faces,
+        thermal_material_table=thermal,
+        prescribed=prescribed,
         element_type=element_type,
         par=True,
     )
     rtol, atol = tolerance(dtype)
 
-    assert np.allclose(parallel.stiffness.toarray(), serial.stiffness.toarray(), rtol=rtol, atol=atol)
+    for operator_name in (
+        "stiffness",
+        "body_force_to_rhs",
+        "pressure_to_rhs",
+        "traction_to_rhs",
+        "temperature_to_rhs",
+        "strain_operator",
+        "stress_operator",
+        "thermal_strain_operator",
+        "thermal_stress_operator",
+    ):
+        assert_sparse_allclose(
+            getattr(parallel, operator_name),
+            getattr(serial, operator_name),
+            rtol=rtol,
+            atol=atol,
+        )
+
+    for array_name in (
+        "constant_rhs",
+        "quadrature_points",
+        "strain_constant",
+        "stress_constant",
+        "thermal_strain_constant",
+        "thermal_stress_constant",
+    ):
+        np.testing.assert_allclose(
+            getattr(parallel, array_name),
+            getattr(serial, array_name),
+            rtol=rtol,
+            atol=atol,
+        )
+    np.testing.assert_array_equal(parallel.free_dofs, serial.free_dofs)
+    np.testing.assert_array_equal(parallel.fixed_dofs, serial.fixed_dofs)
+    np.testing.assert_allclose(parallel.fixed_values, serial.fixed_values, rtol=rtol, atol=atol)
 
 
 def test_structural_sparse_operators_export_lazily_and_are_cached() -> None:

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -644,6 +644,25 @@ def assert_sparse_allclose(
     np.testing.assert_allclose(actual.toarray(), expected.toarray(), rtol=rtol, atol=atol)
 
 
+def assert_reduction_array_allclose(
+    actual: Any,
+    expected: Any,
+    *,
+    dtype: DType,
+    rtol: float,
+    atol: float,
+) -> None:
+    actual_array = np.asarray(actual)
+    expected_array = np.asarray(expected)
+    scale = max(
+        float(np.max(np.abs(actual_array), initial=0.0)),
+        float(np.max(np.abs(expected_array), initial=0.0)),
+        1.0,
+    )
+    scaled_atol = max(atol, float(np.finfo(dtype).eps) * scale)
+    np.testing.assert_allclose(actual_array, expected_array, rtol=rtol, atol=scaled_atol)
+
+
 def solve_with_factorized_model(
     model: fem.Structural2DFEMModel,
     rhs: np.ndarray,
@@ -963,17 +982,18 @@ def test_parallel_structural_assembly_matches_serial(dtype: DType, element_type:
             atol=atol,
         )
 
+    np.testing.assert_allclose(parallel.quadrature_points, serial.quadrature_points, rtol=rtol, atol=atol)
     for array_name in (
         "constant_rhs",
-        "quadrature_points",
         "strain_constant",
         "stress_constant",
         "thermal_strain_constant",
         "thermal_stress_constant",
     ):
-        np.testing.assert_allclose(
+        assert_reduction_array_allclose(
             getattr(parallel, array_name),
             getattr(serial, array_name),
+            dtype=dtype,
             rtol=rtol,
             atol=atol,
         )


### PR DESCRIPTION
## 9.1.0 2026-06-08

* Rust
    * 2D FEM solver
        * Build loads and recovery operators by row instead of via triplets to eliminate sorting overhead
        * Sort chunks of stiffness matrix triplets on each worker thread, then merge sorted chunks on root thread
        * Only export python operator copies if requested
        * Roughly 4x speedup overall
* Python
    * Update 2D FEM bindings for lazy cached properties
