### PR TITLE
Trim FEM API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 10.0.0 2026-06-09
+
+* Rust
+    * !Remove f32 and iterative solve support for 2D FEM solver
+        * Field testing showed only ~25% speedup for each on a problem with >1M elements
+        * This is not enough to justify the complexity and maintenance overhead
+* Python
+    * !Update bindings for changed FEM API
+
 ## 9.1.0 2026-06-08
 
 * Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,6 @@ name = "cfsem"
 version = "10.0.0"
 dependencies = [
  "criterion",
- "deimos_numerics",
  "faer",
  "faer-traits",
  "itertools 0.14.0",
@@ -316,20 +315,6 @@ name = "defer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
-
-[[package]]
-name = "deimos_numerics"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c439fc1af4cc901c8cd7154818ed7df69f20e0e57a6b80a58a2675b19f85df"
-dependencies = [
- "crunchy",
- "faer",
- "faer-traits",
- "levenberg-marquardt",
- "nalgebra",
- "num-traits",
-]
 
 [[package]]
 name = "digest"
@@ -646,162 +631,108 @@ name = "glam"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "glam"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "glam"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "glam"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "glam"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "glam"
 version = "0.30.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12d847aeb25f41be4c0ec9587d624e9cd631bc007a8fd7ce3f5851e064c6460"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "glam"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "glam"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "half"
@@ -877,18 +808,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "levenberg-marquardt"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7a65739a815308eef33a6d8c78e435a7317305d5b0af0c8c465a2d7ac6fc6"
-dependencies = [
- "cfg-if",
- "nalgebra",
- "num-traits",
- "rustc_version",
-]
 
 [[package]]
 name = "libc"
@@ -1589,15 +1508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,12 +1542,6 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfsem"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "criterion",
  "deimos_numerics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfsem"
-version = "9.1.0"
+version = "10.0.0"
 edition = "2024"
 authors = ["Commonwealth Fusion Systems <jlogan@cfs.energy>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ libm = "^0.2"
 num-traits = { version = "0.2.19", features = ["libm"] }
 faer = "0.24.0"
 faer-traits = "0.24.0"
-deimos_numerics = "0.16.2"
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/cfsem/solenoid_stress/__init__.py
+++ b/cfsem/solenoid_stress/__init__.py
@@ -5,7 +5,7 @@ This subpackage includes three complementary toolsets:
 - a 1D finite-difference radial stress solver for deck-of-cards winding-pack models,
 - a 2D quadrilateral FEM implementation centered on reusable sparse load and
   recovery operators, with convenience methods for `build_rhs(...)`, `solve(...)`, and
-  quadrature-field recovery, including direct and iterative linear solve options,
+  quadrature-field recovery,
 - analytic reference formulas used for validation and convergence studies.
 """
 
@@ -29,8 +29,6 @@ from .fem2d import (
     QuadMeshQuery,
     QuadratureFieldSamples,
     Structural2DFEMModel,
-    Structural2DSolveDiagnostics,
-    Structural2DSolveResult,
     assemble_structural_2d,
     cfsem_radial_material,
     interpolate_quad_mesh_values,
@@ -58,8 +56,6 @@ __all__ = [
     "SolenoidStress1D",
     "SolenoidStress1DOperators",
     "Structural2DFEMModel",
-    "Structural2DSolveDiagnostics",
-    "Structural2DSolveResult",
     "assemble_structural_2d",
     "cfsem_radial_material",
     "interpolate_quad_mesh_values",

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -71,7 +71,6 @@ _orthotropic_axisymmetric_thermal_material_f64 = (
 
 ArrayLike = npt.ArrayLike
 _QUAD_FACE_NODE_PAIRS: tuple[tuple[int, int], ...] = ((0, 1), (1, 2), (2, 3), (3, 0))
-_FLOAT_DTYPE = np.dtype(np.float64)
 
 
 def _to_csr_matrix(matrix: Any) -> sp.csr_matrix:

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any, Literal, overload, cast
+from typing import Any, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -48,42 +48,22 @@ import scipy.sparse as sp
 
 import cfsem.cfsem as _cfsem_bindings
 
-_assemble_model_2d_f32 = _cfsem_bindings.solenoid_stress_fem_assemble_model_2d_f32
 _assemble_model_2d_f64 = _cfsem_bindings.solenoid_stress_fem_assemble_model_2d_f64
-_cfsem_radial_material_f32 = _cfsem_bindings.solenoid_stress_fem_cfsem_radial_material_f32
 _cfsem_radial_material_f64 = _cfsem_bindings.solenoid_stress_fem_cfsem_radial_material_f64
-_infer_quad9_mesh_f32 = _cfsem_bindings.solenoid_stress_fem_infer_quad9_mesh_f32
 _infer_quad9_mesh_f64 = _cfsem_bindings.solenoid_stress_fem_infer_quad9_mesh_f64
-_quad_mesh_interpolation_operator_f32 = (
-    _cfsem_bindings.solenoid_stress_fem_quad_mesh_interpolation_operator_f32
-)
 _quad_mesh_interpolation_operator_f64 = (
     _cfsem_bindings.solenoid_stress_fem_quad_mesh_interpolation_operator_f64
 )
-_quad_mesh_query_f32 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_query_f32
 _quad_mesh_query_f64 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_query_f64
-_quad_mesh_strain_operator_f32 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_strain_operator_f32
 _quad_mesh_strain_operator_f64 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_strain_operator_f64
-_quad_mesh_stress_operator_f32 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_stress_operator_f32
 _quad_mesh_stress_operator_f64 = _cfsem_bindings.solenoid_stress_fem_quad_mesh_stress_operator_f64
-_isotropic_axisymmetric_material_f32 = _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_material_f32
 _isotropic_axisymmetric_material_f64 = _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_material_f64
-_isotropic_plane_strain_material_f32 = _cfsem_bindings.solenoid_stress_fem_isotropic_plane_strain_material_f32
 _isotropic_plane_strain_material_f64 = _cfsem_bindings.solenoid_stress_fem_isotropic_plane_strain_material_f64
-_isotropic_axisymmetric_thermal_material_f32 = (
-    _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f32
-)
 _isotropic_axisymmetric_thermal_material_f64 = (
     _cfsem_bindings.solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f64
 )
-_isotropic_plane_strain_thermal_material_f32 = (
-    _cfsem_bindings.solenoid_stress_fem_isotropic_plane_strain_thermal_material_f32
-)
 _isotropic_plane_strain_thermal_material_f64 = (
     _cfsem_bindings.solenoid_stress_fem_isotropic_plane_strain_thermal_material_f64
-)
-_orthotropic_axisymmetric_thermal_material_f32 = (
-    _cfsem_bindings.solenoid_stress_fem_orthotropic_axisymmetric_thermal_material_f32
 )
 _orthotropic_axisymmetric_thermal_material_f64 = (
     _cfsem_bindings.solenoid_stress_fem_orthotropic_axisymmetric_thermal_material_f64
@@ -171,38 +151,6 @@ class ElementQuadrature:
     weights_area: npt.NDArray[np.floating[Any]]
     weights_volume: npt.NDArray[np.floating[Any]]
     nq_per_element: int
-
-
-@dataclass(frozen=True, slots=True)
-class Structural2DSolveDiagnostics:
-    """Diagnostics from one 2D FEM linear solve.
-
-    Args:
-        method: Solver method used for the reduced structural system.
-        converged: Whether the selected solver converged.
-        iterations: Number of BiCGSTAB iterations, or zero for direct solves.
-        residual_norm: Final residual norm in reduced-RHS units, or zero for direct solves.
-        equilibrated: Whether row/column equilibration was applied before the solve.
-    """
-
-    method: Literal["direct", "bicgstab"]
-    converged: bool
-    iterations: int
-    residual_norm: float
-    equilibrated: bool
-
-
-@dataclass(frozen=True, slots=True)
-class Structural2DSolveResult:
-    """Full displacement solution plus linear-solver diagnostics.
-
-    Args:
-        displacement: Full displacement vector with shape `(ndof_full,)`.
-        diagnostics: Solver diagnostics for the reduced structural solve.
-    """
-
-    displacement: npt.NDArray[np.floating[Any]]
-    diagnostics: Structural2DSolveDiagnostics
 
 
 @dataclass(frozen=True, slots=True)
@@ -682,128 +630,23 @@ class Structural2DFEMModel:
         )
         return np.asarray(rhs, dtype=self.dtype)
 
-    @overload
-    def solve(
-        self,
-        rhs: ArrayLike,
-        *,
-        method: Literal["direct", "bicgstab"] = "direct",
-        tolerance: float | None = None,
-        max_iterations: int | None = None,
-        preconditioner: Literal["none", "diagonal"] = "diagonal",
-        equilibration: Literal["none", "ruiz"] = "ruiz",
-        equilibration_max_iterations: int | None = None,
-        equilibration_tolerance: float | None = None,
-        equilibration_norm_floor: float | None = None,
-        equilibration_norm_ceil: float | None = None,
-        initial_guess: Literal["zero", "previous"] = "zero",
-        return_diagnostics: Literal[False] = False,
-    ) -> npt.NDArray[np.floating[Any]]: ...
-
-    @overload
-    def solve(
-        self,
-        rhs: ArrayLike,
-        *,
-        method: Literal["direct", "bicgstab"] = "direct",
-        tolerance: float | None = None,
-        max_iterations: int | None = None,
-        preconditioner: Literal["none", "diagonal"] = "diagonal",
-        equilibration: Literal["none", "ruiz"] = "ruiz",
-        equilibration_max_iterations: int | None = None,
-        equilibration_tolerance: float | None = None,
-        equilibration_norm_floor: float | None = None,
-        equilibration_norm_ceil: float | None = None,
-        initial_guess: Literal["zero", "previous"] = "zero",
-        return_diagnostics: Literal[True],
-    ) -> Structural2DSolveResult: ...
-
-    def solve(
-        self,
-        rhs: ArrayLike,
-        *,
-        method: Literal["direct", "bicgstab"] = "direct",
-        tolerance: float | None = None,
-        max_iterations: int | None = None,
-        preconditioner: Literal["none", "diagonal"] = "diagonal",
-        equilibration: Literal["none", "ruiz"] = "ruiz",
-        equilibration_max_iterations: int | None = None,
-        equilibration_tolerance: float | None = None,
-        equilibration_norm_floor: float | None = None,
-        equilibration_norm_ceil: float | None = None,
-        initial_guess: Literal["zero", "previous"] = "zero",
-        return_diagnostics: bool = False,
-    ) -> npt.NDArray[np.floating[Any]] | Structural2DSolveResult:
+    def solve(self, rhs: ArrayLike) -> npt.NDArray[np.floating[Any]]:
         """Solve the reduced system and recover the full displacement field.
 
         Args:
             rhs: Reduced right-hand side with shape `(ndof_reduced,)` and units
                 `[generalized force] = [energy / distance]`.
-            method: Linear solve method, either `"direct"` for cached sparse LU or `"bicgstab"`
-                for an iterative solve.
-            tolerance: Optional absolute BiCGSTAB residual tolerance for the solved system. If
-                omitted, Rust chooses an RHS-scaled default. When Ruiz equilibration is enabled,
-                this same value is applied to the equilibrated system rather than rescaled to
-                original reduced-RHS units.
-            max_iterations: Optional maximum number of BiCGSTAB iterations.
-            preconditioner: BiCGSTAB preconditioner, either `"diagonal"` or `"none"`.
-            equilibration: BiCGSTAB equilibration mode, either `"ruiz"` or `"none"`.
-            equilibration_max_iterations: Optional maximum number of equilibration iterations.
-            equilibration_tolerance: Optional dimensionless equilibration tolerance.
-            equilibration_norm_floor: Optional lower clamp for measured equilibration norms.
-            equilibration_norm_ceil: Optional upper clamp for measured equilibration norms.
-            initial_guess: BiCGSTAB initial guess, either `"zero"` or `"previous"`.
-            return_diagnostics: If true, return `Structural2DSolveResult` with displacement and
-                diagnostics. If false, return the displacement array directly.
 
         Returns:
-            NDArray | Structural2DSolveResult: Full displacement vector with shape
-            `(ndof_full,)` and component ordering `[u_r0, u_z0, u_r1, u_z1, ...]`, or the same
-            displacement packaged with solver diagnostics. Units are `[length]`.
+            NDArray: Full displacement vector with shape `(ndof_full,)` and component ordering
+            `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
         """
 
         rhs_arr = np.ascontiguousarray(np.asarray(rhs, dtype=self.dtype).reshape(-1))
         assert (
             rhs_arr.shape[0] == self.ndof_reduced
         ), f"rhs must have length {self.ndof_reduced}; got {rhs_arr.shape}"
-        norm_floor = _positive_float_or_none("equilibration_norm_floor", equilibration_norm_floor)
-        norm_ceil = _positive_float_or_none("equilibration_norm_ceil", equilibration_norm_ceil)
-        assert (
-            norm_floor is None or norm_ceil is None or norm_ceil > norm_floor
-        ), "equilibration_norm_ceil must be greater than equilibration_norm_floor"
-        (
-            displacement_raw,
-            method_code,
-            converged,
-            iterations,
-            residual_norm,
-            equilibrated,
-        ) = self._backend.solve(
-            rhs_arr,
-            _solve_method_code(method),
-            _positive_float_or_none("tolerance", tolerance),
-            _positive_int_or_none("max_iterations", max_iterations),
-            _bicgstab_preconditioner_code(preconditioner),
-            _bicgstab_equilibration_code(equilibration),
-            _positive_int_or_none("equilibration_max_iterations", equilibration_max_iterations),
-            _nonnegative_float_or_none("equilibration_tolerance", equilibration_tolerance),
-            norm_floor,
-            norm_ceil,
-            _bicgstab_initial_guess_code(initial_guess),
-        )
-        displacement = np.asarray(displacement_raw, dtype=self.dtype)
-        if not return_diagnostics:
-            return displacement
-        return Structural2DSolveResult(
-            displacement=displacement,
-            diagnostics=Structural2DSolveDiagnostics(
-                method=_solve_method_name(int(method_code)),
-                converged=bool(converged),
-                iterations=int(iterations),
-                residual_norm=float(residual_norm),
-                equilibrated=bool(equilibrated),
-            ),
-        )
+        return np.asarray(self._backend.solve(rhs_arr), dtype=self.dtype)
 
     def recover_full(self, reduced_solution: ArrayLike) -> npt.NDArray[np.floating[Any]]:
         """Reinsert prescribed Dirichlet values into a reduced displacement vector.
@@ -966,18 +809,7 @@ def _normalize_material_orientation_angles(
     return np.ascontiguousarray(angles)
 
 
-def _resolve_float_dtype(*values: object) -> np.dtype[np.float32] | np.dtype[np.float64]:
-    arrays: list[np.ndarray[Any, Any]] = []
-    for value in values:
-        if value is None:
-            continue
-        if isinstance(value, Mapping):
-            arrays.extend(np.asarray(item) for item in value.values())
-        else:
-            arrays.append(np.asarray(value))
-    result = np.dtype(np.result_type(*arrays, np.float32))
-    if result.kind != "f" or result.itemsize <= 4:
-        return np.dtype(np.float32)
+def _resolve_float_dtype(*_values: object) -> np.dtype[np.float64]:
     return np.dtype(np.float64)
 
 
@@ -1020,14 +852,13 @@ def infer_quad9_mesh(nodes: ArrayLike, elements: ArrayLike) -> ElevatedQuad9Mesh
     dtype = _resolve_float_dtype(nodes)
     nodes_arr = _normalize_nodes(nodes, dtype)
     elements_arr = _normalize_elements(elements)
-    binding = _dispatch_pair(dtype, _infer_quad9_mesh_f32, _infer_quad9_mesh_f64)
     (
         analysis_nodes_flat,
         analysis_elements_flat,
         corner_node_indices,
         midside_node_indices,
         center_node_indices,
-    ) = binding(nodes_arr, elements_arr)
+    ) = _infer_quad9_mesh_f64(nodes_arr, elements_arr)
 
     return ElevatedQuad9Mesh(
         input_nodes=nodes_arr,
@@ -1057,7 +888,7 @@ def _normalize_query_tolerance(
         value = float(np.asarray(tolerance, dtype=dtype))
         assert value >= 0.0, f"tolerance must be nonnegative; got {tolerance!r}"
         return value
-    return 1.0e-5 if dtype == np.float32 else 1.0e-10
+    return 1.0e-10
 
 
 def _coo_operator_from_binding(
@@ -1117,8 +948,7 @@ def query_quad_mesh(
         4 if normalized_element_type == "quad4" else 9,
     )
     points_arr = _normalize_query_points(points, dtype)
-    binding = _dispatch_pair(dtype, _quad_mesh_query_f32, _quad_mesh_query_f64)
-    data = binding(
+    data = _quad_mesh_query_f64(
         nodes_arr,
         elements_arr,
         points_arr,
@@ -1171,13 +1001,8 @@ def quad_mesh_interpolation_operator(
     """
 
     dtype = query.nodes.dtype
-    binding = _dispatch_pair(
-        dtype,
-        _quad_mesh_interpolation_operator_f32,
-        _quad_mesh_interpolation_operator_f64,
-    )
     return _coo_operator_from_binding(
-        binding(
+        _quad_mesh_interpolation_operator_f64(
             query.nodes,
             query.elements,
             np.asarray(query.nearest_element_indices, dtype=np.uint64),
@@ -1214,9 +1039,8 @@ def quad_mesh_strain_operator(
     normalized_formulation = _normalize_formulation(formulation)
     thickness_value = _normalize_thickness(normalized_formulation, thickness, query.nodes.dtype)
     dtype = query.nodes.dtype
-    binding = _dispatch_pair(dtype, _quad_mesh_strain_operator_f32, _quad_mesh_strain_operator_f64)
     return _coo_operator_from_binding(
-        binding(
+        _quad_mesh_strain_operator_f64(
             query.nodes,
             query.elements,
             np.asarray(query.nearest_element_indices, dtype=np.uint64),
@@ -1277,9 +1101,8 @@ def quad_mesh_stress_operator(
     )
     normalized_formulation = _normalize_formulation(formulation)
     thickness_value = _normalize_thickness(normalized_formulation, thickness, dtype)
-    binding = _dispatch_pair(dtype, _quad_mesh_stress_operator_f32, _quad_mesh_stress_operator_f64)
     return _coo_operator_from_binding(
-        binding(
+        _quad_mesh_stress_operator_f64(
             np.asarray(query.nodes, dtype=dtype),
             query.elements,
             np.asarray(query.nearest_element_indices, dtype=np.uint64),
@@ -1645,57 +1468,6 @@ def _normalize_prescribed_dirichlet(
     )
 
 
-def _dispatch_pair(dtype: np.dtype[Any], f32: Any, f64: Any) -> Any:
-    if dtype == np.float32:
-        return f32
-    return f64
-
-
-def _solve_method_code(method: str) -> int:
-    code_by_method = {"direct": 0, "bicgstab": 1}
-    assert method in code_by_method, 'method must be "direct" or "bicgstab"'
-    return code_by_method[method]
-
-
-def _solve_method_name(code: int) -> Literal["direct", "bicgstab"]:
-    name_by_code: tuple[Literal["direct"], Literal["bicgstab"]] = ("direct", "bicgstab")
-    assert 0 <= code < len(name_by_code), f"unexpected solve method code {code}"
-    return name_by_code[code]
-
-
-def _bicgstab_preconditioner_code(preconditioner: str) -> int:
-    code_by_preconditioner = {"none": 0, "diagonal": 1}
-    assert preconditioner in code_by_preconditioner, 'preconditioner must be "none" or "diagonal"'
-    return code_by_preconditioner[preconditioner]
-
-
-def _bicgstab_equilibration_code(equilibration: str) -> int:
-    code_by_equilibration = {"none": 0, "ruiz": 1}
-    assert equilibration in code_by_equilibration, 'equilibration must be "none" or "ruiz"'
-    return code_by_equilibration[equilibration]
-
-
-def _bicgstab_initial_guess_code(initial_guess: str) -> int:
-    code_by_initial_guess = {"zero": 0, "previous": 1}
-    assert initial_guess in code_by_initial_guess, 'initial_guess must be "zero" or "previous"'
-    return code_by_initial_guess[initial_guess]
-
-
-def _positive_float_or_none(name: str, value: float | None) -> float | None:
-    assert value is None or (np.isfinite(value) and value > 0.0), f"{name} must be finite and positive"
-    return None if value is None else float(value)
-
-
-def _nonnegative_float_or_none(name: str, value: float | None) -> float | None:
-    assert value is None or (np.isfinite(value) and value >= 0.0), f"{name} must be finite and nonnegative"
-    return None if value is None else float(value)
-
-
-def _positive_int_or_none(name: str, value: int | None) -> int | None:
-    assert value is None or value >= 1, f"{name} must be at least 1"
-    return None if value is None else int(value)
-
-
 def assemble_structural_2d(
     nodes: ArrayLike,
     elements: ArrayLike,
@@ -1785,12 +1557,7 @@ def assemble_structural_2d(
         int(analysis_elements.shape[0]),
         dtype,
     )
-    low_level = _dispatch_pair(
-        dtype,
-        _assemble_model_2d_f32,
-        _assemble_model_2d_f64,
-    )
-    backend = low_level(
+    backend = _assemble_model_2d_f64(
         analysis_nodes,
         analysis_elements,
         material_ids_arr,
@@ -1857,20 +1624,18 @@ def isotropic_axisymmetric_material(
     Args:
         youngs_modulus: Young's modulus with units `[pressure]`.
         poisson_ratio: Poisson ratio with units `[dimensionless]`.
-        dtype: Output floating dtype.
+        dtype: Ignored; structural FEM material helpers always return `float64`.
 
     Returns:
         NDArray: Elastic stress-strain matrix with shape `(4, 4)` in component order
         `[rr, zz, tt, rz]`. Units are `[stress / strain] = [pressure]`.
     """
 
-    resolved_dtype = np.dtype(dtype)
-    binding = _dispatch_pair(
-        resolved_dtype,
-        _isotropic_axisymmetric_material_f32,
-        _isotropic_axisymmetric_material_f64,
-    )
-    return _as_float_array(binding(youngs_modulus, poisson_ratio), resolved_dtype).reshape(4, 4)
+    _ = dtype
+    return _as_float_array(
+        _isotropic_axisymmetric_material_f64(youngs_modulus, poisson_ratio),
+        np.dtype(np.float64),
+    ).reshape(4, 4)
 
 
 def isotropic_axisymmetric_thermal_material(
@@ -1883,7 +1648,7 @@ def isotropic_axisymmetric_thermal_material(
     Args:
         alpha: Isotropic thermal expansion coefficient with units `[strain / temperature]`.
         reference_temperature: Stress-free reference temperature with units `[temperature]`.
-        dtype: Output floating dtype.
+        dtype: Ignored; structural FEM material helpers always return `float64`.
 
     Returns:
         NDArray: Thermal material row with shape `(5,)` storing
@@ -1891,13 +1656,11 @@ def isotropic_axisymmetric_thermal_material(
         `[strain / temperature]`; `T_ref` has units `[temperature]`.
     """
 
-    resolved_dtype = np.dtype(dtype)
-    binding = _dispatch_pair(
-        resolved_dtype,
-        _isotropic_axisymmetric_thermal_material_f32,
-        _isotropic_axisymmetric_thermal_material_f64,
+    _ = dtype
+    return _as_float_array(
+        _isotropic_axisymmetric_thermal_material_f64(alpha, reference_temperature),
+        np.dtype(np.float64),
     )
-    return _as_float_array(binding(alpha, reference_temperature), resolved_dtype)
 
 
 def isotropic_plane_strain_material(
@@ -1912,13 +1675,11 @@ def isotropic_plane_strain_material(
     by the in-plane strains.
     """
 
-    resolved_dtype = np.dtype(dtype)
-    binding = _dispatch_pair(
-        resolved_dtype,
-        _isotropic_plane_strain_material_f32,
-        _isotropic_plane_strain_material_f64,
-    )
-    return _as_float_array(binding(youngs_modulus, poisson_ratio), resolved_dtype).reshape(4, 4)
+    _ = dtype
+    return _as_float_array(
+        _isotropic_plane_strain_material_f64(youngs_modulus, poisson_ratio),
+        np.dtype(np.float64),
+    ).reshape(4, 4)
 
 
 def isotropic_plane_strain_thermal_material(
@@ -1932,13 +1693,11 @@ def isotropic_plane_strain_thermal_material(
     coefficients and zero engineering shear expansion.
     """
 
-    resolved_dtype = np.dtype(dtype)
-    binding = _dispatch_pair(
-        resolved_dtype,
-        _isotropic_plane_strain_thermal_material_f32,
-        _isotropic_plane_strain_thermal_material_f64,
+    _ = dtype
+    return _as_float_array(
+        _isotropic_plane_strain_thermal_material_f64(alpha, reference_temperature),
+        np.dtype(np.float64),
     )
-    return _as_float_array(binding(alpha, reference_temperature), resolved_dtype)
 
 
 def orthotropic_axisymmetric_thermal_material(
@@ -1955,7 +1714,7 @@ def orthotropic_axisymmetric_thermal_material(
         alpha_z: Axial thermal expansion coefficient with units `[strain / temperature]`.
         alpha_t: Hoop thermal expansion coefficient with units `[strain / temperature]`.
         reference_temperature: Stress-free reference temperature with units `[temperature]`.
-        dtype: Output floating dtype.
+        dtype: Ignored; structural FEM material helpers always return `float64`.
 
     Returns:
         NDArray: Thermal material row with shape `(5,)` storing
@@ -1963,13 +1722,16 @@ def orthotropic_axisymmetric_thermal_material(
         `[strain / temperature]`; `T_ref` has units `[temperature]`.
     """
 
-    resolved_dtype = np.dtype(dtype)
-    binding = _dispatch_pair(
-        resolved_dtype,
-        _orthotropic_axisymmetric_thermal_material_f32,
-        _orthotropic_axisymmetric_thermal_material_f64,
+    _ = dtype
+    return _as_float_array(
+        _orthotropic_axisymmetric_thermal_material_f64(
+            alpha_r,
+            alpha_z,
+            alpha_t,
+            reference_temperature,
+        ),
+        np.dtype(np.float64),
     )
-    return _as_float_array(binding(alpha_r, alpha_z, alpha_t, reference_temperature), resolved_dtype)
 
 
 def orthotropic_plane_strain_thermal_material(
@@ -2011,13 +1773,11 @@ def cfsem_radial_material(
         `[rr, zz, tt, rz]`. Units are `[stress / strain] = [pressure]`.
     """
 
-    resolved_dtype = np.dtype(dtype)
-    binding = _dispatch_pair(
-        resolved_dtype,
-        _cfsem_radial_material_f32,
-        _cfsem_radial_material_f64,
-    )
-    return _as_float_array(binding(youngs_modulus, poisson_ratio), resolved_dtype).reshape(4, 4)
+    _ = dtype
+    return _as_float_array(
+        _cfsem_radial_material_f64(youngs_modulus, poisson_ratio),
+        np.dtype(np.float64),
+    ).reshape(4, 4)
 
 
 def _normalize_displacements(
@@ -2042,8 +1802,6 @@ __all__ = [
     "QuadMeshQuery",
     "QuadratureFieldSamples",
     "assemble_structural_2d",
-    "Structural2DSolveDiagnostics",
-    "Structural2DSolveResult",
     "cfsem_radial_material",
     "interpolate_quad_mesh_values",
     "infer_quad9_mesh",

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -71,6 +71,7 @@ _orthotropic_axisymmetric_thermal_material_f64 = (
 
 ArrayLike = npt.ArrayLike
 _QUAD_FACE_NODE_PAIRS: tuple[tuple[int, int], ...] = ((0, 1), (1, 2), (2, 3), (3, 0))
+_FLOAT_DTYPE = np.dtype(np.float64)
 
 
 def _to_csr_matrix(matrix: Any) -> sp.csr_matrix:
@@ -85,21 +86,20 @@ def _to_csc_matrix(matrix: Any) -> sp.csc_matrix:
     return cast(sp.csc_matrix, sp.csc_matrix(matrix))
 
 
-def _as_float_array(data: Any, dtype: np.dtype[Any]) -> npt.NDArray[np.floating[Any]]:
-    """Convert binding output to a NumPy floating array with an explicit static type."""
+def _as_float64_array(data: Any) -> npt.NDArray[np.float64]:
+    """Convert binding output to a NumPy float64 array with an explicit static type."""
 
-    return cast(npt.NDArray[np.floating[Any]], np.asarray(data, dtype=dtype))
+    return cast(npt.NDArray[np.float64], np.asarray(data, dtype=np.float64))
 
 
 def _csr_matrix_from_binding(
     binding: tuple[ArrayLike, ArrayLike, ArrayLike, int, int],
-    dtype: np.dtype[Any],
 ) -> sp.csr_matrix:
     vals, indices, indptr, nrow, ncol = binding
     return _to_csr_matrix(
         sp.csr_matrix(
             (
-                np.asarray(vals, dtype=dtype),
+                np.asarray(vals, dtype=np.float64),
                 np.asarray(indices, dtype=np.int64),
                 np.asarray(indptr, dtype=np.int64),
             ),
@@ -110,13 +110,12 @@ def _csr_matrix_from_binding(
 
 def _csc_matrix_from_binding(
     binding: tuple[ArrayLike, ArrayLike, ArrayLike, int, int],
-    dtype: np.dtype[Any],
 ) -> sp.csc_matrix:
     vals, indices, indptr, nrow, ncol = binding
     return _to_csc_matrix(
         sp.csc_matrix(
             (
-                np.asarray(vals, dtype=dtype),
+                np.asarray(vals, dtype=np.float64),
                 np.asarray(indices, dtype=np.int64),
                 np.asarray(indptr, dtype=np.int64),
             ),
@@ -220,8 +219,7 @@ class QuadMeshQuery:
 class Structural2DFEMModel:
     """Reusable 2D structural FEM model with sparse operators and reduced solve state.
 
-    Structural FEM numeric arrays are stored as `float64`. Floating inputs with lower precision are
-    accepted at the Python boundary and normalized before they enter the Rust backend.
+    Structural FEM numeric arrays are `float64`; floating inputs must already use `float64` arrays.
 
     The sparse operators are exported from the Rust backend lazily:
     - `body_force_to_rhs`, `pressure_to_rhs`, `traction_to_rhs`, and `temperature_to_rhs`
@@ -252,7 +250,6 @@ class Structural2DFEMModel:
         self,
         *,
         backend: Any,
-        dtype: np.dtype[Any],
         input_nodes: npt.NDArray[np.floating[Any]],
         input_elements: npt.NDArray[np.uint64],
         analysis_nodes: npt.NDArray[np.floating[Any]],
@@ -279,7 +276,6 @@ class Structural2DFEMModel:
         n_temperature_nodes: int,
     ) -> None:
         self._backend = backend
-        self._dtype = dtype
         self._input_nodes = input_nodes
         self._input_elements = input_elements
         self._elevated = elevated
@@ -329,9 +325,9 @@ class Structural2DFEMModel:
 
     @property
     def dtype(self) -> np.dtype[Any]:
-        """Floating dtype used by exported operators, arrays, and convenience-method outputs."""
+        """Floating dtype used by structural FEM arrays and outputs."""
 
-        return self._dtype
+        return _FLOAT_DTYPE
 
     @property
     def ndof(self) -> int:
@@ -364,7 +360,7 @@ class Structural2DFEMModel:
         assert elevated is not None, "temperature elevation is available only for inferred quad9 meshes"
         cache = self._temperature_elevation_cache
         if cache is None:
-            cache = _temperature_elevation_operator(elevated, self.dtype)
+            cache = _temperature_elevation_operator(elevated)
             self._temperature_elevation_cache = cache
         return cache
 
@@ -377,7 +373,7 @@ class Structural2DFEMModel:
 
         cache = getattr(self, attr)
         if cache is None:
-            cache = _csc_matrix_from_binding(export(), self.dtype)
+            cache = _csc_matrix_from_binding(export())
             setattr(self, attr, cache)
         return cast(sp.csc_matrix, cache)
 
@@ -386,7 +382,7 @@ class Structural2DFEMModel:
 
         cache = getattr(self, attr)
         if cache is None:
-            cache = _csr_matrix_from_binding(export(), self.dtype)
+            cache = _csr_matrix_from_binding(export())
             setattr(self, attr, cache)
         return cast(sp.csr_matrix, cache)
 
@@ -406,7 +402,7 @@ class Structural2DFEMModel:
         cache = getattr(self, attr)
         if cache is not None:
             return cast(sp.csr_matrix, cache)
-        analysis_operator = _csr_matrix_from_binding(export(), self.dtype)
+        analysis_operator = _csr_matrix_from_binding(export())
         cache = (
             _to_csr_matrix(analysis_operator @ self._temperature_elevation())
             if self._elevated is not None and self.n_temperature_nodes > 0
@@ -531,9 +527,9 @@ class Structural2DFEMModel:
             return cache
         points_flat, weights_area_flat, weights_volume_flat, nq = self._backend.element_quadrature()
         nelem = self.analysis_elements.shape[0]
-        points = np.asarray(points_flat, dtype=self.dtype).reshape(nelem, int(nq), 2)
-        weights_area = np.asarray(weights_area_flat, dtype=self.dtype).reshape(nelem, int(nq))
-        weights_volume = np.asarray(weights_volume_flat, dtype=self.dtype).reshape(nelem, int(nq))
+        points = np.asarray(points_flat, dtype=np.float64).reshape(nelem, int(nq), 2)
+        weights_area = np.asarray(weights_area_flat, dtype=np.float64).reshape(nelem, int(nq))
+        weights_volume = np.asarray(weights_volume_flat, dtype=np.float64).reshape(nelem, int(nq))
         cache = ElementQuadrature(
             points=points,
             weights_area=weights_area,
@@ -557,8 +553,8 @@ class Structural2DFEMModel:
             return cache
         areas, volumes = self._backend.element_measures()
         cache = ElementMeasures(
-            areas=np.asarray(areas, dtype=self.dtype),
-            volumes=np.asarray(volumes, dtype=self.dtype),
+            areas=np.asarray(areas, dtype=np.float64),
+            volumes=np.asarray(volumes, dtype=np.float64),
         )
         self._element_measures_cache = cache
         return cache
@@ -569,9 +565,9 @@ class Structural2DFEMModel:
     ) -> npt.NDArray[np.floating[Any]] | None:
         if self.n_temperature_nodes == 0:
             values = (
-                np.zeros((0,), dtype=self.dtype)
+                np.zeros((0,), dtype=np.float64)
                 if nodal_temperature is None
-                else np.asarray(nodal_temperature, dtype=self.dtype).reshape(-1)
+                else np.asarray(nodal_temperature).reshape(-1)
             )
             assert values.size == 0, "nodal_temperature was provided, but this model has no thermal operator"
             return None
@@ -581,7 +577,6 @@ class Structural2DFEMModel:
             nodal_temperature,
             self._input_nodes.shape[0],
             self._elevated,
-            self.dtype,
         )
 
     def build_rhs(
@@ -613,16 +608,15 @@ class Structural2DFEMModel:
         """
 
         body_force_arr = (
-            np.zeros((self.nelem, 2), dtype=self.dtype)
+            np.zeros((self.nelem, 2), dtype=np.float64)
             if body_force is None
-            else _normalize_body_force(body_force, self.nelem, self.dtype)
+            else _normalize_body_force(body_force, self.nelem)
         )
         npressure = int(self.pressure_faces.shape[0])
-        pressure_arr = _normalize_pressure_values(pressure_values, npressure, self.dtype)
+        pressure_arr = _normalize_pressure_values(pressure_values, npressure)
         traction_arr = _normalize_traction_values(
             traction_values,
             int(self.traction_faces.shape[0]),
-            self.dtype,
         )
         temperature_arr = self._normalize_temperature_for_backend(nodal_temperature)
         rhs = self._backend.build_rhs(
@@ -631,7 +625,7 @@ class Structural2DFEMModel:
             traction_arr.reshape(-1) if traction_arr.size else None,
             temperature_arr,
         )
-        return np.asarray(rhs, dtype=self.dtype)
+        return np.asarray(rhs, dtype=np.float64)
 
     def solve(self, rhs: ArrayLike) -> npt.NDArray[np.floating[Any]]:
         """Solve the reduced system and recover the full displacement field.
@@ -645,11 +639,11 @@ class Structural2DFEMModel:
             `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
         """
 
-        rhs_arr = np.ascontiguousarray(np.asarray(rhs, dtype=self.dtype).reshape(-1))
+        rhs_arr = np.asarray(rhs).reshape(-1)
         assert (
             rhs_arr.shape[0] == self.ndof_reduced
         ), f"rhs must have length {self.ndof_reduced}; got {rhs_arr.shape}"
-        return np.asarray(self._backend.solve(rhs_arr), dtype=self.dtype)
+        return np.asarray(self._backend.solve(rhs_arr), dtype=np.float64)
 
     def recover_full(self, reduced_solution: ArrayLike) -> npt.NDArray[np.floating[Any]]:
         """Reinsert prescribed Dirichlet values into a reduced displacement vector.
@@ -663,11 +657,11 @@ class Structural2DFEMModel:
             `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
         """
 
-        reduced_arr = np.asarray(reduced_solution, dtype=self.dtype).reshape(-1)
+        reduced_arr = np.asarray(reduced_solution).reshape(-1)
         assert (
             reduced_arr.shape[0] == self.ndof_reduced
         ), f"reduced_solution must have length {self.ndof_reduced}; got {reduced_arr.shape}"
-        full = np.zeros((self.ndof_full,), dtype=self.dtype)
+        full = np.zeros((self.ndof_full,), dtype=np.float64)
         full[self.fixed_dofs] = self.fixed_values
         full[self.free_dofs] = reduced_arr
         return full
@@ -698,12 +692,12 @@ class Structural2DFEMModel:
             ValueError: If thermal materials are present but `nodal_temperature` is omitted.
         """
 
-        arr = np.asarray(displacements, dtype=self.dtype)
+        arr = np.asarray(displacements)
         if arr.ndim == 1 and arr.shape == (self.ndof_reduced,):
             displacements_full = self.recover_full(arr)
         else:
             displacements_full = _normalize_displacements(
-                displacements, self.analysis_nodes.shape[0], self.dtype
+                displacements, self.analysis_nodes.shape[0]
             ).reshape(-1)
         temperature_arr = self._normalize_temperature_for_backend(nodal_temperature)
         (
@@ -717,11 +711,11 @@ class Structural2DFEMModel:
         nelem = self.analysis_elements.shape[0]
         nq = int(nq)
         return QuadratureFieldSamples(
-            points=np.asarray(points_flat, dtype=self.dtype).reshape(nelem, nq, 2),
-            strain=np.asarray(strain_flat, dtype=self.dtype).reshape(nelem, nq, 4),
-            thermal_strain=np.asarray(thermal_strain_flat, dtype=self.dtype).reshape(nelem, nq, 4),
-            elastic_strain=np.asarray(elastic_strain_flat, dtype=self.dtype).reshape(nelem, nq, 4),
-            stress=np.asarray(stress_flat, dtype=self.dtype).reshape(nelem, nq, 4),
+            points=np.asarray(points_flat, dtype=np.float64).reshape(nelem, nq, 2),
+            strain=np.asarray(strain_flat, dtype=np.float64).reshape(nelem, nq, 4),
+            thermal_strain=np.asarray(thermal_strain_flat, dtype=np.float64).reshape(nelem, nq, 4),
+            elastic_strain=np.asarray(elastic_strain_flat, dtype=np.float64).reshape(nelem, nq, 4),
+            stress=np.asarray(stress_flat, dtype=np.float64).reshape(nelem, nq, 4),
         )
 
 
@@ -785,13 +779,12 @@ def _formulation_code(formulation: str) -> int:
 def _normalize_thickness(
     formulation: str,
     thickness: float | None,
-    dtype: np.dtype[Any],
 ) -> float:
     if formulation == "axisymmetric":
         assert thickness is None, "thickness is only valid for formulation='plane_strain'"
-        return float(np.asarray(0.0, dtype=dtype))
+        return 0.0
     assert thickness is not None, "thickness is required for formulation='plane_strain'"
-    value = float(np.asarray(thickness, dtype=dtype))
+    value = float(thickness)
     assert value > 0.0, f"thickness must be positive; got {thickness!r}"
     return value
 
@@ -799,40 +792,35 @@ def _normalize_thickness(
 def _normalize_material_orientation_angles(
     material_orientation_angles: ArrayLike | None,
     nelem: int,
-    dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]]:
     if material_orientation_angles is None:
-        return np.zeros((0,), dtype=dtype)
-    angles = np.asarray(material_orientation_angles, dtype=dtype)
+        return np.zeros((0,), dtype=np.float64)
+    angles = np.asarray(material_orientation_angles)
     if angles.ndim == 0:
         angles = np.broadcast_to(angles, (nelem,)).copy()
     assert angles.ndim == 1 and angles.shape[0] == nelem, (
         f"material_orientation_angles must be a scalar or have shape ({nelem},); " f"got {angles.shape}"
     )
-    return np.ascontiguousarray(angles)
+    return angles
 
 
-def _resolve_float_dtype(*_values: object) -> np.dtype[np.float64]:
-    return np.dtype(np.float64)
-
-
-def _normalize_nodes(nodes: ArrayLike, dtype: np.dtype[Any]) -> npt.NDArray[np.floating[Any]]:
-    arr = np.asarray(nodes, dtype=dtype)
+def _normalize_nodes(nodes: ArrayLike) -> npt.NDArray[np.floating[Any]]:
+    arr = np.asarray(nodes)
     assert arr.ndim == 2 and arr.shape[1] == 2, f"nodes must have shape (nnode, 2); got {arr.shape}"
-    return np.ascontiguousarray(arr)
+    return arr
 
 
 def _normalize_elements(
     elements: ArrayLike,
     nodes_per_element: int | tuple[int, ...] = 4,
 ) -> npt.NDArray[np.uint64]:
-    arr = np.asarray(elements, dtype=np.uint64)
+    arr = np.asarray(elements)
     expected = (nodes_per_element,) if isinstance(nodes_per_element, int) else nodes_per_element
     expected_text = " or ".join(f"(nelem, {count})" for count in expected)
     assert (
         arr.ndim == 2 and arr.shape[1] in expected
     ), f"elements must have shape {expected_text}; got {arr.shape}"
-    return np.ascontiguousarray(arr)
+    return arr
 
 
 def infer_quad9_mesh(nodes: ArrayLike, elements: ArrayLike) -> ElevatedQuad9Mesh:
@@ -852,8 +840,7 @@ def infer_quad9_mesh(nodes: ArrayLike, elements: ArrayLike) -> ElevatedQuad9Mesh
             one-dimensional index arrays.
     """
 
-    dtype = _resolve_float_dtype(nodes)
-    nodes_arr = _normalize_nodes(nodes, dtype)
+    nodes_arr = _normalize_nodes(nodes)
     elements_arr = _normalize_elements(elements)
     (
         analysis_nodes_flat,
@@ -866,7 +853,7 @@ def infer_quad9_mesh(nodes: ArrayLike, elements: ArrayLike) -> ElevatedQuad9Mesh
     return ElevatedQuad9Mesh(
         input_nodes=nodes_arr,
         input_elements=elements_arr,
-        analysis_nodes=np.asarray(analysis_nodes_flat, dtype=dtype).reshape(-1, 2),
+        analysis_nodes=np.asarray(analysis_nodes_flat, dtype=np.float64).reshape(-1, 2),
         analysis_elements=np.asarray(analysis_elements_flat, dtype=np.uint64).reshape(-1, 9),
         corner_node_indices=np.asarray(corner_node_indices, dtype=np.int64),
         midside_node_indices=np.asarray(midside_node_indices, dtype=np.int64),
@@ -876,19 +863,17 @@ def infer_quad9_mesh(nodes: ArrayLike, elements: ArrayLike) -> ElevatedQuad9Mesh
 
 def _normalize_query_points(
     points: ArrayLike,
-    dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]]:
-    arr = np.asarray(points, dtype=dtype)
+    arr = np.asarray(points)
     assert arr.ndim == 2 and arr.shape[1] == 2, f"points must have shape (npoint, 2); got {arr.shape}"
-    return np.ascontiguousarray(arr)
+    return arr
 
 
 def _normalize_query_tolerance(
     tolerance: float | None,
-    dtype: np.dtype[Any],
 ) -> float:
     if tolerance is not None:
-        value = float(np.asarray(tolerance, dtype=dtype))
+        value = float(tolerance)
         assert value >= 0.0, f"tolerance must be nonnegative; got {tolerance!r}"
         return value
     return 1.0e-10
@@ -896,13 +881,12 @@ def _normalize_query_tolerance(
 
 def _coo_operator_from_binding(
     binding: tuple[ArrayLike, ArrayLike, ArrayLike, int, int],
-    dtype: np.dtype[Any],
 ) -> sp.csr_matrix:
     vals, rows, cols, nrow, ncol = binding
     return _to_csr_matrix(
         sp.coo_matrix(
             (
-                np.asarray(vals, dtype=dtype),
+                np.asarray(vals, dtype=np.float64),
                 (
                     np.asarray(rows, dtype=np.int64),
                     np.asarray(cols, dtype=np.int64),
@@ -943,14 +927,13 @@ def query_quad_mesh(
         and index arrays are unitless.
     """
 
-    dtype = _resolve_float_dtype(nodes, points)
     normalized_element_type = _normalize_element_type(element_type)
-    nodes_arr = _normalize_nodes(nodes, dtype)
+    nodes_arr = _normalize_nodes(nodes)
     elements_arr = _normalize_elements(
         elements,
         4 if normalized_element_type == "quad4" else 9,
     )
-    points_arr = _normalize_query_points(points, dtype)
+    points_arr = _normalize_query_points(points)
     data = _quad_mesh_query_f64(
         nodes_arr,
         elements_arr,
@@ -965,23 +948,23 @@ def query_quad_mesh(
         points=points_arr,
         element_type=normalized_element_type,
         nearest_node_indices=np.asarray(data["nearest_node_indices"], dtype=np.int64),
-        nearest_node_points=np.asarray(data["nearest_node_points"], dtype=dtype).reshape(-1, 2),
-        nearest_node_distances=np.asarray(data["nearest_node_distances"], dtype=dtype),
+        nearest_node_points=np.asarray(data["nearest_node_points"], dtype=np.float64).reshape(-1, 2),
+        nearest_node_distances=np.asarray(data["nearest_node_distances"], dtype=np.float64),
         nearest_element_indices=np.asarray(data["nearest_element_indices"], dtype=np.int64),
         nearest_element_reference_points=np.asarray(
             data["nearest_element_reference_points"],
-            dtype=dtype,
+            dtype=np.float64,
         ).reshape(-1, 2),
-        nearest_element_points=np.asarray(data["nearest_element_points"], dtype=dtype).reshape(-1, 2),
-        nearest_element_distances=np.asarray(data["nearest_element_distances"], dtype=dtype),
+        nearest_element_points=np.asarray(data["nearest_element_points"], dtype=np.float64).reshape(-1, 2),
+        nearest_element_distances=np.asarray(data["nearest_element_distances"], dtype=np.float64),
         nearest_face_element_indices=np.asarray(data["nearest_face_element_indices"], dtype=np.int64),
         nearest_face_local_faces=np.asarray(data["nearest_face_local_faces"], dtype=np.int64),
         nearest_face_reference_coordinates=np.asarray(
             data["nearest_face_reference_coordinates"],
-            dtype=dtype,
+            dtype=np.float64,
         ),
-        nearest_face_points=np.asarray(data["nearest_face_points"], dtype=dtype).reshape(-1, 2),
-        nearest_face_distances=np.asarray(data["nearest_face_distances"], dtype=dtype),
+        nearest_face_points=np.asarray(data["nearest_face_points"], dtype=np.float64).reshape(-1, 2),
+        nearest_face_distances=np.asarray(data["nearest_face_distances"], dtype=np.float64),
     )
 
 
@@ -1003,7 +986,6 @@ def quad_mesh_interpolation_operator(
         matrix multiplication.
     """
 
-    dtype = query.nodes.dtype
     return _coo_operator_from_binding(
         _quad_mesh_interpolation_operator_f64(
             query.nodes,
@@ -1012,7 +994,6 @@ def quad_mesh_interpolation_operator(
             query.nearest_element_reference_points,
             query.element_type,
         ),
-        dtype,
     )
 
 
@@ -1040,8 +1021,7 @@ def quad_mesh_strain_operator(
     """
 
     normalized_formulation = _normalize_formulation(formulation)
-    thickness_value = _normalize_thickness(normalized_formulation, thickness, query.nodes.dtype)
-    dtype = query.nodes.dtype
+    thickness_value = _normalize_thickness(normalized_formulation, thickness)
     return _coo_operator_from_binding(
         _quad_mesh_strain_operator_f64(
             query.nodes,
@@ -1052,7 +1032,6 @@ def quad_mesh_strain_operator(
             _formulation_code(normalized_formulation),
             thickness_value,
         ),
-        dtype,
     )
 
 
@@ -1092,24 +1071,22 @@ def quad_mesh_stress_operator(
         units `[pressure]`.
     """
 
-    dtype = _resolve_float_dtype(query.nodes, material_table, material_orientation_angles)
-    material_ids_arr, material_table_arr = _normalize_materials(material_ids, material_table, dtype)
+    material_ids_arr, material_table_arr = _normalize_materials(material_ids, material_table)
     assert material_ids_arr.shape == (
         query.elements.shape[0],
     ), f"material_ids must have shape ({query.elements.shape[0]},); got {material_ids_arr.shape}"
     material_orientation_angles_arr = _normalize_material_orientation_angles(
         material_orientation_angles,
         query.elements.shape[0],
-        dtype,
     )
     normalized_formulation = _normalize_formulation(formulation)
-    thickness_value = _normalize_thickness(normalized_formulation, thickness, dtype)
+    thickness_value = _normalize_thickness(normalized_formulation, thickness)
     return _coo_operator_from_binding(
         _quad_mesh_stress_operator_f64(
-            np.asarray(query.nodes, dtype=dtype),
+            query.nodes,
             query.elements,
             np.asarray(query.nearest_element_indices, dtype=np.uint64),
-            np.asarray(query.nearest_element_reference_points, dtype=dtype),
+            query.nearest_element_reference_points,
             material_ids_arr,
             material_table_arr,
             material_orientation_angles_arr,
@@ -1117,7 +1094,6 @@ def quad_mesh_stress_operator(
             _formulation_code(normalized_formulation),
             thickness_value,
         ),
-        dtype,
     )
 
 
@@ -1160,7 +1136,6 @@ def interpolate_quad_mesh_values(
         is unitless with shape `(npoint, 2)`; `inside` has shape `(npoint,)`.
     """
 
-    dtype = _resolve_float_dtype(nodes, nodal_values, points)
     query = query_quad_mesh(
         nodes,
         elements,
@@ -1168,14 +1143,14 @@ def interpolate_quad_mesh_values(
         element_type=element_type,
         max_iterations=max_iterations,
     )
-    values_arr = np.asarray(nodal_values, dtype=dtype)
+    values_arr = np.asarray(nodal_values)
     assert (
         values_arr.ndim >= 1 and values_arr.shape[0] == query.nodes.shape[0]
     ), f"nodal_values must have shape (nnode,) or (nnode, ...); got {values_arr.shape}"
     values_shape = values_arr.shape[1:]
-    values_2d = np.ascontiguousarray(values_arr.reshape(query.nodes.shape[0], -1), dtype=dtype)
+    values_2d = values_arr.reshape(query.nodes.shape[0], -1)
     outside_policy = str(outside).strip().lower()
-    tol = _normalize_query_tolerance(tolerance, dtype)
+    tol = _normalize_query_tolerance(tolerance)
     inside = query.nearest_element_distances <= tol
     if outside_policy in {"raise", "error"} and not np.all(inside):
         first = int(np.flatnonzero(~inside)[0])
@@ -1183,7 +1158,7 @@ def interpolate_quad_mesh_values(
     if outside_policy not in {"nearest", "nan", "raise", "error"}:
         raise ValueError(f"unsupported outside policy {outside!r}; use 'raise', 'nan', or 'nearest'")
     operator = quad_mesh_interpolation_operator(query)
-    values = np.asarray(operator @ values_2d, dtype=dtype).reshape((query.points.shape[0], *values_shape))
+    values = np.asarray(operator @ values_2d).reshape((query.points.shape[0], *values_shape))
     if outside_policy == "nan" and np.any(~inside):
         values[~inside] = np.nan
     return QuadMeshInterpolation(
@@ -1196,7 +1171,6 @@ def interpolate_quad_mesh_values(
 
 def _temperature_elevation_operator(
     elevated: ElevatedQuad9Mesh,
-    dtype: np.dtype[Any],
 ) -> sp.csr_matrix:
     n_input_nodes = elevated.input_nodes.shape[0]
     n_analysis_nodes = elevated.analysis_nodes.shape[0]
@@ -1230,7 +1204,7 @@ def _temperature_elevation_operator(
     return _to_csr_matrix(
         sp.coo_matrix(
             (
-                np.asarray(vals, dtype=dtype),
+                np.asarray(vals, dtype=np.float64),
                 (np.asarray(rows, dtype=np.int64), np.asarray(cols, dtype=np.int64)),
             ),
             shape=(n_analysis_nodes, n_input_nodes),
@@ -1242,40 +1216,36 @@ def _analysis_temperature_for_element_type(
     nodal_temperature: ArrayLike,
     n_input_nodes: int,
     elevated: ElevatedQuad9Mesh | None,
-    dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]]:
     if elevated is None:
-        return _normalize_nodal_temperature(nodal_temperature, n_input_nodes, dtype)
+        return _normalize_nodal_temperature(nodal_temperature, n_input_nodes)
     input_temperature = _normalize_nodal_temperature(
         nodal_temperature,
         n_input_nodes,
-        dtype,
     )
-    elevation = _temperature_elevation_operator(elevated, dtype)
-    return np.asarray(elevation @ input_temperature, dtype=dtype)
+    elevation = _temperature_elevation_operator(elevated)
+    return np.asarray(elevation @ input_temperature, dtype=np.float64)
 
 
 def _normalize_materials(
     material_ids: ArrayLike,
     material_table: ArrayLike,
-    dtype: np.dtype[Any],
 ) -> tuple[npt.NDArray[np.uint64], npt.NDArray[np.floating[Any]]]:
-    ids = np.asarray(material_ids, dtype=np.uint64)
+    ids = np.asarray(material_ids)
     assert ids.ndim == 1, f"material_ids must have shape (nelem,); got {ids.shape}"
     assert not isinstance(
         material_table, Mapping
     ), "material_table must be a dense array; use pack_material_tables_from_tags(...) for tagged inputs"
-    table = np.asarray(material_table, dtype=dtype)
+    table = np.asarray(material_table)
     assert table.ndim == 3 and table.shape[1:] == (
         4,
         4,
     ), f"material_table must have shape (nmat, 4, 4); got {table.shape}"
-    return np.ascontiguousarray(ids), np.ascontiguousarray(table)
+    return ids, table
 
 
 def _normalize_thermal_material_table(
     thermal_material_table: ArrayLike | None,
-    dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]] | None:
     if thermal_material_table is None:
         return None
@@ -1283,11 +1253,10 @@ def _normalize_thermal_material_table(
         "thermal_material_table must be a dense array; use pack_material_tables_from_tags(...) "
         "for tagged inputs"
     )
-    table = np.asarray(thermal_material_table, dtype=dtype)
+    table = np.asarray(thermal_material_table)
     assert (
         table.ndim == 2 and table.shape[1] == 5
     ), f"thermal_material_table must have shape (nmat, 5); got {table.shape}"
-    table = np.ascontiguousarray(table)
     assert not np.any(table[:, 3] != 0.0), "shear thermal expansion (alpha_rz) is not yet supported"
     return table
 
@@ -1385,78 +1354,73 @@ def pack_material_tables_from_tags(
 def _normalize_nodal_temperature(
     nodal_temperature: ArrayLike,
     nnode: int,
-    dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]]:
-    arr = np.asarray(nodal_temperature, dtype=dtype)
+    arr = np.asarray(nodal_temperature)
     assert (
         arr.ndim == 1 and arr.shape[0] == nnode
     ), f"nodal_temperature must have shape ({nnode},); got {arr.shape}"
-    return np.ascontiguousarray(arr)
+    return arr
 
 
 def _normalize_body_force(
     body_force: ArrayLike,
     nelem: int,
-    dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]]:
-    arr = np.asarray(body_force, dtype=dtype)
+    arr = np.asarray(body_force)
     if arr.ndim == 1 and arr.shape == (2,):
         arr = np.broadcast_to(arr, (nelem, 2)).copy()
     assert arr.ndim == 2 and arr.shape == (
         nelem,
         2,
     ), f"body_force must have shape (2,) or (nelem, 2); got {arr.shape}"
-    return np.ascontiguousarray(arr)
+    return arr
 
 
 def _normalize_face_pairs(name: str, faces: ArrayLike | None) -> npt.NDArray[np.uint64]:
     if faces is None:
         return np.zeros((0, 2), dtype=np.uint64)
-    faces = np.asarray(faces, dtype=np.uint64)
+    faces = np.asarray(faces)
     assert faces.ndim == 2 and faces.shape[1] == 2, f"{name} must have shape (nload, 2); got {faces.shape}"
-    return np.ascontiguousarray(faces)
+    return faces
 
 
 def _normalize_pressure_values(
     pressure_values: ArrayLike | None,
     nload: int,
-    dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]]:
     if pressure_values is None:
-        return np.zeros((nload,), dtype=dtype)
-    values = np.asarray(pressure_values, dtype=dtype)
+        return np.zeros((nload,), dtype=np.float64)
+    values = np.asarray(pressure_values)
     assert values.ndim == 1, f"pressure_values must have shape (nload,); got {values.shape}"
     assert values.shape[0] == nload, f"pressure_values has {values.shape[0]} entries, but expected {nload}"
-    return np.ascontiguousarray(values)
+    return values
 
 
 def _normalize_traction_values(
     traction_values: ArrayLike | None,
     nload: int,
-    dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]]:
     if traction_values is None:
-        return np.zeros((nload, 2), dtype=dtype)
-    values = np.asarray(traction_values, dtype=dtype)
+        return np.zeros((nload, 2), dtype=np.float64)
+    values = np.asarray(traction_values)
     if values.ndim == 1 and values.shape == (2,):
         values = np.broadcast_to(values, (nload, 2)).copy()
     assert values.ndim == 2 and values.shape == (
         nload,
         2,
     ), f"traction_values must have shape (2,) or ({nload}, 2); got {values.shape}"
-    return np.ascontiguousarray(values)
+    return values
 
 
 def _normalize_prescribed_dirichlet(
     prescribed: Mapping[int, float] | None,
-    dtype: np.dtype[Any],
 ) -> tuple[npt.NDArray[np.uint64], npt.NDArray[np.floating[Any]]]:
     if prescribed is None:
-        return np.zeros((0,), dtype=np.uint64), np.zeros((0,), dtype=dtype)
+        return np.zeros((0,), dtype=np.uint64), np.zeros((0,), dtype=np.float64)
     items = sorted((int(dof), float(value)) for dof, value in prescribed.items())
     return (
         np.asarray([dof for dof, _ in items], dtype=np.uint64),
-        np.asarray([value for _, value in items], dtype=dtype),
+        np.asarray([value for _, value in items], dtype=np.float64),
     )
 
 
@@ -1482,7 +1446,7 @@ def assemble_structural_2d(
     Args:
         nodes: Corner-node coordinates with shape `(nnode, 2)`. Coordinates are `(r, z)` for
             `formulation="axisymmetric"` and `(x, y)` for `formulation="plane_strain"`.
-            Units are `[length]`. Floating inputs are normalized to `float64`.
+            Units are `[length]`. Floating input arrays must have dtype `float64`.
         elements: Connectivity with shape `(nelem, 4)` for `element_type="quad4"`. For
             `element_type="quad9"`, pass either corner-only `(nelem, 4)` connectivity to infer a
             straight-sided quad9 mesh, or explicit `(nelem, 9)` connectivity in local order
@@ -1512,7 +1476,7 @@ def assemble_structural_2d(
 
     Returns:
         Structural2DFEMModel: Reusable model with backend solve state and lazy Python sparse
-        operator exports. The model stores floating arrays as `float64`.
+        operator exports.
 
     Raises:
         ValueError: If `quadrature` is unsupported.
@@ -1520,19 +1484,17 @@ def assemble_structural_2d(
             instead of dense arrays.
     """
 
-    dtype = _resolve_float_dtype(nodes, material_table, thermal_material_table)
-    nodes_arr = _normalize_nodes(nodes, dtype)
-    material_ids_arr, material_table_arr = _normalize_materials(material_ids, material_table, dtype)
+    nodes_arr = _normalize_nodes(nodes)
+    material_ids_arr, material_table_arr = _normalize_materials(material_ids, material_table)
     thermal_material_table_arr = _normalize_thermal_material_table(
         thermal_material_table,
-        dtype,
     )
     pressure_faces_arr = _normalize_face_pairs("pressure_faces", pressure_faces)
     traction_faces_arr = _normalize_face_pairs("traction_faces", traction_faces)
-    prescribed_dofs, prescribed_values = _normalize_prescribed_dirichlet(prescribed, dtype)
+    prescribed_dofs, prescribed_values = _normalize_prescribed_dirichlet(prescribed)
     quadrature_code = _quadrature_code(quadrature)
     normalized_formulation = _normalize_formulation(formulation)
-    thickness_value = _normalize_thickness(normalized_formulation, thickness, dtype)
+    thickness_value = _normalize_thickness(normalized_formulation, thickness)
     normalized_element_type = _normalize_element_type(element_type)
     if normalized_element_type == "quad4":
         elements_arr = _normalize_elements(elements, 4)
@@ -1547,7 +1509,6 @@ def assemble_structural_2d(
     material_orientation_angles_arr = _normalize_material_orientation_angles(
         material_orientation_angles,
         int(analysis_elements.shape[0]),
-        dtype,
     )
     backend = _assemble_model_2d_f64(
         analysis_nodes,
@@ -1559,7 +1520,7 @@ def assemble_structural_2d(
         (
             thermal_material_table_arr
             if thermal_material_table_arr is not None
-            else np.zeros((0, 5), dtype=dtype)
+            else np.zeros((0, 5), dtype=np.float64)
         ),
         material_orientation_angles_arr,
         prescribed_dofs,
@@ -1574,7 +1535,6 @@ def assemble_structural_2d(
 
     model = Structural2DFEMModel(
         backend=backend,
-        dtype=dtype,
         input_nodes=nodes_arr,
         input_elements=elements_arr,
         analysis_nodes=analysis_nodes,
@@ -1585,18 +1545,18 @@ def assemble_structural_2d(
         formulation=normalized_formulation,
         thickness=thickness_value,
         element_type=normalized_element_type,
-        constant_rhs=np.asarray(backend.constant_rhs(), dtype=dtype),
+        constant_rhs=np.asarray(backend.constant_rhs(), dtype=np.float64),
         quadrature_points=np.asarray(
             backend.quadrature_points_flat(),
-            dtype=dtype,
+            dtype=np.float64,
         ).reshape(analysis_elements.shape[0], int(backend.nq_per_element), 2),
-        strain_constant=np.asarray(backend.strain_constant(), dtype=dtype),
-        stress_constant=np.asarray(backend.stress_constant(), dtype=dtype),
-        thermal_strain_constant=np.asarray(backend.thermal_strain_constant(), dtype=dtype),
-        thermal_stress_constant=np.asarray(backend.thermal_stress_constant(), dtype=dtype),
+        strain_constant=np.asarray(backend.strain_constant(), dtype=np.float64),
+        stress_constant=np.asarray(backend.stress_constant(), dtype=np.float64),
+        thermal_strain_constant=np.asarray(backend.thermal_strain_constant(), dtype=np.float64),
+        thermal_stress_constant=np.asarray(backend.thermal_stress_constant(), dtype=np.float64),
         free_dofs=np.asarray(backend.free_dofs(), dtype=np.int64),
         fixed_dofs=np.asarray(backend.fixed_dofs(), dtype=np.int64),
-        fixed_values=np.asarray(backend.fixed_values(), dtype=dtype),
+        fixed_values=np.asarray(backend.fixed_values(), dtype=np.float64),
         ndof_full=int(backend.ndof_full),
         ndof_reduced=int(backend.ndof_reduced),
         nelem=elements_arr.shape[0],
@@ -1621,10 +1581,9 @@ def isotropic_axisymmetric_material(
         `[rr, zz, tt, rz]`. Units are `[stress / strain] = [pressure]`.
     """
 
-    return _as_float_array(
-        _isotropic_axisymmetric_material_f64(youngs_modulus, poisson_ratio),
-        np.dtype(np.float64),
-    ).reshape(4, 4)
+    return _as_float64_array(_isotropic_axisymmetric_material_f64(youngs_modulus, poisson_ratio)).reshape(
+        4, 4
+    )
 
 
 def isotropic_axisymmetric_thermal_material(
@@ -1643,10 +1602,7 @@ def isotropic_axisymmetric_thermal_material(
         `[strain / temperature]`; `T_ref` has units `[temperature]`.
     """
 
-    return _as_float_array(
-        _isotropic_axisymmetric_thermal_material_f64(alpha, reference_temperature),
-        np.dtype(np.float64),
-    )
+    return _as_float64_array(_isotropic_axisymmetric_thermal_material_f64(alpha, reference_temperature))
 
 
 def isotropic_plane_strain_material(
@@ -1660,10 +1616,9 @@ def isotropic_plane_strain_material(
     by the in-plane strains.
     """
 
-    return _as_float_array(
-        _isotropic_plane_strain_material_f64(youngs_modulus, poisson_ratio),
-        np.dtype(np.float64),
-    ).reshape(4, 4)
+    return _as_float64_array(_isotropic_plane_strain_material_f64(youngs_modulus, poisson_ratio)).reshape(
+        4, 4
+    )
 
 
 def isotropic_plane_strain_thermal_material(
@@ -1676,10 +1631,7 @@ def isotropic_plane_strain_thermal_material(
     coefficients and zero engineering shear expansion.
     """
 
-    return _as_float_array(
-        _isotropic_plane_strain_thermal_material_f64(alpha, reference_temperature),
-        np.dtype(np.float64),
-    )
+    return _as_float64_array(_isotropic_plane_strain_thermal_material_f64(alpha, reference_temperature))
 
 
 def orthotropic_axisymmetric_thermal_material(
@@ -1702,14 +1654,13 @@ def orthotropic_axisymmetric_thermal_material(
         `[strain / temperature]`; `T_ref` has units `[temperature]`.
     """
 
-    return _as_float_array(
+    return _as_float64_array(
         _orthotropic_axisymmetric_thermal_material_f64(
             alpha_r,
             alpha_z,
             alpha_t,
             reference_temperature,
-        ),
-        np.dtype(np.float64),
+        )
     )
 
 
@@ -1748,18 +1699,14 @@ def cfsem_radial_material(
         `[rr, zz, tt, rz]`. Units are `[stress / strain] = [pressure]`.
     """
 
-    return _as_float_array(
-        _cfsem_radial_material_f64(youngs_modulus, poisson_ratio),
-        np.dtype(np.float64),
-    ).reshape(4, 4)
+    return _as_float64_array(_cfsem_radial_material_f64(youngs_modulus, poisson_ratio)).reshape(4, 4)
 
 
 def _normalize_displacements(
     displacements: ArrayLike,
     nnode: int,
-    dtype: np.dtype[Any],
 ) -> npt.NDArray[np.floating[Any]]:
-    arr = np.asarray(displacements, dtype=dtype)
+    arr = np.asarray(displacements)
     if arr.ndim == 1 and arr.shape == (2 * nnode,):
         return arr.reshape(nnode, 2)
     if arr.ndim == 2 and arr.shape == (nnode, 2):

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -324,12 +324,6 @@ class Structural2DFEMModel:
         self._thermal_stress_operator_cache: sp.csr_matrix | None = None
 
     @property
-    def dtype(self) -> np.dtype[Any]:
-        """Floating dtype used by structural FEM arrays and outputs."""
-
-        return _FLOAT_DTYPE
-
-    @property
     def ndof(self) -> int:
         """Compatibility alias for `ndof_full`, the full displacement-vector length `(ndof_full,)`."""
 

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -1296,7 +1296,6 @@ def pack_material_tables_from_tags(
     material_ids: ArrayLike,
     material_table_by_tag: Mapping[int, ArrayLike],
     thermal_material_table_by_tag: Mapping[int, ArrayLike] | None = None,
-    dtype: npt.DTypeLike | None = None,
 ) -> tuple[
     npt.NDArray[np.uint64],
     npt.NDArray[np.floating[Any]],
@@ -1312,9 +1311,6 @@ def pack_material_tables_from_tags(
             with shape `(5,)` storing `[alpha_r, alpha_z, alpha_t, alpha_rz, T_ref]`. Thermal
             expansion coefficients have units `[strain / temperature]` and `T_ref` has units
             `[temperature]`.
-        dtype: Optional output floating dtype. Defaults to the resolved dtype of the provided
-            material rows.
-
     Returns:
         tuple: `(packed_material_ids, packed_material_table, packed_thermal_material_table)` where:
             `packed_material_ids` has shape `(nelem,)`,
@@ -1327,14 +1323,7 @@ def pack_material_tables_from_tags(
     """
 
     assert material_table_by_tag, "material_table_by_tag cannot be empty"
-    resolved_dtype = (
-        np.dtype(dtype)
-        if dtype is not None
-        else _resolve_float_dtype(
-            material_table_by_tag,
-            thermal_material_table_by_tag,
-        )
-    )
+    resolved_dtype = np.dtype(np.float64)
     ids = np.asarray(material_ids, dtype=np.uint64)
     assert ids.ndim == 1, f"material_ids must have shape (nelem,); got {ids.shape}"
 
@@ -1620,21 +1609,18 @@ def assemble_structural_2d(
 def isotropic_axisymmetric_material(
     youngs_modulus: float,
     poisson_ratio: float,
-    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
     """Construct the isotropic axisymmetric elastic stress-strain matrix.
 
     Args:
         youngs_modulus: Young's modulus with units `[pressure]`.
         poisson_ratio: Poisson ratio with units `[dimensionless]`.
-        dtype: Ignored; structural FEM material helpers always return `float64`.
 
     Returns:
         NDArray: Elastic stress-strain matrix with shape `(4, 4)` in component order
         `[rr, zz, tt, rz]`. Units are `[stress / strain] = [pressure]`.
     """
 
-    _ = dtype
     return _as_float_array(
         _isotropic_axisymmetric_material_f64(youngs_modulus, poisson_ratio),
         np.dtype(np.float64),
@@ -1644,14 +1630,12 @@ def isotropic_axisymmetric_material(
 def isotropic_axisymmetric_thermal_material(
     alpha: float,
     reference_temperature: float = 0.0,
-    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
     """Construct isotropic thermal-expansion data.
 
     Args:
         alpha: Isotropic thermal expansion coefficient with units `[strain / temperature]`.
         reference_temperature: Stress-free reference temperature with units `[temperature]`.
-        dtype: Ignored; structural FEM material helpers always return `float64`.
 
     Returns:
         NDArray: Thermal material row with shape `(5,)` storing
@@ -1659,7 +1643,6 @@ def isotropic_axisymmetric_thermal_material(
         `[strain / temperature]`; `T_ref` has units `[temperature]`.
     """
 
-    _ = dtype
     return _as_float_array(
         _isotropic_axisymmetric_thermal_material_f64(alpha, reference_temperature),
         np.dtype(np.float64),
@@ -1669,7 +1652,6 @@ def isotropic_axisymmetric_thermal_material(
 def isotropic_plane_strain_material(
     youngs_modulus: float,
     poisson_ratio: float,
-    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
     """Construct the isotropic plane-strain elastic stress-strain matrix.
 
@@ -1678,7 +1660,6 @@ def isotropic_plane_strain_material(
     by the in-plane strains.
     """
 
-    _ = dtype
     return _as_float_array(
         _isotropic_plane_strain_material_f64(youngs_modulus, poisson_ratio),
         np.dtype(np.float64),
@@ -1688,7 +1669,6 @@ def isotropic_plane_strain_material(
 def isotropic_plane_strain_thermal_material(
     alpha: float,
     reference_temperature: float = 0.0,
-    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
     """Construct isotropic plane-strain thermal-expansion data.
 
@@ -1696,7 +1676,6 @@ def isotropic_plane_strain_thermal_material(
     coefficients and zero engineering shear expansion.
     """
 
-    _ = dtype
     return _as_float_array(
         _isotropic_plane_strain_thermal_material_f64(alpha, reference_temperature),
         np.dtype(np.float64),
@@ -1708,7 +1687,6 @@ def orthotropic_axisymmetric_thermal_material(
     alpha_z: float,
     alpha_t: float,
     reference_temperature: float = 0.0,
-    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
     """Construct orthotropic thermal-expansion data.
 
@@ -1717,7 +1695,6 @@ def orthotropic_axisymmetric_thermal_material(
         alpha_z: Axial thermal expansion coefficient with units `[strain / temperature]`.
         alpha_t: Hoop thermal expansion coefficient with units `[strain / temperature]`.
         reference_temperature: Stress-free reference temperature with units `[temperature]`.
-        dtype: Ignored; structural FEM material helpers always return `float64`.
 
     Returns:
         NDArray: Thermal material row with shape `(5,)` storing
@@ -1725,7 +1702,6 @@ def orthotropic_axisymmetric_thermal_material(
         `[strain / temperature]`; `T_ref` has units `[temperature]`.
     """
 
-    _ = dtype
     return _as_float_array(
         _orthotropic_axisymmetric_thermal_material_f64(
             alpha_r,
@@ -1742,7 +1718,6 @@ def orthotropic_plane_strain_thermal_material(
     alpha_y: float,
     alpha_z: float,
     reference_temperature: float = 0.0,
-    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
     """Construct orthotropic plane-strain thermal-expansion data.
 
@@ -1755,28 +1730,24 @@ def orthotropic_plane_strain_thermal_material(
         alpha_y,
         alpha_z,
         reference_temperature,
-        dtype,
     )
 
 
 def cfsem_radial_material(
     youngs_modulus: float,
     poisson_ratio: float,
-    dtype: npt.DTypeLike = np.float64,
 ) -> npt.NDArray[np.floating[Any]]:
     """Construct the reduced elastic matrix used by the 1D radial solver.
 
     Args:
         youngs_modulus: Young's modulus with units `[pressure]`.
         poisson_ratio: Poisson ratio with units `[dimensionless]`.
-        dtype: Ignored; structural FEM material helpers always return `float64`.
 
     Returns:
         NDArray: Elastic stress-strain matrix with shape `(4, 4)` in component order
         `[rr, zz, tt, rz]`. Units are `[stress / strain] = [pressure]`.
     """
 
-    _ = dtype
     return _as_float_array(
         _cfsem_radial_material_f64(youngs_modulus, poisson_ratio),
         np.dtype(np.float64),

--- a/cfsem/solenoid_stress/fem2d.py
+++ b/cfsem/solenoid_stress/fem2d.py
@@ -220,6 +220,9 @@ class QuadMeshQuery:
 class Structural2DFEMModel:
     """Reusable 2D structural FEM model with sparse operators and reduced solve state.
 
+    Structural FEM numeric arrays are stored as `float64`. Floating inputs with lower precision are
+    accepted at the Python boundary and normalized before they enter the Rust backend.
+
     The sparse operators are exported from the Rust backend lazily:
     - `body_force_to_rhs`, `pressure_to_rhs`, `traction_to_rhs`, and `temperature_to_rhs`
       map load amplitudes to the reduced structural right-hand side,
@@ -326,7 +329,7 @@ class Structural2DFEMModel:
 
     @property
     def dtype(self) -> np.dtype[Any]:
-        """Floating dtype used by all exported operators, arrays, and convenience-method outputs."""
+        """Floating dtype used by exported operators, arrays, and convenience-method outputs."""
 
         return self._dtype
 
@@ -1490,7 +1493,7 @@ def assemble_structural_2d(
     Args:
         nodes: Corner-node coordinates with shape `(nnode, 2)`. Coordinates are `(r, z)` for
             `formulation="axisymmetric"` and `(x, y)` for `formulation="plane_strain"`.
-            Units are `[length]`.
+            Units are `[length]`. Floating inputs are normalized to `float64`.
         elements: Connectivity with shape `(nelem, 4)` for `element_type="quad4"`. For
             `element_type="quad9"`, pass either corner-only `(nelem, 4)` connectivity to infer a
             straight-sided quad9 mesh, or explicit `(nelem, 9)` connectivity in local order
@@ -1520,7 +1523,7 @@ def assemble_structural_2d(
 
     Returns:
         Structural2DFEMModel: Reusable model with backend solve state and lazy Python sparse
-        operator exports.
+        operator exports. The model stores floating arrays as `float64`.
 
     Raises:
         ValueError: If `quadrature` is unsupported.
@@ -1766,7 +1769,7 @@ def cfsem_radial_material(
     Args:
         youngs_modulus: Young's modulus with units `[pressure]`.
         poisson_ratio: Poisson ratio with units `[dimensionless]`.
-        dtype: Output floating dtype.
+        dtype: Ignored; structural FEM material helpers always return `float64`.
 
     Returns:
         NDArray: Elastic stress-strain matrix with shape `(4, 4)` in component order

--- a/docs/python/solenoid_stress.md
+++ b/docs/python/solenoid_stress.md
@@ -28,7 +28,7 @@ The FEM path supports:
 - reusable reduced-space operators for body force, pressure, traction, and nodal-temperature thermal strain,
 - reduced quadrature-point recovery operators for strain and stress,
 - direct sparse-LU reduced-system solves,
-- `float64` numeric storage; `float32` inputs are accepted and normalized to `float64`,
+- `float64` numeric storage; floating input arrays must already have dtype `float64`,
 - model-owned Dirichlet constraints applied during assembly.
 
 The intended workflow is:

--- a/docs/python/solenoid_stress.md
+++ b/docs/python/solenoid_stress.md
@@ -3,7 +3,7 @@
 This package includes three complementary layers:
 
 - a 1D finite-difference radial stress solver for winding-pack models with zero `rz` shear,
-- a 2D quadrilateral FEM solver with axisymmetric and plane-strain formulations, reusable sparse load operators, cached Rust-side LU solves, and optional BiCGSTAB iterative solves,
+- a 2D quadrilateral FEM solver with axisymmetric and plane-strain formulations, reusable sparse load operators, and cached Rust-side sparse-LU solves,
 - analytic reference formulas used for validation and convergence studies.
 
 ## 1D Finite-Difference Solver
@@ -27,25 +27,20 @@ The FEM path supports:
 - optional threaded stiffness assembly with `par=True`,
 - reusable reduced-space operators for body force, pressure, traction, and nodal-temperature thermal strain,
 - reduced quadrature-point recovery operators for strain and stress,
-- direct sparse-LU or BiCGSTAB reduced-system solves,
+- direct sparse-LU reduced-system solves,
+- `float64` numeric storage; `float32` inputs are accepted and normalized to `float64`,
 - model-owned Dirichlet constraints applied during assembly.
 
 The intended workflow is:
 
 1. call `assemble_structural_2d(...)` once with mesh, materials, load topology, and prescribed Dirichlet values,
 2. build each reduced load vector with `model.build_rhs(...)` or the exposed sparse operators,
-3. solve with `model.solve(rhs)`, using the default cached LU factorization or
-   `model.solve(rhs, method="bicgstab", ...)` for an iterative solve,
+3. solve with `model.solve(rhs)`, using the cached sparse-LU factorization,
 4. recover quadrature strain and stress with `model.evaluate_quadrature(...)`.
 
 By default, `model.solve(rhs)` uses the direct sparse-LU path and returns the full displacement
-array. Passing `method="bicgstab"` selects the iterative solver; this path supports diagonal
-preconditioning, Ruiz-style row/column equilibration, optional reuse of the previous converged
-iterative solution as the initial guess, and optional diagnostics via `return_diagnostics=True`.
-Equilibration scales and the scaled stiffness matrix are cached on the model for repeated
-right-hand sides. The BiCGSTAB tolerance is passed unchanged to the system being solved. With
-equilibration enabled, this means the tolerance applies to the equilibrated residual rather than
-being rescaled to original reduced-RHS units.
+array. The sparse-LU factorization is built lazily on the first solve and then cached on the model
+for repeated right-hand sides.
 
 ### Formulation Notes
 

--- a/examples/solenoid_stress_axisymmetric_fem_convergence.py
+++ b/examples/solenoid_stress_axisymmetric_fem_convergence.py
@@ -257,7 +257,7 @@ def solve_fem_midplane_profile(
     analysis_nodes = elevated.analysis_nodes if elevated is not None else nodes
     analysis_elements = elevated.analysis_elements if elevated is not None else elements
     nelem = elements.shape[0]
-    material = cfsem_radial_material(ELASTICITY_MODULUS, POISSON_RATIO, dtype=np.float64)
+    material = cfsem_radial_material(ELASTICITY_MODULUS, POISSON_RATIO)
     prescribed = prescribed_z_dofs(analysis_nodes.shape[0])
     model = assemble_structural_2d(
         nodes=nodes,

--- a/examples/solenoid_stress_surface_traction.py
+++ b/examples/solenoid_stress_surface_traction.py
@@ -189,11 +189,10 @@ def main() -> None:
     _inner_faces, outer_faces = pressure_faces_for_strip(nr=nr, nz=nz)
     _bottom_faces, top_faces = horizontal_faces_for_strip(nr=nr, nz=nz)
 
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=np.float64)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
     thermal_material = isotropic_axisymmetric_thermal_material(
         1.1e-5,
         reference_temperature=293.15,
-        dtype=np.float64,
     )
 
     analysis_nodes = nodes if element_type == "quad4" else infer_quad9_mesh(nodes, elements).analysis_nodes

--- a/src/physics/solenoid_stress/mod.rs
+++ b/src/physics/solenoid_stress/mod.rs
@@ -506,11 +506,8 @@ pub use convenience::{
     rotate_thermal_expansion_in_plane, rotate_thermal_material_in_plane,
 };
 pub use model::{
-    BicgstabEquilibration, BicgstabInitialGuess, BicgstabPreconditioner, BicgstabSolveOptions,
-    EquilibrationSolveOptions, ReducedRecoveryOperators, Structural2dElementType,
-    Structural2dElements, Structural2dIterativeScalar, Structural2dModel,
-    Structural2dSolveDiagnostics, Structural2dSolveMethod, Structural2dSolveMethodName,
-    Structural2dSolveOutput, assemble_structural_2d,
+    ReducedRecoveryOperators, Structural2dElementType, Structural2dElements, Structural2dModel,
+    assemble_structural_2d,
 };
 pub(crate) use types::validate_element_material_inputs;
 pub use types::{

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -3,18 +3,12 @@
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
-use deimos_numerics::sparse::{
-    BiCGSTAB, BiCGSTABSolveError, CompensatedField, DiagonalPrecond, Equilibration,
-    EquilibrationParams, Precond, SparseMatVec,
-};
+use faer::Col;
 use faer::linalg::solvers::Solve;
-use faer::sparse::linalg::matmul::sparse_dense_matmul;
 use faer::sparse::linalg::solvers::Lu;
 use faer::sparse::{
-    SparseColMat, SparseColMatRef, SparseRowMat, SymbolicSparseColMat, SymbolicSparseRowMat,
-    Triplet,
+    SparseColMat, SparseRowMat, SymbolicSparseColMat, SymbolicSparseRowMat, Triplet,
 };
-use faer::{Accum, Col, Par};
 use rayon::prelude::*;
 
 use crate::mesh::elements::quad2d::{quad4, quad9};
@@ -41,20 +35,7 @@ use crate::physics::solenoid_stress::types::{
     dof_per_element,
 };
 
-mod private {
-    use super::{CompensatedField, Real};
-
-    pub trait IterativeScalarSealed: Real + CompensatedField {}
-
-    impl<T> IterativeScalarSealed for T where T: Real + CompensatedField {}
-}
-
-/// Scalar types supported by the iterative 2D structural FEM solve path.
-///
-/// This trait is sealed and implemented by the floating-point types supported by the backend.
-pub trait Structural2dIterativeScalar: Real + private::IterativeScalarSealed {}
-
-impl<T> Structural2dIterativeScalar for T where T: Real + private::IterativeScalarSealed {}
+type F = f64;
 
 /// Public element-family selector for the 2D structural solver.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,152 +44,6 @@ pub enum Structural2dElementType {
     Quad4,
     /// Quadratic nine-node quadrilateral in the analysis plane.
     Quad9,
-}
-
-/// Linear-solver method used for one reduced 2D structural FEM solve.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Structural2dSolveMethod<F: Real> {
-    /// Sparse LU direct solve with lazy factorization caching.
-    Direct,
-    /// BiCGSTAB Krylov solve with optional diagonal preconditioning and equilibration.
-    Bicgstab(BicgstabSolveOptions<F>),
-}
-
-/// Compact solver name used by diagnostics and Python bindings.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Structural2dSolveMethodName {
-    /// Sparse LU direct solve.
-    Direct,
-    /// BiCGSTAB Krylov solve.
-    Bicgstab,
-}
-
-impl Structural2dSolveMethodName {
-    /// Return the compact code used by the Python binding.
-    pub const fn code(self) -> u8 {
-        match self {
-            Self::Direct => 0,
-            Self::Bicgstab => 1,
-        }
-    }
-}
-
-/// Options for the BiCGSTAB reduced-system solve.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct BicgstabSolveOptions<F: Real> {
-    /// Absolute BiCGSTAB residual tolerance in the units of the solved system.
-    ///
-    /// With equilibration disabled, this is in reduced-RHS units. With equilibration enabled, the
-    /// same value is passed to the equilibrated linear system rather than being rescaled back to
-    /// original RHS units.
-    pub tolerance: Option<F>,
-    /// Maximum number of BiCGSTAB iterations. If `None`, a size-based default is used.
-    pub max_iterations: Option<usize>,
-    /// Optional preconditioner used by BiCGSTAB.
-    pub preconditioner: BicgstabPreconditioner,
-    /// Optional matrix equilibration applied before BiCGSTAB.
-    pub equilibration: BicgstabEquilibration<F>,
-    /// Initial-guess policy for the reduced displacement vector.
-    pub initial_guess: BicgstabInitialGuess,
-}
-
-impl<F: Real> Default for BicgstabSolveOptions<F> {
-    fn default() -> Self {
-        Self {
-            tolerance: None,
-            max_iterations: None,
-            preconditioner: BicgstabPreconditioner::Diagonal,
-            equilibration: BicgstabEquilibration::Ruiz(EquilibrationSolveOptions::default()),
-            initial_guess: BicgstabInitialGuess::Zero,
-        }
-    }
-}
-
-/// Preconditioner selection for BiCGSTAB.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BicgstabPreconditioner {
-    /// No preconditioner.
-    None,
-    /// Diagonal/Jacobi-style preconditioner.
-    Diagonal,
-}
-
-/// Equilibration selection for BiCGSTAB.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum BicgstabEquilibration<F: Real> {
-    /// Solve the original reduced system directly.
-    None,
-    /// Apply Ruiz-style row/column equilibration before solving.
-    Ruiz(EquilibrationSolveOptions<F>),
-}
-
-/// Parameters controlling Ruiz-style sparse matrix equilibration.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct EquilibrationSolveOptions<F: Real> {
-    /// Maximum number of equilibration iterations.
-    pub max_iterations: usize,
-    /// Dimensionless row/column balance tolerance.
-    pub tolerance: F,
-    /// Lower clamp applied to measured row/column norms.
-    pub norm_floor: F,
-    /// Upper clamp applied to measured row/column norms.
-    pub norm_ceil: F,
-}
-
-impl<F: Real> Default for EquilibrationSolveOptions<F> {
-    fn default() -> Self {
-        let params = EquilibrationParams::<F>::default();
-        Self {
-            max_iterations: params.max_iters,
-            tolerance: params.tol,
-            norm_floor: params.norm_floor,
-            norm_ceil: params.norm_ceil,
-        }
-    }
-}
-
-impl<F: Real> From<EquilibrationSolveOptions<F>> for EquilibrationParams<F> {
-    fn from(options: EquilibrationSolveOptions<F>) -> Self {
-        Self {
-            max_iters: options.max_iterations,
-            tol: options.tolerance,
-            norm_floor: options.norm_floor,
-            norm_ceil: options.norm_ceil,
-        }
-    }
-}
-
-/// Initial-guess policy for iterative solves.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BicgstabInitialGuess {
-    /// Start from a zero reduced displacement vector.
-    Zero,
-    /// Reuse the previous converged BiCGSTAB reduced solution when available.
-    Previous,
-}
-
-/// Full displacement solution plus solve diagnostics.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Structural2dSolveOutput<F: Real> {
-    /// Full displacement vector with shape `(ndof_full,)`.
-    pub displacement: Vec<F>,
-    /// Solver diagnostics for the reduced solve.
-    pub diagnostics: Structural2dSolveDiagnostics<F>,
-}
-
-/// Diagnostics from one reduced structural solve.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Structural2dSolveDiagnostics<F: Real> {
-    /// Solver method used for this solve.
-    pub method: Structural2dSolveMethodName,
-    /// Whether the selected solver converged.
-    pub converged: bool,
-    /// Number of BiCGSTAB iterations, or zero for direct solves.
-    pub iterations: usize,
-    /// Latest residual norm in RHS units, or zero for direct solves.
-    pub residual_norm: F,
-    /// Whether row/column equilibration was applied.
-    pub equilibrated: bool,
 }
 
 impl Structural2dElementType {
@@ -252,7 +87,7 @@ pub enum Structural2dElements<'a> {
 /// vector acts on or stores flattened quadrature-point blocks with row ordering
 /// `[rr, zz, tt, rz]`, so those arrays have flattened shape `(4 * nelem * nq_per_element,)`.
 #[derive(Debug, Clone)]
-pub struct ReducedRecoveryOperators<F: Real> {
+pub struct ReducedRecoveryOperators {
     /// Quadrature-point coordinates `(r, z)` in element-major order.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 2)`.
@@ -310,7 +145,7 @@ pub struct ReducedRecoveryOperators<F: Real> {
 /// `(nelem * nodes_per_element,)`, `pressure_faces` has shape `(n_pressure_faces, 2)`, and
 /// `traction_faces` has shape `(n_traction_faces, 2)`.
 #[derive(Debug)]
-pub struct Structural2dModel<F: Real> {
+pub struct Structural2dModel {
     /// Reduced structural stiffness matrix in CSC form.
     ///
     /// This matrix maps reduced displacements `[length]` to reduced generalized nodal forces
@@ -344,7 +179,7 @@ pub struct Structural2dModel<F: Real> {
     /// Units: `[energy / distance]`.
     pub constant_rhs: Vec<F>,
     /// Quadrature-point recovery operators and constants associated with this reduced model.
-    pub recovery: ReducedRecoveryOperators<F>,
+    pub recovery: ReducedRecoveryOperators,
     /// Metadata listing the loaded pressure faces as `[element_index, local_face]`.
     ///
     /// Shape: `(n_pressure_faces, 2)`.
@@ -390,15 +225,9 @@ pub struct Structural2dModel<F: Real> {
     /// Units: `[length]`.
     pub fixed_values: Vec<F>,
     lu: Option<Lu<usize, F>>,
-    diagonal_preconditioner: Option<DiagonalPrecond<F>>,
-    equilibration: Option<Equilibration<F>>,
-    equilibration_options: Option<EquilibrationSolveOptions<F>>,
-    equilibrated_stiffness: Option<SparseColMat<usize, F>>,
-    equilibrated_diagonal_preconditioner: Option<DiagonalPrecond<F>>,
-    previous_bicgstab_solution: Option<Vec<F>>,
 }
 
-impl<F: Real> Structural2dModel<F> {
+impl Structural2dModel {
     /// Build one reduced structural right-hand side.
     ///
     /// Args:
@@ -521,7 +350,7 @@ impl<F: Real> Structural2dModel<F> {
             reduced_solution.len(),
             self.ndof_reduced
         );
-        let mut full = vec![F::zero(); self.ndof_full];
+        let mut full = vec![0.0; self.ndof_full];
         for (&dof, &value) in self.fixed_dofs.iter().zip(&self.fixed_values) {
             full[dof] = value;
         }
@@ -570,8 +399,8 @@ impl<F: Real> Structural2dModel<F> {
     ///     - `volumes` shape `(nelem,)` and units `[volume]`
     pub fn element_measures(&self) -> Result<Structural2dElementMeasures<F>, String> {
         let quadrature = self.element_quadrature()?;
-        let mut areas = vec![F::zero(); self.nelem];
-        let mut volumes = vec![F::zero(); self.nelem];
+        let mut areas = vec![0.0; self.nelem];
+        let mut volumes = vec![0.0; self.nelem];
         for element in 0..self.nelem {
             let start = element * quadrature.nq_per_element;
             let end = start + quadrature.nq_per_element;
@@ -669,401 +498,9 @@ impl<F: Real> Structural2dModel<F> {
     }
 }
 
-impl<F: Structural2dIterativeScalar> Structural2dModel<F> {
-    /// Solve the reduced structural system with an explicit solver method.
-    ///
-    /// Args:
-    ///     rhs: Reduced right-hand side with shape `(ndof_reduced,)` and units
-    ///         `[generalized force] = [energy / distance]`.
-    ///     method: Solver method and method-specific options.
-    ///
-    /// Returns:
-    ///     Full displacement vector and solve diagnostics.
-    pub fn solve_with_method(
-        &mut self,
-        rhs: &[F],
-        method: Structural2dSolveMethod<F>,
-    ) -> Result<Structural2dSolveOutput<F>, String> {
-        let (reduced_solution, diagnostics) = match method {
-            Structural2dSolveMethod::Direct => {
-                (self.solve_direct_reduced(rhs)?, direct_diagnostics())
-            }
-            Structural2dSolveMethod::Bicgstab(options) => {
-                self.solve_bicgstab_reduced(rhs, options)?
-            }
-        };
-        Ok(Structural2dSolveOutput {
-            displacement: self.recover_full(&reduced_solution),
-            diagnostics,
-        })
-    }
-
-    /// Solve the reduced structural system with BiCGSTAB.
-    fn solve_bicgstab_reduced(
-        &mut self,
-        rhs: &[F],
-        options: BicgstabSolveOptions<F>,
-    ) -> Result<(Vec<F>, Structural2dSolveDiagnostics<F>), String> {
-        validate_bicgstab_options(options)?;
-        if rhs.len() != self.ndof_reduced {
-            return Err(format!(
-                "rhs has length {}, but reduced system has {} rows",
-                rhs.len(),
-                self.ndof_reduced
-            ));
-        }
-        if self.ndof_reduced == 0 {
-            return Ok((
-                Vec::new(),
-                Structural2dSolveDiagnostics {
-                    method: Structural2dSolveMethodName::Bicgstab,
-                    converged: true,
-                    iterations: 0,
-                    residual_norm: F::zero(),
-                    equilibrated: !matches!(options.equilibration, BicgstabEquilibration::None),
-                },
-            ));
-        }
-
-        let tolerance = resolve_bicgstab_tolerance(rhs, options.tolerance);
-        let max_iterations = options
-            .max_iterations
-            .unwrap_or_else(|| self.ndof_reduced.saturating_mul(2).max(100));
-        let mut rhs_work = rhs.to_vec();
-        let mut initial_guess = self.bicgstab_initial_guess(options.initial_guess);
-
-        match options.equilibration {
-            BicgstabEquilibration::None => {
-                if options.preconditioner == BicgstabPreconditioner::Diagonal {
-                    self.ensure_diagonal_preconditioner()?;
-                }
-                let (reduced_solution, diagnostics) = match options.preconditioner {
-                    BicgstabPreconditioner::None => solve_bicgstab_no_precond(
-                        self.stiffness.as_ref(),
-                        &initial_guess,
-                        &rhs_work,
-                        tolerance,
-                        max_iterations,
-                        false,
-                    )?,
-                    BicgstabPreconditioner::Diagonal => {
-                        let preconditioner = self
-                            .diagonal_preconditioner
-                            .as_ref()
-                            .ok_or_else(|| {
-                                "diagonal preconditioner was not initialized".to_string()
-                            })?
-                            .clone();
-                        solve_bicgstab_with_precond(
-                            self.stiffness.as_ref(),
-                            preconditioner,
-                            &initial_guess,
-                            &rhs_work,
-                            tolerance,
-                            max_iterations,
-                            false,
-                        )?
-                    }
-                };
-                self.previous_bicgstab_solution = Some(reduced_solution.clone());
-                Ok((reduced_solution, diagnostics))
-            }
-            BicgstabEquilibration::Ruiz(equilibration_options) => {
-                self.ensure_equilibration(equilibration_options)?;
-                if options.preconditioner == BicgstabPreconditioner::Diagonal {
-                    self.ensure_equilibrated_diagonal_preconditioner()?;
-                }
-                let equilibration = self
-                    .equilibration
-                    .as_ref()
-                    .ok_or_else(|| "equilibration was not initialized".to_string())?;
-                let equilibrated_stiffness = self
-                    .equilibrated_stiffness
-                    .as_ref()
-                    .ok_or_else(|| "equilibrated stiffness was not initialized".to_string())?;
-                equilibration.scale_rhs_in_place(&mut rhs_work);
-                equilibration.scale_initial_guess_in_place(&mut initial_guess);
-                let (mut reduced_solution, mut diagnostics) = match options.preconditioner {
-                    BicgstabPreconditioner::None => solve_bicgstab_no_precond(
-                        equilibrated_stiffness.as_ref(),
-                        &initial_guess,
-                        &rhs_work,
-                        tolerance,
-                        max_iterations,
-                        true,
-                    )?,
-                    BicgstabPreconditioner::Diagonal => {
-                        let preconditioner = self
-                            .equilibrated_diagonal_preconditioner
-                            .as_ref()
-                            .ok_or_else(|| {
-                                "equilibrated diagonal preconditioner was not initialized"
-                                    .to_string()
-                            })?
-                            .clone();
-                        solve_bicgstab_with_precond(
-                            equilibrated_stiffness.as_ref(),
-                            preconditioner,
-                            &initial_guess,
-                            &rhs_work,
-                            tolerance,
-                            max_iterations,
-                            true,
-                        )?
-                    }
-                };
-                equilibration.unscale_solution_in_place(&mut reduced_solution);
-                diagnostics.residual_norm =
-                    csc_residual_norm(self.stiffness.as_ref(), &reduced_solution, rhs)?;
-                self.previous_bicgstab_solution = Some(reduced_solution.clone());
-                Ok((reduced_solution, diagnostics))
-            }
-        }
-    }
-
-    /// Return the reduced-space initial guess requested by the iterative solve options.
-    fn bicgstab_initial_guess(&self, policy: BicgstabInitialGuess) -> Vec<F> {
-        match policy {
-            BicgstabInitialGuess::Zero => vec![F::zero(); self.ndof_reduced],
-            BicgstabInitialGuess::Previous => self
-                .previous_bicgstab_solution
-                .as_ref()
-                .filter(|solution| solution.len() == self.ndof_reduced)
-                .cloned()
-                .unwrap_or_else(|| vec![F::zero(); self.ndof_reduced]),
-        }
-    }
-
-    /// Build and cache the diagonal preconditioner for the original reduced stiffness.
-    fn ensure_diagonal_preconditioner(&mut self) -> Result<(), String> {
-        if self.diagonal_preconditioner.is_none() {
-            self.diagonal_preconditioner = Some(
-                DiagonalPrecond::try_from(self.stiffness.as_ref())
-                    .map_err(|err| format!("failed to build diagonal preconditioner: {err:?}"))?,
-            );
-        }
-        Ok(())
-    }
-
-    /// Build and cache equilibration scales and the scaled reduced stiffness.
-    fn ensure_equilibration(
-        &mut self,
-        options: EquilibrationSolveOptions<F>,
-    ) -> Result<(), String> {
-        if self.equilibration_options != Some(options) {
-            self.equilibration = None;
-            self.equilibrated_stiffness = None;
-            self.equilibrated_diagonal_preconditioner = None;
-            self.equilibration_options = Some(options);
-        }
-        if self.equilibration.is_none() || self.equilibrated_stiffness.is_none() {
-            let equilibration = Equilibration::<F>::compute_from_csc(
-                self.stiffness.as_ref(),
-                EquilibrationParams::from(options),
-            )
-            .map_err(|err| format!("failed to equilibrate reduced stiffness: {err:?}"))?;
-            let mut equilibrated_stiffness = self.stiffness.clone();
-            equilibration.scale_csc_matrix_in_place(&mut equilibrated_stiffness);
-            self.equilibration = Some(equilibration);
-            self.equilibrated_stiffness = Some(equilibrated_stiffness);
-            self.equilibrated_diagonal_preconditioner = None;
-        }
-        Ok(())
-    }
-
-    /// Build and cache the diagonal preconditioner for the equilibrated reduced stiffness.
-    fn ensure_equilibrated_diagonal_preconditioner(&mut self) -> Result<(), String> {
-        if self.equilibrated_diagonal_preconditioner.is_none() {
-            let stiffness = self
-                .equilibrated_stiffness
-                .as_ref()
-                .ok_or_else(|| "equilibrated stiffness was not initialized".to_string())?;
-            self.equilibrated_diagonal_preconditioner = Some(
-                DiagonalPrecond::try_from(stiffness.as_ref()).map_err(|err| {
-                    format!("failed to build equilibrated diagonal preconditioner: {err:?}")
-                })?,
-            );
-        }
-        Ok(())
-    }
-}
-
-/// Diagnostics for the sparse LU path.
-fn direct_diagnostics<F: Real>() -> Structural2dSolveDiagnostics<F> {
-    Structural2dSolveDiagnostics {
-        method: Structural2dSolveMethodName::Direct,
-        converged: true,
-        iterations: 0,
-        residual_norm: F::zero(),
-        equilibrated: false,
-    }
-}
-
-/// Validate BiCGSTAB and equilibration options before allocating solver scratch space.
-fn validate_bicgstab_options<F: Real>(options: BicgstabSolveOptions<F>) -> Result<(), String> {
-    if let Some(tolerance) = options.tolerance
-        && (!tolerance.is_finite() || tolerance <= F::zero())
-    {
-        return Err(format!(
-            "BiCGSTAB tolerance must be finite and positive; got {tolerance:?}"
-        ));
-    }
-    if let Some(max_iterations) = options.max_iterations
-        && max_iterations == 0
-    {
-        return Err("BiCGSTAB max_iterations must be at least 1".to_string());
-    }
-    if let BicgstabEquilibration::Ruiz(equilibration) = options.equilibration {
-        if equilibration.max_iterations == 0 {
-            return Err("equilibration max_iterations must be at least 1".to_string());
-        }
-        if !equilibration.tolerance.is_finite() || equilibration.tolerance < F::zero() {
-            return Err(format!(
-                "equilibration tolerance must be finite and nonnegative; got {:?}",
-                equilibration.tolerance
-            ));
-        }
-        if !equilibration.norm_floor.is_finite()
-            || equilibration.norm_floor <= F::zero()
-            || !equilibration.norm_ceil.is_finite()
-            || equilibration.norm_ceil <= equilibration.norm_floor
-        {
-            return Err(format!(
-                "equilibration norm clamps must satisfy 0 < floor < ceil; got floor={:?}, ceil={:?}",
-                equilibration.norm_floor, equilibration.norm_ceil
-            ));
-        }
-    }
-    Ok(())
-}
-
-/// Resolve a RHS-scaled absolute residual tolerance when the caller does not provide one.
-fn resolve_bicgstab_tolerance<F: Real>(rhs: &[F], tolerance: Option<F>) -> F {
-    if let Some(tolerance) = tolerance {
-        return tolerance;
-    }
-    let mut norm_sq = F::zero();
-    for &value in rhs {
-        norm_sq = value.mul_add(value, norm_sq);
-    }
-    let rhs_norm = norm_sq.sqrt();
-    let scale = if rhs_norm > F::zero() {
-        rhs_norm
-    } else {
-        F::one()
-    };
-    scale * F::epsilon().sqrt()
-}
-
-/// Compute `||A x - b||_2` for one CSC matrix-vector product.
-fn csc_residual_norm<F: Real>(
-    matrix: SparseColMatRef<'_, usize, F>,
-    solution: &[F],
-    rhs: &[F],
-) -> Result<F, String> {
-    if solution.len() != matrix.ncols() {
-        return Err(format!(
-            "solution has length {}, but CSC matrix has {} columns",
-            solution.len(),
-            matrix.ncols()
-        ));
-    }
-    if rhs.len() != matrix.nrows() {
-        return Err(format!(
-            "rhs has length {}, but CSC matrix has {} rows",
-            rhs.len(),
-            matrix.nrows()
-        ));
-    }
-    let solution = Col::from_fn(matrix.ncols(), |index| solution[index]);
-    let mut residual = Col::<F>::zeros(matrix.nrows());
-    sparse_dense_matmul(
-        residual.as_mat_mut(),
-        Accum::Replace,
-        matrix,
-        solution.as_mat(),
-        F::one(),
-        Par::Seq,
-    );
-    let mut norm_sq = F::zero();
-    for row in 0..rhs.len() {
-        let value = residual[row] - rhs[row];
-        norm_sq = value.mul_add(value, norm_sq);
-    }
-    Ok(norm_sq.sqrt())
-}
-
-/// Solve a reduced system with unpreconditioned BiCGSTAB.
-fn solve_bicgstab_no_precond<F: Structural2dIterativeScalar>(
-    matrix: SparseColMatRef<'_, usize, F>,
-    initial_guess: &[F],
-    rhs: &[F],
-    tolerance: F,
-    max_iterations: usize,
-    equilibrated: bool,
-) -> Result<(Vec<F>, Structural2dSolveDiagnostics<F>), String> {
-    match BiCGSTAB::solve(matrix, initial_guess, rhs, tolerance, max_iterations) {
-        Ok(solver) => Ok(bicgstab_success(solver, equilibrated)),
-        Err(BiCGSTABSolveError::InvalidInput(err)) => Err(format!("invalid BiCGSTAB input: {err}")),
-        Err(BiCGSTABSolveError::NoConvergence(solver)) => Err(format!(
-            "BiCGSTAB did not converge within {} iterations; residual norm is {:?}",
-            solver.iteration_count(),
-            solver.err()
-        )),
-    }
-}
-
-/// Solve a reduced system with diagonally preconditioned BiCGSTAB.
-fn solve_bicgstab_with_precond<F: Structural2dIterativeScalar>(
-    matrix: SparseColMatRef<'_, usize, F>,
-    preconditioner: DiagonalPrecond<F>,
-    initial_guess: &[F],
-    rhs: &[F],
-    tolerance: F,
-    max_iterations: usize,
-    equilibrated: bool,
-) -> Result<(Vec<F>, Structural2dSolveDiagnostics<F>), String> {
-    match BiCGSTAB::solve_with_precond(
-        matrix,
-        preconditioner,
-        initial_guess,
-        rhs,
-        tolerance,
-        max_iterations,
-    ) {
-        Ok(solver) => Ok(bicgstab_success(solver, equilibrated)),
-        Err(BiCGSTABSolveError::InvalidInput(err)) => Err(format!("invalid BiCGSTAB input: {err}")),
-        Err(BiCGSTABSolveError::NoConvergence(solver)) => Err(format!(
-            "BiCGSTAB did not converge within {} iterations; residual norm is {:?}",
-            solver.iteration_count(),
-            solver.err()
-        )),
-    }
-}
-
-/// Convert a converged BiCGSTAB solver state into a reduced solution and diagnostics.
-fn bicgstab_success<F: Structural2dIterativeScalar, A, P>(
-    solver: BiCGSTAB<F, A, P>,
-    equilibrated: bool,
-) -> (Vec<F>, Structural2dSolveDiagnostics<F>)
-where
-    A: SparseMatVec<F>,
-    P: Precond<F>,
-{
-    let diagnostics = Structural2dSolveDiagnostics {
-        method: Structural2dSolveMethodName::Bicgstab,
-        converged: true,
-        iterations: solver.iteration_count(),
-        residual_norm: solver.err(),
-        equilibrated,
-    };
-    let solution = solver.x().iter().copied().collect::<Vec<_>>();
-    (solution, diagnostics)
-}
-
 #[allow(clippy::too_many_arguments)]
 /// Assemble the reduced 2D structural model and all associated operators.
-pub fn assemble_structural_2d<F: Real>(
+pub fn assemble_structural_2d(
     nodes_rz: &[[F; 2]],
     elements: Structural2dElements<'_>,
     material_ids: &[usize],
@@ -1076,10 +513,9 @@ pub fn assemble_structural_2d<F: Real>(
     formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
     par: bool,
-) -> Result<Structural2dModel<F>, String> {
+) -> Result<Structural2dModel, String> {
     match elements {
         Structural2dElements::Quad4(elements) => build_model_for_family::<
-            F,
             Quad4Family,
             { quad4::NODES_PER_ELEMENT },
             { dof_per_element(quad4::NODES_PER_ELEMENT) },
@@ -1098,7 +534,6 @@ pub fn assemble_structural_2d<F: Real>(
             par,
         ),
         Structural2dElements::Quad9(elements) => build_model_for_family::<
-            F,
             Quad9Family,
             { quad9::NODES_PER_ELEMENT },
             { dof_per_element(quad9::NODES_PER_ELEMENT) },
@@ -1135,12 +570,7 @@ type ReducedLayout<F> = (Vec<usize>, Vec<usize>, Vec<F>, Vec<usize>, Vec<Option<
 /// This is the family-generic core of the public assembly path.  It builds the unreduced
 /// operators, applies Dirichlet reduction, compresses the final sparse matrices, and packages the
 /// result into the public `Structural2dModel`.
-fn build_model_for_family<
-    F: Real,
-    Family,
-    const NODES_PER_ELEMENT: usize,
-    const DOF_PER_ELEMENT: usize,
->(
+fn build_model_for_family<Family, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
     nodes_rz: &[[F; 2]],
     elements: &[[usize; NODES_PER_ELEMENT]],
     material_ids: &[usize],
@@ -1153,7 +583,7 @@ fn build_model_for_family<
     formulation: Structural2dFormulation<F>,
     quadrature: QuadratureRule,
     par: bool,
-) -> Result<Structural2dModel<F>, String>
+) -> Result<Structural2dModel, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -1167,7 +597,7 @@ where
         reduce_layout(ndof_full, prescribed)?;
     let ndof_reduced = free_dofs.len();
 
-    let mut constant_rhs = vec![F::zero(); ndof_reduced];
+    let mut constant_rhs = vec![0.0; ndof_reduced];
     // Assemble stiffness in the full displacement space first, then apply Dirichlet reduction.
     // The parallel path keeps worker chunks separate so each chunk can be reduced and sorted
     // independently before a k-way merge builds the canonical CSC structure.
@@ -1258,7 +688,7 @@ where
     } else {
         (
             csr_from_parts(ndof_reduced, 0, Vec::new(), Vec::new(), Vec::new())?,
-            vec![F::zero(); ndof_reduced],
+            vec![0.0; ndof_reduced],
             0,
         )
     };
@@ -1399,12 +829,6 @@ where
         fixed_dofs,
         fixed_values,
         lu: None,
-        diagonal_preconditioner: None,
-        equilibration: None,
-        equilibration_options: None,
-        equilibrated_stiffness: None,
-        equilibrated_diagonal_preconditioner: None,
-        previous_bicgstab_solution: None,
     })
 }
 
@@ -2007,60 +1431,4 @@ fn pack_rank4_field<F: Real>(flat: Vec<F>) -> Result<Vec<[F; 4]>, String> {
         packed.push([chunk[0], chunk[1], chunk[2], chunk[3]]);
     }
     Ok(packed)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::physics::solenoid_stress::convenience::isotropic_axisymmetric_material;
-
-    #[test]
-    fn bicgstab_solve_matches_direct_solve() {
-        let material = [isotropic_axisymmetric_material(200.0e9_f64, 0.27)];
-        let mut model = assemble_structural_2d(
-            &crate::physics::solenoid_stress::test_utils::SINGLE_QUAD4_NODES,
-            Structural2dElements::Quad4(
-                &crate::physics::solenoid_stress::test_utils::SINGLE_QUAD4_ELEMENTS,
-            ),
-            &[0],
-            &material,
-            &[],
-            &[],
-            None,
-            None,
-            &[(0, 0.0), (1, 0.0), (3, 0.0), (5, 0.0), (7, 0.0)],
-            Structural2dFormulation::Axisymmetric,
-            QuadratureRule::GaussLegendre3,
-            false,
-        )
-        .unwrap();
-        let rhs = model
-            .build_rhs(Some(&[2.0e5, -1.0e5]), None, None, None)
-            .unwrap();
-        let direct = model.solve(&rhs).unwrap();
-        let iterative = model
-            .solve_with_method(
-                &rhs,
-                Structural2dSolveMethod::Bicgstab(BicgstabSolveOptions {
-                    tolerance: Some(1.0e-9),
-                    max_iterations: Some(1000),
-                    ..BicgstabSolveOptions::default()
-                }),
-            )
-            .unwrap();
-
-        assert!(iterative.diagnostics.converged);
-        assert!(iterative.diagnostics.iterations > 0);
-        let reduced_solution = model
-            .free_dofs
-            .iter()
-            .map(|&dof| iterative.displacement[dof])
-            .collect::<Vec<_>>();
-        let residual_norm =
-            csc_residual_norm(model.stiffness.as_ref(), &reduced_solution, &rhs).unwrap();
-        assert!((iterative.diagnostics.residual_norm - residual_norm).abs() < 1.0e-12);
-        for (actual, expected) in iterative.displacement.iter().zip(&direct) {
-            assert!((actual - expected).abs() < 1.0e-10);
-        }
-    }
 }

--- a/src/physics/solenoid_stress/types.rs
+++ b/src/physics/solenoid_stress/types.rs
@@ -5,8 +5,8 @@ use num_traits::{Float, FromPrimitive};
 
 /// Floating-point trait bound used throughout the solenoid-stress backend.
 ///
-/// Keeping the bound in one place makes it easier to support both `f32` and `f64` entry points
-/// without duplicating generic constraints everywhere else.
+/// Keeping the bound in one place avoids duplicating generic constraints inside the Rust backend,
+/// even though the public Python structural-FEM bindings expose only `f64` entry points.
 pub trait Real:
     Float + FromPrimitive + RealField + Copy + std::fmt::Debug + Send + Sync + 'static
 {

--- a/src/python.rs
+++ b/src/python.rs
@@ -410,7 +410,7 @@ struct SolenoidStress2dModelF64 {
 /// Low-level PyO3 wrapper for the reusable f64 structural 2D FEM model.
 ///
 /// The public Python API lives in `cfsem.solenoid_stress.fem2d`. This wrapper exposes
-/// raw arrays and sparse storage tuples so the higher-level Python module can normalize inputs,
+/// raw arrays and sparse storage tuples so the higher-level Python module can validate shapes,
 /// build SciPy sparse matrices, and present a cleaner user-facing surface.
 macro_rules! impl_solenoid_stress_model_pyclass {
     ($name:ident, $ty:ty) => {

--- a/src/python.rs
+++ b/src/python.rs
@@ -407,7 +407,7 @@ struct SolenoidStress2dModelF64 {
     inner: physics::solenoid_stress::Structural2dModel,
 }
 
-/// Low-level PyO3 wrapper for the reusable axisymmetric FEM model.
+/// Low-level PyO3 wrapper for the reusable f64 structural 2D FEM model.
 ///
 /// The public Python API lives in `cfsem.solenoid_stress.fem2d`. This wrapper exposes
 /// raw arrays and sparse storage tuples so the higher-level Python module can normalize inputs,

--- a/src/python.rs
+++ b/src/python.rs
@@ -335,82 +335,6 @@ fn parse_solenoid_fem_quadrature(
         .map_err(|msg| PyInteropError::ValueError { msg }.into())
 }
 
-fn parse_solenoid_fem_solve_method<F: physics::solenoid_stress::Real>(
-    method: u8,
-    tolerance: Option<F>,
-    max_iterations: Option<usize>,
-    preconditioner: u8,
-    equilibration: u8,
-    equilibration_max_iterations: Option<usize>,
-    equilibration_tolerance: Option<F>,
-    equilibration_norm_floor: Option<F>,
-    equilibration_norm_ceil: Option<F>,
-    initial_guess: u8,
-) -> PyResult<physics::solenoid_stress::Structural2dSolveMethod<F>> {
-    match method {
-        0 => Ok(physics::solenoid_stress::Structural2dSolveMethod::Direct),
-        1 => {
-            let preconditioner = match preconditioner {
-                0 => physics::solenoid_stress::BicgstabPreconditioner::None,
-                1 => physics::solenoid_stress::BicgstabPreconditioner::Diagonal,
-                _ => {
-                    return Err(PyInteropError::ValueError {
-                        msg: "unsupported BiCGSTAB preconditioner code".to_string(),
-                    }
-                    .into());
-                }
-            };
-            let mut equilibration_options =
-                physics::solenoid_stress::EquilibrationSolveOptions::<F>::default();
-            if let Some(max_iterations) = equilibration_max_iterations {
-                equilibration_options.max_iterations = max_iterations;
-            }
-            if let Some(tolerance) = equilibration_tolerance {
-                equilibration_options.tolerance = tolerance;
-            }
-            if let Some(norm_floor) = equilibration_norm_floor {
-                equilibration_options.norm_floor = norm_floor;
-            }
-            if let Some(norm_ceil) = equilibration_norm_ceil {
-                equilibration_options.norm_ceil = norm_ceil;
-            }
-            let equilibration = match equilibration {
-                0 => physics::solenoid_stress::BicgstabEquilibration::None,
-                1 => physics::solenoid_stress::BicgstabEquilibration::Ruiz(equilibration_options),
-                _ => {
-                    return Err(PyInteropError::ValueError {
-                        msg: "unsupported BiCGSTAB equilibration code".to_string(),
-                    }
-                    .into());
-                }
-            };
-            let initial_guess = match initial_guess {
-                0 => physics::solenoid_stress::BicgstabInitialGuess::Zero,
-                1 => physics::solenoid_stress::BicgstabInitialGuess::Previous,
-                _ => {
-                    return Err(PyInteropError::ValueError {
-                        msg: "unsupported BiCGSTAB initial guess code".to_string(),
-                    }
-                    .into());
-                }
-            };
-            Ok(physics::solenoid_stress::Structural2dSolveMethod::Bicgstab(
-                physics::solenoid_stress::BicgstabSolveOptions {
-                    tolerance,
-                    max_iterations,
-                    preconditioner,
-                    equilibration,
-                    initial_guess,
-                },
-            ))
-        }
-        _ => Err(PyInteropError::ValueError {
-            msg: "unsupported structural solve method code".to_string(),
-        }
-        .into()),
-    }
-}
-
 fn flatten_points<F: Copy>(points: Vec<[F; 2]>) -> Vec<F> {
     let mut points_flat = Vec::with_capacity(points.len() * 2);
     for point in points {
@@ -480,12 +404,7 @@ fn read_axisym_prescribed<F: NumpyElement + Copy>(
 
 #[pyclass(module = "cfsem", unsendable)]
 struct SolenoidStress2dModelF64 {
-    inner: physics::solenoid_stress::Structural2dModel<f64>,
-}
-
-#[pyclass(module = "cfsem", unsendable)]
-struct SolenoidStress2dModelF32 {
-    inner: physics::solenoid_stress::Structural2dModel<f32>,
+    inner: physics::solenoid_stress::Structural2dModel,
 }
 
 /// Low-level PyO3 wrapper for the reusable axisymmetric FEM model.
@@ -804,59 +723,17 @@ macro_rules! impl_solenoid_stress_model_pyclass {
                 Ok(PyArray1::from_vec(py, rhs).unbind())
             }
 
-            #[pyo3(signature = (
-                rhs,
-                method=0,
-                tolerance=None,
-                max_iterations=None,
-                preconditioner=1,
-                equilibration=1,
-                equilibration_max_iterations=None,
-                equilibration_tolerance=None,
-                equilibration_norm_floor=None,
-                equilibration_norm_ceil=None,
-                initial_guess=0
-            ))]
             fn solve<'py>(
                 &mut self,
                 py: Python<'py>,
                 rhs: PyReadonlyArray1<'_, $ty>,
-                method: u8,
-                tolerance: Option<$ty>,
-                max_iterations: Option<usize>,
-                preconditioner: u8,
-                equilibration: u8,
-                equilibration_max_iterations: Option<usize>,
-                equilibration_tolerance: Option<$ty>,
-                equilibration_norm_floor: Option<$ty>,
-                equilibration_norm_ceil: Option<$ty>,
-                initial_guess: u8,
-            ) -> PyResult<(Py<PyArray1<$ty>>, u8, bool, usize, $ty, bool)> {
+            ) -> PyResult<Py<PyArray1<$ty>>> {
                 let rhs = rhs.as_slice()?;
-                let method = parse_solenoid_fem_solve_method(
-                    method,
-                    tolerance,
-                    max_iterations,
-                    preconditioner,
-                    equilibration,
-                    equilibration_max_iterations,
-                    equilibration_tolerance,
-                    equilibration_norm_floor,
-                    equilibration_norm_ceil,
-                    initial_guess,
-                )?;
-                let output = self
+                let displacement = self
                     .inner
-                    .solve_with_method(rhs, method)
+                    .solve(rhs)
                     .map_err(|msg| PyInteropError::ValueError { msg })?;
-                Ok((
-                    PyArray1::from_vec(py, output.displacement).unbind(),
-                    output.diagnostics.method.code(),
-                    output.diagnostics.converged,
-                    output.diagnostics.iterations,
-                    output.diagnostics.residual_norm,
-                    output.diagnostics.equilibrated,
-                ))
+                Ok(PyArray1::from_vec(py, displacement).unbind())
             }
 
             fn element_quadrature<'py>(
@@ -931,25 +808,24 @@ macro_rules! impl_solenoid_stress_model_pyclass {
 }
 
 impl_solenoid_stress_model_pyclass!(SolenoidStress2dModelF64, f64);
-impl_solenoid_stress_model_pyclass!(SolenoidStress2dModelF32, f32);
 
-fn assemble_structural_2d_model_low_level<F: physics::solenoid_stress::Real + NumpyElement>(
-    nodes: PyReadonlyArray2<'_, F>,
+fn assemble_structural_2d_model_low_level(
+    nodes: PyReadonlyArray2<'_, f64>,
     elements: PyReadonlyArray2<'_, u64>,
     material_ids: PyReadonlyArray1<'_, u64>,
-    material_table: PyReadonlyArray3<'_, F>,
+    material_table: PyReadonlyArray3<'_, f64>,
     pressure_faces: PyReadonlyArray2<'_, u64>,
     traction_faces: PyReadonlyArray2<'_, u64>,
-    thermal_material_table: PyReadonlyArray2<'_, F>,
-    material_orientation_angles: PyReadonlyArray1<'_, F>,
+    thermal_material_table: PyReadonlyArray2<'_, f64>,
+    material_orientation_angles: PyReadonlyArray1<'_, f64>,
     prescribed_dofs: PyReadonlyArray1<'_, u64>,
-    prescribed_values: PyReadonlyArray1<'_, F>,
+    prescribed_values: PyReadonlyArray1<'_, f64>,
     element_type: u8,
     formulation: u8,
-    thickness: F,
+    thickness: f64,
     quadrature: u8,
     par: bool,
-) -> PyResult<physics::solenoid_stress::Structural2dModel<F>> {
+) -> PyResult<physics::solenoid_stress::Structural2dModel> {
     let quadrature = parse_solenoid_fem_quadrature(quadrature)?;
     let element_type = physics::solenoid_stress::Structural2dElementType::from_code(element_type)
         .map_err(|msg| PyInteropError::ValueError { msg })?;
@@ -1032,47 +908,7 @@ fn solenoid_stress_fem_assemble_model_2d_f64(
     par: bool,
 ) -> PyResult<SolenoidStress2dModelF64> {
     Ok(SolenoidStress2dModelF64 {
-        inner: assemble_structural_2d_model_low_level::<f64>(
-            nodes,
-            elements,
-            material_ids,
-            material_table,
-            pressure_faces,
-            traction_faces,
-            thermal_material_table,
-            material_orientation_angles,
-            prescribed_dofs,
-            prescribed_values,
-            element_type,
-            formulation,
-            thickness,
-            quadrature,
-            par,
-        )?,
-    })
-}
-
-/// Low-level binding for `physics::solenoid_stress::assemble_structural_2d` using `f32`.
-#[pyfunction]
-fn solenoid_stress_fem_assemble_model_2d_f32(
-    nodes: PyReadonlyArray2<'_, f32>,
-    elements: PyReadonlyArray2<'_, u64>,
-    material_ids: PyReadonlyArray1<'_, u64>,
-    material_table: PyReadonlyArray3<'_, f32>,
-    pressure_faces: PyReadonlyArray2<'_, u64>,
-    traction_faces: PyReadonlyArray2<'_, u64>,
-    thermal_material_table: PyReadonlyArray2<'_, f32>,
-    material_orientation_angles: PyReadonlyArray1<'_, f32>,
-    prescribed_dofs: PyReadonlyArray1<'_, u64>,
-    prescribed_values: PyReadonlyArray1<'_, f32>,
-    element_type: u8,
-    formulation: u8,
-    thickness: f32,
-    quadrature: u8,
-    par: bool,
-) -> PyResult<SolenoidStress2dModelF32> {
-    Ok(SolenoidStress2dModelF32 {
-        inner: assemble_structural_2d_model_low_level::<f32>(
+        inner: assemble_structural_2d_model_low_level(
             nodes,
             elements,
             material_ids,
@@ -1108,22 +944,6 @@ fn solenoid_stress_fem_isotropic_axisymmetric_material_f64<'py>(
     PyArray1::from_vec(py, flat).unbind()
 }
 
-/// Low-level binding for the isotropic constitutive helper returning a flattened `4 x 4` matrix.
-#[pyfunction]
-fn solenoid_stress_fem_isotropic_axisymmetric_material_f32<'py>(
-    py: Python<'py>,
-    youngs_modulus: f32,
-    poisson_ratio: f32,
-) -> Py<PyArray1<f32>> {
-    let material =
-        physics::solenoid_stress::isotropic_axisymmetric_material(youngs_modulus, poisson_ratio);
-    let mut flat = Vec::with_capacity(16);
-    for row in material {
-        flat.extend_from_slice(&row);
-    }
-    PyArray1::from_vec(py, flat).unbind()
-}
-
 /// Low-level binding for the isotropic plane-strain constitutive helper returning a flattened `4 x 4` matrix.
 #[pyfunction]
 fn solenoid_stress_fem_isotropic_plane_strain_material_f64<'py>(
@@ -1132,16 +952,6 @@ fn solenoid_stress_fem_isotropic_plane_strain_material_f64<'py>(
     poisson_ratio: f64,
 ) -> Py<PyArray1<f64>> {
     solenoid_stress_fem_isotropic_axisymmetric_material_f64(py, youngs_modulus, poisson_ratio)
-}
-
-/// Low-level binding for the isotropic plane-strain constitutive helper returning a flattened `4 x 4` matrix.
-#[pyfunction]
-fn solenoid_stress_fem_isotropic_plane_strain_material_f32<'py>(
-    py: Python<'py>,
-    youngs_modulus: f32,
-    poisson_ratio: f32,
-) -> Py<PyArray1<f32>> {
-    solenoid_stress_fem_isotropic_axisymmetric_material_f32(py, youngs_modulus, poisson_ratio)
 }
 
 /// Low-level binding for the isotropic thermal-material helper returning `[alpha_r, alpha_z, alpha_t, alpha_rz, T_ref]`.
@@ -1161,23 +971,6 @@ fn solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f64<'py>(
     PyArray1::from_vec(py, flat).unbind()
 }
 
-/// Low-level binding for the isotropic thermal-material helper returning `[alpha_r, alpha_z, alpha_t, alpha_rz, T_ref]`.
-#[pyfunction]
-fn solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f32<'py>(
-    py: Python<'py>,
-    alpha: f32,
-    reference_temperature: f32,
-) -> Py<PyArray1<f32>> {
-    let material = physics::solenoid_stress::isotropic_axisymmetric_thermal_material(
-        alpha,
-        reference_temperature,
-    );
-    let mut flat = Vec::with_capacity(5);
-    flat.extend_from_slice(&material.alpha);
-    flat.push(material.reference_temperature);
-    PyArray1::from_vec(py, flat).unbind()
-}
-
 /// Low-level binding for the isotropic plane-strain thermal-material helper returning `[alpha_x, alpha_y, alpha_z, alpha_xy, T_ref]`.
 #[pyfunction]
 fn solenoid_stress_fem_isotropic_plane_strain_thermal_material_f64<'py>(
@@ -1186,20 +979,6 @@ fn solenoid_stress_fem_isotropic_plane_strain_thermal_material_f64<'py>(
     reference_temperature: f64,
 ) -> Py<PyArray1<f64>> {
     solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f64(
-        py,
-        alpha,
-        reference_temperature,
-    )
-}
-
-/// Low-level binding for the isotropic plane-strain thermal-material helper returning `[alpha_x, alpha_y, alpha_z, alpha_xy, T_ref]`.
-#[pyfunction]
-fn solenoid_stress_fem_isotropic_plane_strain_thermal_material_f32<'py>(
-    py: Python<'py>,
-    alpha: f32,
-    reference_temperature: f32,
-) -> Py<PyArray1<f32>> {
-    solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f32(
         py,
         alpha,
         reference_temperature,
@@ -1227,27 +1006,6 @@ fn solenoid_stress_fem_orthotropic_axisymmetric_thermal_material_f64<'py>(
     PyArray1::from_vec(py, flat).unbind()
 }
 
-/// Low-level binding for the orthotropic thermal-material helper returning `[alpha_r, alpha_z, alpha_t, alpha_rz, T_ref]`.
-#[pyfunction]
-fn solenoid_stress_fem_orthotropic_axisymmetric_thermal_material_f32<'py>(
-    py: Python<'py>,
-    alpha_r: f32,
-    alpha_z: f32,
-    alpha_t: f32,
-    reference_temperature: f32,
-) -> Py<PyArray1<f32>> {
-    let material = physics::solenoid_stress::orthotropic_axisymmetric_thermal_material(
-        alpha_r,
-        alpha_z,
-        alpha_t,
-        reference_temperature,
-    );
-    let mut flat = Vec::with_capacity(5);
-    flat.extend_from_slice(&material.alpha);
-    flat.push(material.reference_temperature);
-    PyArray1::from_vec(py, flat).unbind()
-}
-
 /// Low-level binding for the reduced constitutive helper returning a flattened `4 x 4` matrix.
 #[pyfunction]
 fn solenoid_stress_fem_cfsem_radial_material_f64<'py>(
@@ -1255,21 +1013,6 @@ fn solenoid_stress_fem_cfsem_radial_material_f64<'py>(
     youngs_modulus: f64,
     poisson_ratio: f64,
 ) -> Py<PyArray1<f64>> {
-    let material = physics::solenoid_stress::cfsem_radial_material(youngs_modulus, poisson_ratio);
-    let mut flat = Vec::with_capacity(16);
-    for row in material {
-        flat.extend_from_slice(&row);
-    }
-    PyArray1::from_vec(py, flat).unbind()
-}
-
-/// Low-level binding for the reduced constitutive helper returning a flattened `4 x 4` matrix.
-#[pyfunction]
-fn solenoid_stress_fem_cfsem_radial_material_f32<'py>(
-    py: Python<'py>,
-    youngs_modulus: f32,
-    poisson_ratio: f32,
-) -> Py<PyArray1<f32>> {
     let material = physics::solenoid_stress::cfsem_radial_material(youngs_modulus, poisson_ratio);
     let mut flat = Vec::with_capacity(16);
     for row in material {
@@ -1286,61 +1029,6 @@ fn solenoid_stress_fem_infer_quad9_mesh_f64<'py>(
     elements: PyReadonlyArray2<'_, u64>,
 ) -> PyResult<(
     Py<PyArray1<f64>>,
-    Py<PyArray1<u64>>,
-    Py<PyArray1<u64>>,
-    Py<PyArray1<u64>>,
-    Py<PyArray1<u64>>,
-)> {
-    let nodes = read_axisym_nodes("nodes", nodes)?;
-    let elements = read_axisym_elements::<4>("elements", elements)?;
-    let elevated = physics::solenoid_stress::infer_quad9_mesh(&nodes, &elements)
-        .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let analysis_nodes = flatten_points(elevated.analysis_nodes);
-    let mut analysis_elements = Vec::with_capacity(elevated.analysis_elements.len() * 9);
-    for conn in elevated.analysis_elements {
-        analysis_elements.extend(conn.into_iter().map(|node| node as u64));
-    }
-    Ok((
-        PyArray1::from_vec(py, analysis_nodes).unbind(),
-        PyArray1::from_vec(py, analysis_elements).unbind(),
-        PyArray1::from_vec(
-            py,
-            elevated
-                .corner_node_indices
-                .into_iter()
-                .map(|index| index as u64)
-                .collect(),
-        )
-        .unbind(),
-        PyArray1::from_vec(
-            py,
-            elevated
-                .midside_node_indices
-                .into_iter()
-                .map(|index| index as u64)
-                .collect(),
-        )
-        .unbind(),
-        PyArray1::from_vec(
-            py,
-            elevated
-                .center_node_indices
-                .into_iter()
-                .map(|index| index as u64)
-                .collect(),
-        )
-        .unbind(),
-    ))
-}
-
-/// Low-level binding for elevating a quad4 input mesh to an explicit quad9 analysis mesh.
-#[pyfunction]
-fn solenoid_stress_fem_infer_quad9_mesh_f32<'py>(
-    py: Python<'py>,
-    nodes: PyReadonlyArray2<'_, f32>,
-    elements: PyReadonlyArray2<'_, u64>,
-) -> PyResult<(
-    Py<PyArray1<f32>>,
     Py<PyArray1<u64>>,
     Py<PyArray1<u64>>,
     Py<PyArray1<u64>>,
@@ -1535,23 +1223,6 @@ fn solenoid_stress_fem_quad_mesh_query_f64<'py>(
     quad_mesh_query_to_py(py, query)
 }
 
-/// Low-level binding for one-pass quad mesh queries.
-#[pyfunction]
-fn solenoid_stress_fem_quad_mesh_query_f32<'py>(
-    py: Python<'py>,
-    nodes: PyReadonlyArray2<'_, f32>,
-    elements: PyReadonlyArray2<'_, u64>,
-    points: PyReadonlyArray2<'_, f32>,
-    element_type: &str,
-    max_iterations: usize,
-) -> PyResult<Py<PyDict>> {
-    let nodes = read_axisym_nodes("nodes", nodes)?;
-    let points = read_axisym_nodes("points", points)?;
-    let query =
-        quad_mesh_query_for_element_type(&nodes, elements, &points, element_type, max_iterations)?;
-    quad_mesh_query_to_py(py, query)
-}
-
 fn quad_mesh_interpolation_operator_for_element_type<F>(
     nodes: &[[F; 2]],
     elements: PyReadonlyArray2<'_, u64>,
@@ -1730,35 +1401,6 @@ fn solenoid_stress_fem_quad_mesh_interpolation_operator_f64<'py>(
     sparse_operator_to_py(py, operator)
 }
 
-/// Low-level binding for scalar interpolation operators from query element/reference data.
-#[pyfunction]
-fn solenoid_stress_fem_quad_mesh_interpolation_operator_f32<'py>(
-    py: Python<'py>,
-    nodes: PyReadonlyArray2<'_, f32>,
-    elements: PyReadonlyArray2<'_, u64>,
-    element_indices: PyReadonlyArray1<'_, u64>,
-    reference_points: PyReadonlyArray2<'_, f32>,
-    element_type: &str,
-) -> PyResult<(
-    Py<PyArray1<f32>>,
-    Py<PyArray1<u64>>,
-    Py<PyArray1<u64>>,
-    u64,
-    u64,
-)> {
-    let nodes = read_axisym_nodes("nodes", nodes)?;
-    let element_indices = read_axisym_material_ids("element_indices", element_indices)?;
-    let reference_points = read_axisym_nodes("reference_points", reference_points)?;
-    let operator = quad_mesh_interpolation_operator_for_element_type(
-        &nodes,
-        elements,
-        &element_indices,
-        &reference_points,
-        element_type,
-    )?;
-    sparse_operator_to_py(py, operator)
-}
-
 /// Low-level binding for strain-recovery operators from query element/reference data.
 #[pyfunction]
 fn solenoid_stress_fem_quad_mesh_strain_operator_f64<'py>(
@@ -1772,41 +1414,6 @@ fn solenoid_stress_fem_quad_mesh_strain_operator_f64<'py>(
     thickness: f64,
 ) -> PyResult<(
     Py<PyArray1<f64>>,
-    Py<PyArray1<u64>>,
-    Py<PyArray1<u64>>,
-    u64,
-    u64,
-)> {
-    let nodes = read_axisym_nodes("nodes", nodes)?;
-    let element_indices = read_axisym_material_ids("element_indices", element_indices)?;
-    let reference_points = read_axisym_nodes("reference_points", reference_points)?;
-    let formulation =
-        physics::solenoid_stress::Structural2dFormulation::from_code(formulation, thickness)
-            .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let operator = quad_mesh_strain_operator_for_element_type(
-        &nodes,
-        elements,
-        &element_indices,
-        &reference_points,
-        element_type,
-        formulation,
-    )?;
-    sparse_operator_to_py(py, operator)
-}
-
-/// Low-level binding for strain-recovery operators from query element/reference data.
-#[pyfunction]
-fn solenoid_stress_fem_quad_mesh_strain_operator_f32<'py>(
-    py: Python<'py>,
-    nodes: PyReadonlyArray2<'_, f32>,
-    elements: PyReadonlyArray2<'_, u64>,
-    element_indices: PyReadonlyArray1<'_, u64>,
-    reference_points: PyReadonlyArray2<'_, f32>,
-    element_type: &str,
-    formulation: u8,
-    thickness: f32,
-) -> PyResult<(
-    Py<PyArray1<f32>>,
     Py<PyArray1<u64>>,
     Py<PyArray1<u64>>,
     u64,
@@ -1845,55 +1452,6 @@ fn solenoid_stress_fem_quad_mesh_stress_operator_f64<'py>(
     thickness: f64,
 ) -> PyResult<(
     Py<PyArray1<f64>>,
-    Py<PyArray1<u64>>,
-    Py<PyArray1<u64>>,
-    u64,
-    u64,
-)> {
-    let nodes = read_axisym_nodes("nodes", nodes)?;
-    let element_indices = read_axisym_material_ids("element_indices", element_indices)?;
-    let reference_points = read_axisym_nodes("reference_points", reference_points)?;
-    let material_ids = read_axisym_material_ids("material_ids", material_ids)?;
-    let material_table = read_axisym_material_table("material_table", material_table)?;
-    let material_orientation_angles = read_axisym_material_orientation_angles(
-        "material_orientation_angles",
-        material_orientation_angles,
-    )?;
-    let material_orientation_angles =
-        (!material_orientation_angles.is_empty()).then_some(material_orientation_angles.as_slice());
-    let formulation =
-        physics::solenoid_stress::Structural2dFormulation::from_code(formulation, thickness)
-            .map_err(|msg| PyInteropError::ValueError { msg })?;
-    let operator = quad_mesh_stress_operator_for_element_type(
-        &nodes,
-        elements,
-        &element_indices,
-        &reference_points,
-        &material_ids,
-        &material_table,
-        material_orientation_angles,
-        element_type,
-        formulation,
-    )?;
-    sparse_operator_to_py(py, operator)
-}
-
-/// Low-level binding for stress-recovery operators from query element/reference data.
-#[pyfunction]
-fn solenoid_stress_fem_quad_mesh_stress_operator_f32<'py>(
-    py: Python<'py>,
-    nodes: PyReadonlyArray2<'_, f32>,
-    elements: PyReadonlyArray2<'_, u64>,
-    element_indices: PyReadonlyArray1<'_, u64>,
-    reference_points: PyReadonlyArray2<'_, f32>,
-    material_ids: PyReadonlyArray1<'_, u64>,
-    material_table: PyReadonlyArray3<'_, f32>,
-    material_orientation_angles: PyReadonlyArray1<'_, f32>,
-    element_type: &str,
-    formulation: u8,
-    thickness: f32,
-) -> PyResult<(
-    Py<PyArray1<f32>>,
     Py<PyArray1<u64>>,
     Py<PyArray1<u64>>,
     u64,
@@ -3764,13 +3322,8 @@ fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
 
     // Solenoid stress FEM
     m.add_class::<SolenoidStress2dModelF64>()?;
-    m.add_class::<SolenoidStress2dModelF32>()?;
     m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_assemble_model_2d_f64,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_assemble_model_2d_f32,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
@@ -3778,15 +3331,7 @@ fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_isotropic_axisymmetric_material_f32,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_isotropic_plane_strain_material_f64,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_isotropic_plane_strain_material_f32,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
@@ -3794,15 +3339,7 @@ fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_isotropic_axisymmetric_thermal_material_f32,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_isotropic_plane_strain_thermal_material_f64,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_isotropic_plane_strain_thermal_material_f32,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
@@ -3810,15 +3347,7 @@ fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_orthotropic_axisymmetric_thermal_material_f32,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_cfsem_radial_material_f64,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_cfsem_radial_material_f32,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
@@ -3826,15 +3355,7 @@ fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_infer_quad9_mesh_f32,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_quad_mesh_query_f64,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_quad_mesh_query_f32,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
@@ -3842,23 +3363,11 @@ fn _cfsem<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_quad_mesh_interpolation_operator_f32,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_quad_mesh_strain_operator_f64,
         m.clone()
     )?)?;
     m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_quad_mesh_strain_operator_f32,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
         solenoid_stress_fem_quad_mesh_stress_operator_f64,
-        m.clone()
-    )?)?;
-    m.add_function(wrap_pyfunction!(
-        solenoid_stress_fem_quad_mesh_stress_operator_f32,
         m.clone()
     )?)?;
     Ok(())

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -597,18 +597,18 @@ def build_multimaterial_checkerboard_case(
     nodes, elements = build_annulus_strip_mesh(ri, ro, height, nr=nr, nz=nz, dtype=dtype)
     material_table = np.asarray(
         [
-            isotropic_axisymmetric_material(205.0e9, 0.28, dtype=dtype),
-            isotropic_axisymmetric_material(145.0e9, 0.32, dtype=dtype),
+            isotropic_axisymmetric_material(205.0e9, 0.28),
+            isotropic_axisymmetric_material(145.0e9, 0.32),
         ],
         dtype=dtype,
     )
     thermal_material_table = np.asarray(
         [
             fem.isotropic_axisymmetric_thermal_material(
-                1.1e-5, thermal_reference_temperatures[0], dtype=dtype
+                1.1e-5, thermal_reference_temperatures[0]
             ),
             fem.isotropic_axisymmetric_thermal_material(
-                1.9e-5, thermal_reference_temperatures[1], dtype=dtype
+                1.9e-5, thermal_reference_temperatures[1]
             ),
         ],
         dtype=dtype,
@@ -840,7 +840,7 @@ def test_element_measures_and_quadrature_match_exact_cylindrical_shell_values(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
-        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)]),
+        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27)]),
         quadrature=quadrature,
     )
     measures = model.element_measures()
@@ -874,7 +874,7 @@ def test_body_force_total_matches_requested_total_force(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
-        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)]),
+        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27)]),
         quadrature=quadrature,
     )
     measures = model.element_measures()
@@ -885,7 +885,7 @@ def test_body_force_total_matches_requested_total_force(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
-        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)]),
+        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27)]),
         body_force=density,
         quadrature=quadrature,
     )
@@ -899,11 +899,10 @@ def test_body_force_total_matches_requested_total_force(
 
 def test_model_dtype_resolution_includes_material_tables() -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=np.float32)
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=np.float64)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
     thermal_material = fem.isotropic_axisymmetric_thermal_material(
         1.1e-5,
         reference_temperature=293.15,
-        dtype=np.float64,
     )
     nodal_temperature = np.linspace(294.0, 301.0, nodes.shape[0], dtype=np.float32)
 
@@ -930,9 +929,9 @@ def test_model_dtype_resolution_includes_material_tables() -> None:
 @pytest.mark.parametrize("element_type", ELEMENT_TYPES)
 def test_parallel_structural_assembly_matches_serial(dtype: DType, element_type: str) -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=3, nz=2, dtype=dtype)
-    material = np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)])
+    material = np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27)])
     thermal = np.asarray(
-        [fem.isotropic_axisymmetric_thermal_material(1.2e-5, reference_temperature=293.15, dtype=dtype)]
+        [fem.isotropic_axisymmetric_thermal_material(1.2e-5, reference_temperature=293.15)]
     )
     material_ids = np.zeros(elements.shape[0], dtype=np.uint64)
     _inner_faces, outer_faces = pressure_faces_for_strip(nr=3, nz=2)
@@ -1007,8 +1006,8 @@ def test_structural_sparse_operators_export_lazily_and_are_cached() -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=dtype)
     _inner_faces, outer_faces = pressure_faces_for_strip(nr=2, nz=1)
     _bottom_faces, top_faces = horizontal_faces_for_strip(nr=2, nz=1)
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
-    thermal = fem.isotropic_axisymmetric_thermal_material(1.2e-5, reference_temperature=293.15, dtype=dtype)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
+    thermal = fem.isotropic_axisymmetric_thermal_material(1.2e-5, reference_temperature=293.15)
     model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
@@ -1065,7 +1064,7 @@ def test_axisymmetric_model_reuses_factorization_across_load_cases(dtype: DType,
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=4, nz=2, dtype=dtype)
     inner_faces, outer_faces = pressure_faces_for_strip(nr=4, nz=2)
     pressure_faces = np.vstack([inner_faces, outer_faces])
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
     model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
@@ -1121,7 +1120,7 @@ def test_radial_traction_on_outer_face_matches_expected_total_force(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
-        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)]),
+        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27)]),
         body_force=np.array([0.0, 0.0], dtype=dtype),
         traction_faces=outer_faces,
         traction_values=np.array([traction, 0.0], dtype=dtype),
@@ -1148,7 +1147,7 @@ def test_axial_traction_on_top_face_matches_expected_total_force(quadrature: str
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
-        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)]),
+        material_table=np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27)]),
         body_force=np.array([0.0, 0.0], dtype=dtype),
         traction_faces=top_faces,
         traction_values=np.array([0.0, traction], dtype=dtype),
@@ -1174,7 +1173,7 @@ def test_pressure_matches_equivalent_normal_traction_on_straight_faces(
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=dtype)
     _inner_faces, outer_faces = pressure_faces_for_strip(nr=2, nz=1)
     _bottom_faces, top_faces = horizontal_faces_for_strip(nr=2, nz=1)
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
 
     _outer_pressure_model, outer_pressure_rhs = assemble_model_and_rhs(
         nodes=nodes,
@@ -1243,7 +1242,7 @@ def test_zero_surface_traction_matches_natural_free_boundary(
             np.linspace(-1.5e4, 1.5e4, elements.shape[0], dtype=dtype),
         ]
     )
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
     prescribed = {1: 0.0}
 
     free_model, free_rhs = assemble_model_and_rhs(
@@ -1281,7 +1280,7 @@ def test_factorized_solve_reuses_stiffness_with_varying_traction(quadrature: str
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=3, nz=2, dtype=dtype)
     _inner_faces, outer_faces = pressure_faces_for_strip(nr=3, nz=2)
     _bottom_faces, top_faces = horizontal_faces_for_strip(nr=3, nz=2)
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
     prescribed = prescribed_z_dofs(analysis_node_count_for_element_type(nodes, elements, element_type))
     model = fem.assemble_structural_2d(
         nodes=nodes,
@@ -1339,11 +1338,10 @@ def test_uniform_temperature_recovery_matches_fully_constrained_thermal_stress(
     reference_temperature = 293.15
     delta_temperature = 40.0
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=dtype)
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
     thermal_material = fem.isotropic_axisymmetric_thermal_material(
         alpha,
         reference_temperature=reference_temperature,
-        dtype=dtype,
     )
     nodal_temperature = np.full(nodes.shape[0], reference_temperature + delta_temperature, dtype=dtype)
     all_fixed = {
@@ -1396,12 +1394,10 @@ def test_linear_radial_temperature_long_cylinder_matches_analytic_midplane_stres
     material = isotropic_axisymmetric_material(
         elasticity_modulus,
         poisson_ratio,
-        dtype=dtype,
     )
     thermal_material = fem.isotropic_axisymmetric_thermal_material(
         alpha,
         reference_temperature=reference_temperature,
-        dtype=dtype,
     )
     nodal_temperature = temperature_inner + (temperature_outer - temperature_inner) * (
         (nodes[:, 0] - ri) / (ro - ri)
@@ -1639,11 +1635,10 @@ def test_quadrature_recovery_splits_total_elastic_and_thermal_strain_consistentl
 ) -> None:
     dtype = np.float64
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=dtype)
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
     thermal_material = fem.isotropic_axisymmetric_thermal_material(
         9.0e-6,
         reference_temperature=290.0,
-        dtype=dtype,
     )
     analysis_nnode = analysis_node_count_for_element_type(nodes, elements, element_type)
     displacement = np.linspace(-2.0e-4, 3.0e-4, 2 * analysis_nnode, dtype=dtype)
@@ -1682,7 +1677,7 @@ def test_pressure_vessel_stresses_match_lame_reference(
         ]
     )
 
-    material = cfsem_radial_material(200.0e9, 0.27, dtype=dtype)
+    material = cfsem_radial_material(200.0e9, 0.27)
     prescribed = prescribed_z_dofs(analysis_node_count_for_element_type(nodes, elements, element_type))
     model_fe, rhs = assemble_model_and_rhs(
         nodes=nodes,
@@ -1730,7 +1725,7 @@ def test_pressure_vessel_radial_displacement_matches_cfsem_1d_solver(
     pin, pout = 1.5e6, 0.2e6
     nodes, elements = build_annulus_strip_mesh(ri, ro, height=0.1, nr=nr, nz=1, dtype=dtype)
     inner_faces, outer_faces = pressure_faces_for_strip(nr=nr, nz=1)
-    material = cfsem_radial_material(200.0e9, 0.27, dtype=dtype)
+    material = cfsem_radial_material(200.0e9, 0.27)
     model_fe, rhs = assemble_model_and_rhs(
         nodes=nodes,
         elements=elements,
@@ -1794,8 +1789,8 @@ def test_two_material_pressure_vessel_matches_chained_1d_solver(element_type: st
     outer_material = (135.0e9, 0.31)
     material_table = np.asarray(
         [
-            cfsem_radial_material(*inner_material, dtype=dtype),
-            cfsem_radial_material(*outer_material, dtype=dtype),
+            cfsem_radial_material(*inner_material),
+            cfsem_radial_material(*outer_material),
         ]
     )
     material_ids = np.concatenate(
@@ -1921,7 +1916,7 @@ def test_distorted_2d_mesh_matches_regular_solution_at_common_points(
             -3.0e4 * np.cos(np.pi * xi) * np.sin(np.pi * eta),
         ]
     )
-    material = isotropic_axisymmetric_material(205.0e9, 0.29, dtype=dtype)
+    material = isotropic_axisymmetric_material(205.0e9, 0.29)
     regular_analysis_nodes = analysis_nodes_for_element_type(regular_nodes, elements, element_type)
     prescribed = prescribed_bottom_supports(regular_analysis_nodes)
 
@@ -2061,7 +2056,7 @@ def test_assembly_and_postprocessing_validation_branches() -> None:
 def test_model_zero_load_and_empty_reduction_branches() -> None:
     dtype = np.float64
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=1, nz=1, dtype=dtype)
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
 
     model = fem.assemble_structural_2d(
         nodes=nodes,
@@ -2091,8 +2086,8 @@ def test_model_zero_load_and_empty_reduction_branches() -> None:
 def test_thermal_model_missing_temperature_and_alignment_validation_branches() -> None:
     dtype = np.float64
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=1, nz=1, dtype=dtype)
-    material = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
-    thermal_material = fem.isotropic_axisymmetric_thermal_material(1.2e-5, 293.15, dtype=dtype)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
+    thermal_material = fem.isotropic_axisymmetric_thermal_material(1.2e-5, 293.15)
 
     model = fem.assemble_structural_2d(
         nodes=nodes,
@@ -2165,11 +2160,10 @@ def test_thermal_model_missing_temperature_and_alignment_validation_branches() -
 
 
 def test_pack_material_tables_from_tags_sorts_tags_and_rewrites_ids() -> None:
-    dtype = np.float64
-    material_a = isotropic_axisymmetric_material(200.0e9, 0.27, dtype=dtype)
-    material_b = isotropic_axisymmetric_material(150.0e9, 0.31, dtype=dtype)
-    thermal_a = fem.isotropic_axisymmetric_thermal_material(1.2e-5, 293.15, dtype=dtype)
-    thermal_b = fem.isotropic_axisymmetric_thermal_material(1.8e-5, 310.0, dtype=dtype)
+    material_a = isotropic_axisymmetric_material(200.0e9, 0.27)
+    material_b = isotropic_axisymmetric_material(150.0e9, 0.31)
+    thermal_a = fem.isotropic_axisymmetric_thermal_material(1.2e-5, 293.15)
+    thermal_b = fem.isotropic_axisymmetric_thermal_material(1.8e-5, 310.0)
 
     packed_ids_no_thermal, packed_material_table_no_thermal, packed_thermal_table_no_thermal = (
         fem.pack_material_tables_from_tags(
@@ -2196,27 +2190,24 @@ def test_pack_material_tables_from_tags_sorts_tags_and_rewrites_ids() -> None:
     assert np.allclose(packed_thermal_table[1], thermal_b)
 
 
-def test_python_convenience_wrappers_normalize_float32_inputs_to_float64() -> None:
-    requested_dtype = np.dtype(np.float32)
+def test_python_convenience_wrappers_return_float64() -> None:
     expected_dtype = np.dtype(np.float64)
-    iso = fem.isotropic_axisymmetric_material(200.0e9, 0.3, dtype=requested_dtype)
-    iso_plane = fem.isotropic_plane_strain_material(200.0e9, 0.3, dtype=requested_dtype)
-    reduced = fem.cfsem_radial_material(200.0e9, 0.3, dtype=requested_dtype)
+    iso = fem.isotropic_axisymmetric_material(200.0e9, 0.3)
+    iso_plane = fem.isotropic_plane_strain_material(200.0e9, 0.3)
+    reduced = fem.cfsem_radial_material(200.0e9, 0.3)
     thermal = fem.isotropic_axisymmetric_thermal_material(
         1.0e-5,
         reference_temperature=293.15,
-        dtype=requested_dtype,
     )
     thermal_plane = fem.isotropic_plane_strain_thermal_material(
         1.0e-5,
         reference_temperature=293.15,
-        dtype=requested_dtype,
     )
     ortho = fem.orthotropic_axisymmetric_thermal_material(
-        1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15, dtype=requested_dtype
+        1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15
     )
     ortho_plane = fem.orthotropic_plane_strain_thermal_material(
-        1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15, dtype=requested_dtype
+        1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15
     )
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=np.float32)
     elevated = fem.infer_quad9_mesh(nodes, elements)
@@ -2285,7 +2276,7 @@ def test_plane_strain_accepts_negative_coordinates_and_recovers_linear_strain() 
         dtype=dtype,
     )
     elements = np.asarray([[0, 1, 2, 3]], dtype=np.uint64)
-    material = fem.isotropic_plane_strain_material(200.0e9, 0.29, dtype=dtype)
+    material = fem.isotropic_plane_strain_material(200.0e9, 0.29)
 
     model = fem.assemble_structural_2d(
         nodes,
@@ -2384,7 +2375,7 @@ def test_explicit_quad9_input_uses_supplied_analysis_mesh() -> None:
         dtype=dtype,
     )
     elements = np.asarray([[0, 1, 2, 3, 4, 5, 6, 7, 8]], dtype=np.uint64)
-    material = fem.isotropic_plane_strain_material(185.0e9, 0.31, dtype=dtype)
+    material = fem.isotropic_plane_strain_material(185.0e9, 0.31)
     model = fem.assemble_structural_2d(
         nodes,
         elements,
@@ -2418,7 +2409,7 @@ def test_plane_strain_affine_patch_solve_is_exact(element_type: str, quadrature:
     dtype = np.float64
     nodes, elements = build_planar_rect_mesh(-1.25, 1.75, -0.8, 1.4, nx=2, ny=2, dtype=dtype)
     analysis_nodes = analysis_nodes_for_element_type(nodes, elements, element_type)
-    material = fem.isotropic_plane_strain_material(185.0e9, 0.31, dtype=dtype)
+    material = fem.isotropic_plane_strain_material(185.0e9, 0.31)
 
     a, b, c, d = 0.017, -0.023, 0.019, -0.013
 
@@ -2479,7 +2470,7 @@ def test_plane_strain_uniaxial_stress_has_nonzero_out_of_plane_stress(
     remote_stress = 12.5e6
     nodes, elements = build_planar_rect_mesh(-0.6, 0.9, -0.4, 0.5, nx=3, ny=3, dtype=dtype)
     analysis_nodes = analysis_nodes_for_element_type(nodes, elements, element_type)
-    material = fem.isotropic_plane_strain_material(youngs_modulus, poisson_ratio, dtype=dtype)
+    material = fem.isotropic_plane_strain_material(youngs_modulus, poisson_ratio)
 
     epsilon_xx = remote_stress * (1.0 - poisson_ratio**2) / youngs_modulus
     epsilon_yy = -poisson_ratio * (1.0 + poisson_ratio) * remote_stress / youngs_modulus
@@ -2557,7 +2548,7 @@ def test_plane_strain_circular_hole_matches_kirsch_stress_concentration(
     )
     traction_values = cartesian_traction_from_polar_stress(sigma_rr, sigma_rt, face_theta).astype(dtype)
 
-    material = fem.isotropic_plane_strain_material(200.0e9, poisson_ratio, dtype=dtype)
+    material = fem.isotropic_plane_strain_material(200.0e9, poisson_ratio)
     prescribed = {
         0: 0.0,
         1: 0.0,

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -1060,41 +1060,6 @@ def test_structural_sparse_operators_export_lazily_and_are_cached() -> None:
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
-@pytest.mark.parametrize("equilibration", ["ruiz", "none"])
-def test_iterative_structural_solve_matches_direct_and_reports_diagnostics(
-    dtype: DType,
-    equilibration: str,
-) -> None:
-    nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=3, nz=2, dtype=dtype)
-    model, rhs = assemble_model_and_rhs(
-        nodes=nodes,
-        elements=elements,
-        material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
-        material_table=np.asarray([isotropic_axisymmetric_material(200.0, 0.27, dtype=dtype)]),
-        body_force=np.array([2.0, -1.0], dtype=dtype),
-        prescribed=prescribed_z_dofs(nodes.shape[0]),
-    )
-
-    direct = model.solve(rhs)
-    solve_tolerance = 1e-4 if dtype is np.float32 else 1.0e-9
-    iterative = model.solve(
-        rhs,
-        method="bicgstab",
-        tolerance=solve_tolerance,
-        max_iterations=100,
-        equilibration=equilibration,  # type: ignore[arg-type]
-        return_diagnostics=True,
-    )
-    rtol, atol = tolerance(dtype)
-
-    assert iterative.diagnostics.method == "bicgstab"
-    assert iterative.diagnostics.converged
-    assert iterative.diagnostics.iterations > 0
-    assert iterative.diagnostics.equilibrated == (equilibration == "ruiz")
-    assert np.allclose(iterative.displacement, direct, rtol=rtol, atol=atol)
-
-
-@pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
 @pytest.mark.parametrize("quadrature", QUADRATURES)
 def test_axisymmetric_model_reuses_factorization_across_load_cases(dtype: DType, quadrature: str) -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=4, nz=2, dtype=dtype)
@@ -2077,18 +2042,18 @@ def test_assembly_and_postprocessing_validation_branches() -> None:
     near_axis_nodes = np.array(
         [
             [0.0, 0.0],
-            [1.0e-8, 0.0],
-            [1.0e-8, 1.0],
+            [1.0e-16, 0.0],
+            [1.0e-16, 1.0],
             [0.0, 1.0],
         ],
-        dtype=np.float32,
+        dtype=np.float64,
     )
     with pytest.raises(ValueError, match="too close to zero"):
         model = fem.assemble_structural_2d(
             near_axis_nodes,
             np.array([[0, 1, 2, 3]], dtype=np.uint64),
             np.zeros((1,), dtype=np.uint64),
-            np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27, dtype=np.float32)]),
+            np.asarray([isotropic_axisymmetric_material(200.0e9, 0.27)]),
         )
         model.element_quadrature()
 
@@ -2231,22 +2196,27 @@ def test_pack_material_tables_from_tags_sorts_tags_and_rewrites_ids() -> None:
     assert np.allclose(packed_thermal_table[1], thermal_b)
 
 
-def test_python_convenience_wrappers_preserve_dtype_and_shapes() -> None:
-    dtype = np.dtype(np.float32)
-    iso = fem.isotropic_axisymmetric_material(200.0e9, 0.3, dtype=dtype)
-    iso_plane = fem.isotropic_plane_strain_material(200.0e9, 0.3, dtype=dtype)
-    reduced = fem.cfsem_radial_material(200.0e9, 0.3, dtype=dtype)
-    thermal = fem.isotropic_axisymmetric_thermal_material(1.0e-5, reference_temperature=293.15, dtype=dtype)
+def test_python_convenience_wrappers_normalize_float32_inputs_to_float64() -> None:
+    requested_dtype = np.dtype(np.float32)
+    expected_dtype = np.dtype(np.float64)
+    iso = fem.isotropic_axisymmetric_material(200.0e9, 0.3, dtype=requested_dtype)
+    iso_plane = fem.isotropic_plane_strain_material(200.0e9, 0.3, dtype=requested_dtype)
+    reduced = fem.cfsem_radial_material(200.0e9, 0.3, dtype=requested_dtype)
+    thermal = fem.isotropic_axisymmetric_thermal_material(
+        1.0e-5,
+        reference_temperature=293.15,
+        dtype=requested_dtype,
+    )
     thermal_plane = fem.isotropic_plane_strain_thermal_material(
         1.0e-5,
         reference_temperature=293.15,
-        dtype=dtype,
+        dtype=requested_dtype,
     )
     ortho = fem.orthotropic_axisymmetric_thermal_material(
-        1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15, dtype=dtype
+        1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15, dtype=requested_dtype
     )
     ortho_plane = fem.orthotropic_plane_strain_thermal_material(
-        1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15, dtype=dtype
+        1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15, dtype=requested_dtype
     )
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=np.float32)
     elevated = fem.infer_quad9_mesh(nodes, elements)
@@ -2258,15 +2228,15 @@ def test_python_convenience_wrappers_preserve_dtype_and_shapes() -> None:
     assert thermal_plane.shape == (5,)
     assert ortho.shape == (5,)
     assert ortho_plane.shape == (5,)
-    assert iso.dtype == dtype
-    assert iso_plane.dtype == dtype
-    assert reduced.dtype == dtype
-    assert thermal.dtype == dtype
-    assert thermal_plane.dtype == dtype
-    assert ortho.dtype == dtype
-    assert ortho_plane.dtype == dtype
+    assert iso.dtype == expected_dtype
+    assert iso_plane.dtype == expected_dtype
+    assert reduced.dtype == expected_dtype
+    assert thermal.dtype == expected_dtype
+    assert thermal_plane.dtype == expected_dtype
+    assert ortho.dtype == expected_dtype
+    assert ortho_plane.dtype == expected_dtype
     assert elevated.analysis_elements.shape[1] == 9
-    assert elevated.analysis_nodes.dtype == dtype
+    assert elevated.analysis_nodes.dtype == expected_dtype
 
 
 def test_private_formulation_code_rejects_unknown_formulation() -> None:

--- a/test/test_solenoid_stress_fem.py
+++ b/test/test_solenoid_stress_fem.py
@@ -26,9 +26,9 @@ from cfsem.solenoid_stress.thick_wall_cylinder_handcalc import (
 )
 
 
-DType = type[np.float32] | type[np.float64]
+DType = type[np.float64]
 QUADRATURES = ["gl3", "gl4"]
-DTYPES: list[DType] = [np.float32, np.float64]
+DTYPES: list[DType] = [np.float64]
 AREA_VOLUME_MESHES = [(1, 1), (3, 2)]
 BODY_FORCE_MESHES = [(2, 1), (4, 2)]
 PRESSURE_NR_CASES = [24, 48]
@@ -629,8 +629,6 @@ def build_multimaterial_checkerboard_case(
 
 
 def tolerance(dtype: DType) -> tuple[float, float]:
-    if dtype is np.float32:
-        return 1e-3, 1e-5
     return 1.0e-12, 1.0e-12
 
 
@@ -897,32 +895,36 @@ def test_body_force_total_matches_requested_total_force(
     assert np.allclose(rhs[:, 1].sum(), total_force[1], rtol=rtol, atol=max(atol, 1.0e-4))
 
 
-def test_model_dtype_resolution_includes_material_tables() -> None:
+def test_structural_fem_rejects_float32_input_arrays() -> None:
     nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=np.float32)
     material = isotropic_axisymmetric_material(200.0e9, 0.27)
     thermal_material = fem.isotropic_axisymmetric_thermal_material(
         1.1e-5,
         reference_temperature=293.15,
     )
-    nodal_temperature = np.linspace(294.0, 301.0, nodes.shape[0], dtype=np.float32)
 
+    with pytest.raises(TypeError, match="nodes"):
+        fem.assemble_structural_2d(
+            nodes=nodes,
+            elements=elements,
+            material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
+            material_table=np.asarray([material]),
+            thermal_material_table=np.asarray([thermal_material]),
+        )
+
+
+def test_structural_rhs_rejects_float32_load_arrays() -> None:
+    nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=np.float64)
+    material = isotropic_axisymmetric_material(200.0e9, 0.27)
     model = fem.assemble_structural_2d(
         nodes=nodes,
         elements=elements,
         material_ids=np.zeros(elements.shape[0], dtype=np.uint64),
         material_table=np.asarray([material]),
-        thermal_material_table=np.asarray([thermal_material]),
     )
 
-    assert model.dtype == np.dtype(np.float64)
-    assert model.stiffness.dtype == np.float64
-    assert (
-        model.build_rhs(
-            body_force=np.array([0.0, 0.0], dtype=np.float32),
-            nodal_temperature=nodal_temperature,
-        ).dtype
-        == np.float64
-    )
+    with pytest.raises(TypeError, match="body_force"):
+        model.build_rhs(body_force=np.array([0.0, 0.0], dtype=np.float32))
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: dtype.__name__)
@@ -1697,12 +1699,8 @@ def test_pressure_vessel_stresses_match_lame_reference(
     radial_exact = s_radial_thick_wall_cylinder(radii, ri, ro, pin, pout)
     hoop_exact = s_hoop_thick_wall_cylinder(radii, ri, ro, pin, pout)
 
-    if nr <= 24 and dtype is np.float32:
-        radial_rtol, hoop_rtol, atol = 7.0e-2, 6.0e-2, 1.8e4
-    elif nr <= 24:
+    if nr <= 24:
         radial_rtol, hoop_rtol, atol = 5.0e-2, 4.0e-2, 1.0e4
-    elif dtype is np.float32:
-        radial_rtol, hoop_rtol, atol = 3.0e-2, 2.5e-2, 8.0e3
     else:
         radial_rtol, hoop_rtol, atol = 2.5e-2, 2.0e-2, 2.5e3
     # Stress is a recovered field built from displacement gradients, so it
@@ -1763,12 +1761,8 @@ def test_pressure_vessel_radial_displacement_matches_cfsem_1d_solver(
     )
     radial_cfsem = model.displacement_solver(rhs)[1:-1]
 
-    if nr <= 24 and dtype is np.float32:
-        rtol, atol = 7.0e-2, 2.5e-6
-    elif nr <= 24:
+    if nr <= 24:
         rtol, atol = 5.0e-2, 8.0e-7
-    elif dtype is np.float32:
-        rtol, atol = 4.0e-2, 1.0e-6
     else:
         rtol, atol = 3.0e-2, 2.0e-7
     assert np.allclose(radial_fe, radial_cfsem, rtol=rtol, atol=atol)
@@ -2209,7 +2203,7 @@ def test_python_convenience_wrappers_return_float64() -> None:
     ortho_plane = fem.orthotropic_plane_strain_thermal_material(
         1.0e-5, 2.0e-5, 3.0e-5, reference_temperature=293.15
     )
-    nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=np.float32)
+    nodes, elements = build_annulus_strip_mesh(0.5, 1.0, 0.2, nr=2, nz=1, dtype=np.float64)
     elevated = fem.infer_quad9_mesh(nodes, elements)
 
     assert iso.shape == (4, 4)
@@ -2257,7 +2251,6 @@ def test_quad9_temperature_elevation_reproduces_affine_temperature_field() -> No
         corner_temperature,
         nodes.shape[0],
         elevated,
-        dtype,
     )
     expected_temperature = a_r * elevated.analysis_nodes[:, 0] + b_z * elevated.analysis_nodes[:, 1] + c0
 


### PR DESCRIPTION
## 10.0.0 2026-06-09

* Rust
    * !Remove f32 and iterative solve support for 2D FEM solver
        * Field testing showed only ~25% speedup for each on a problem with >1M elements
        * This is not enough to justify the complexity and maintenance overhead
* Python
    * !Update bindings for changed FEM API