### PR TITLE
Trim FEM internals

### DIFF
--- a/src/mesh/quad2d.rs
+++ b/src/mesh/quad2d.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use crate::mesh::elements::quad2d::{mapping, quad4, quad9};
 use crate::mesh::{Scalar, cast};
 use crate::physics::solenoid_stress::{
-    DOF_PER_NODE, Real, Structural2dFormulation, build_b_matrix, rotate_material_in_plane,
+    DOF_PER_NODE, Structural2dFormulation, build_b_matrix, rotate_material_in_plane,
     validate_element_material_inputs,
 };
 
@@ -541,20 +541,14 @@ where
 /// The operator has shape `(4 * nquery, 2 * nnode)` and maps full nodal displacement values to the
 /// four-component strain vector at each query point. Rows are grouped per query point in the same
 /// component ordering as the structural formulation.
-pub fn quad_mesh_strain_operator<
-    E,
-    F,
-    const NODES_PER_ELEMENT: usize,
-    const DOF_PER_ELEMENT: usize,
->(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+pub fn quad_mesh_strain_operator<E, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     element_indices: &[usize],
-    reference_points: &[[F; 2]],
-    formulation: Structural2dFormulation<F>,
-) -> Result<QuadMeshSparseOperator<F>, String>
+    reference_points: &[[f64; 2]],
+    formulation: Structural2dFormulation,
+) -> Result<QuadMeshSparseOperator<f64>, String>
 where
     E: QuadReferenceElement<NODES_PER_ELEMENT>,
-    F: Real,
 {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
@@ -584,7 +578,7 @@ where
         let inv_jac = mapping::inv_j(&jac)?;
         let grad_phys = mapping::grad_phys(&grad_ref, &inv_jac);
         let point = mapping::map_point(&coords, &shape);
-        let b = build_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        let b = build_b_matrix::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             formulation,
             &shape,
             &grad_phys,
@@ -596,7 +590,7 @@ where
                 for dof_component in 0..DOF_PER_NODE {
                     let local_dof = DOF_PER_NODE * local_node + dof_component;
                     let value = b[component][local_dof];
-                    if value != F::zero() {
+                    if value != 0.0 {
                         rows.push(row);
                         cols.push(DOF_PER_NODE * nodes[local_node] + dof_component);
                         vals.push(value);
@@ -629,23 +623,17 @@ where
 /// `material_orientation_angles` has shape `(nelem,)` and unitless radians. Operator entries have
 /// units `[pressure / length]`, so multiplying by nodal displacements with units `[length]`
 /// returns stresses with units `[pressure]`.
-pub fn quad_mesh_stress_operator<
-    E,
-    F,
-    const NODES_PER_ELEMENT: usize,
-    const DOF_PER_ELEMENT: usize,
->(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+pub fn quad_mesh_stress_operator<E, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     element_indices: &[usize],
-    reference_points: &[[F; 2]],
+    reference_points: &[[f64; 2]],
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
-) -> Result<QuadMeshSparseOperator<F>, String>
+    material_table: &[[[f64; 4]; 4]],
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
+) -> Result<QuadMeshSparseOperator<f64>, String>
 where
     E: QuadReferenceElement<NODES_PER_ELEMENT>,
-    F: Real,
 {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
@@ -692,7 +680,7 @@ where
         let inv_jac = mapping::inv_j(&jac)?;
         let grad_phys = mapping::grad_phys(&grad_ref, &inv_jac);
         let point = mapping::map_point(&coords, &shape);
-        let b = build_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        let b = build_b_matrix::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             formulation,
             &shape,
             &grad_phys,
@@ -704,13 +692,13 @@ where
             for local_node in 0..NODES_PER_ELEMENT {
                 for dof_component in 0..DOF_PER_NODE {
                     let local_dof = DOF_PER_NODE * local_node + dof_component;
-                    let mut value = F::zero();
+                    let mut value = 0.0;
                     for strain_component in 0..4 {
                         value = value
                             + material[component][strain_component]
                                 * b[strain_component][local_dof];
                     }
-                    if value != F::zero() {
+                    if value != 0.0 {
                         rows.push(row);
                         cols.push(DOF_PER_NODE * nodes[local_node] + dof_component);
                         vals.push(value);
@@ -864,7 +852,7 @@ mod tests {
         let query =
             query_quad_mesh::<Quad4ReferenceElement, _, 4>(mesh, &[[0.25, 0.5], [1.75, 0.5]], 20)
                 .expect("mesh query");
-        let operator = quad_mesh_stress_operator::<Quad4ReferenceElement, _, 4, 8>(
+        let operator = quad_mesh_stress_operator::<Quad4ReferenceElement, 4, 8>(
             mesh,
             &query.nearest_element_indices,
             &query.nearest_element_reference_points,

--- a/src/physics/solenoid_stress/assembly.rs
+++ b/src/physics/solenoid_stress/assembly.rs
@@ -11,7 +11,7 @@ use crate::physics::solenoid_stress::convenience::rotate_material_in_plane;
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::validate_structural_2d_mesh;
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, StiffnessTriplets, Structural2dFormulation, local_dofs,
+    DOF_PER_NODE, StiffnessTriplets, Structural2dFormulation, local_dofs,
     validate_element_material_inputs,
 };
 use crate::{chunksize, ranges_for_len};
@@ -22,28 +22,27 @@ use crate::{chunksize, ranges_for_len};
 /// reduction and CSC compression.  Its entries have units
 /// `[generalized nodal force / displacement] = [energy / distance^2]`.
 pub(crate) fn assemble_stiffness_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<StiffnessTriplets<F>, String>
+) -> Result<StiffnessTriplets, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
-    validate_stiffness_inputs::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+    validate_stiffness_inputs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
         mesh,
         material_ids,
         material_orientation_angles,
         formulation,
     )?;
-    assemble_stiffness_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+    assemble_stiffness_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
         mesh,
         material_ids,
         material_table,
@@ -62,23 +61,22 @@ where
 /// constrained-system reduction and sparse compression stages consume them.
 #[cfg(test)]
 pub(crate) fn assemble_stiffness_for_family_par<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<StiffnessTriplets<F>, String>
+) -> Result<StiffnessTriplets, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
     let chunks =
-        assemble_stiffness_chunks_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        assemble_stiffness_chunks_for_family_par::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             material_ids,
             material_table,
@@ -95,22 +93,21 @@ where
 
 /// Assemble full-space stiffness triplet chunks with element ranges split across Rayon workers.
 pub(crate) fn assemble_stiffness_chunks_for_family_par<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<Vec<StiffnessTriplets<F>>, String>
+) -> Result<Vec<StiffnessTriplets>, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
-    validate_stiffness_inputs::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+    validate_stiffness_inputs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
         mesh,
         material_ids,
         material_orientation_angles,
@@ -121,7 +118,7 @@ where
     ranges_for_len(nelem, chunksize(nelem))
         .into_par_iter()
         .map(|(start, end)| {
-            assemble_stiffness_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            assemble_stiffness_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
                 mesh,
                 material_ids,
                 material_table,
@@ -136,15 +133,11 @@ where
 }
 
 /// Validate shape and material inputs shared by serial and threaded stiffness assembly.
-fn validate_stiffness_inputs<
-    F: Real,
-    const NODES_PER_ELEMENT: usize,
-    const DOF_PER_ELEMENT: usize,
->(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+fn validate_stiffness_inputs<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
 ) -> Result<(), String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
@@ -160,20 +153,19 @@ fn validate_stiffness_inputs<
 #[allow(clippy::too_many_arguments)]
 /// Assemble the contribution from a contiguous element range into an independent triplet buffer.
 fn assemble_stiffness_range_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     element_start: usize,
     element_end: usize,
-) -> Result<StiffnessTriplets<F>, String>
+) -> Result<StiffnessTriplets, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -196,10 +188,10 @@ where
         } else {
             material
         };
-        let mut ke = [[F::zero(); DOF_PER_ELEMENT]; DOF_PER_ELEMENT];
+        let mut ke = [[0.0; DOF_PER_ELEMENT]; DOF_PER_ELEMENT];
 
-        for sample in Family::volume_samples::<F>(&coords, quadrature)? {
-            let b = build_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        for sample in Family::volume_samples(&coords, quadrature)? {
+            let b = build_b_matrix::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
                 formulation,
                 &sample.n,
                 &sample.grad_phys,
@@ -225,10 +217,7 @@ where
 
 /// Concatenate independently assembled triplet chunks without changing element order.
 #[cfg(test)]
-fn concat_stiffness_triplets<F: Real>(
-    chunks: Vec<StiffnessTriplets<F>>,
-    capacity: usize,
-) -> StiffnessTriplets<F> {
+fn concat_stiffness_triplets(chunks: Vec<StiffnessTriplets>, capacity: usize) -> StiffnessTriplets {
     let mut rows = Vec::with_capacity(capacity);
     let mut cols = Vec::with_capacity(capacity);
     let mut vals = Vec::with_capacity(capacity);
@@ -257,7 +246,7 @@ mod tests {
         let mesh = single_element_quad4_mesh();
         let material_ids = [0usize];
         let material_table = [isotropic_axisymmetric_material(200.0e9, 0.27)];
-        let result = assemble_stiffness_for_family::<f64, Quad4Family, 4, { dof_per_element(4) }>(
+        let result = assemble_stiffness_for_family::<Quad4Family, 4, { dof_per_element(4) }>(
             mesh,
             &material_ids,
             &material_table,
@@ -285,7 +274,7 @@ mod tests {
         let mesh = single_element_quad4_mesh();
         let material_ids = [0usize];
         let material_table = [isotropic_axisymmetric_material(200.0e9, 0.27)];
-        let serial = assemble_stiffness_for_family::<f64, Quad4Family, 4, { dof_per_element(4) }>(
+        let serial = assemble_stiffness_for_family::<Quad4Family, 4, { dof_per_element(4) }>(
             mesh,
             &material_ids,
             &material_table,
@@ -294,16 +283,15 @@ mod tests {
             QuadratureRule::GaussLegendre3,
         )
         .expect("serial assembly should succeed");
-        let parallel =
-            assemble_stiffness_for_family_par::<f64, Quad4Family, 4, { dof_per_element(4) }>(
-                mesh,
-                &material_ids,
-                &material_table,
-                None,
-                crate::physics::solenoid_stress::types::Structural2dFormulation::Axisymmetric,
-                QuadratureRule::GaussLegendre3,
-            )
-            .expect("parallel assembly should succeed");
+        let parallel = assemble_stiffness_for_family_par::<Quad4Family, 4, { dof_per_element(4) }>(
+            mesh,
+            &material_ids,
+            &material_table,
+            None,
+            crate::physics::solenoid_stress::types::Structural2dFormulation::Axisymmetric,
+            QuadratureRule::GaussLegendre3,
+        )
+        .expect("parallel assembly should succeed");
 
         assert_eq!(serial.rows, parallel.rows);
         assert_eq!(serial.cols, parallel.cols);

--- a/src/physics/solenoid_stress/axisym.rs
+++ b/src/physics/solenoid_stress/axisym.rs
@@ -11,7 +11,7 @@
 //! `u_z`.  Circumferential displacement is omitted by the axisymmetric assumption, but the hoop
 //! normal strain `e_tt` still appears because moving a ring outward changes its circumference.
 
-use crate::physics::solenoid_stress::types::{DOF_PER_NODE, Real, Structural2dFormulation};
+use crate::physics::solenoid_stress::types::{DOF_PER_NODE, Structural2dFormulation};
 
 /// Build the axisymmetric strain-displacement matrix `B` at one quadrature point.
 ///
@@ -23,24 +23,20 @@ use crate::physics::solenoid_stress::types::{DOF_PER_NODE, Real, Structural2dFor
 /// - Allan F. Bower, *Applied Mechanics of Solids*, CRC Press, 2009, Section 8.1.
 /// - E. L. Wilson, "Structural Analysis of Axisymmetric Solids," *AIAA Journal*, 3(12), pp. 2269-2274, December 1965. doi:10.2514/3.3356.
 /// - R. A. Mitchell, R. M. Woolley, and C. R. Fisher, "Formulation and experimental verification of an axisymmetric finite-element structural analysis," *Journal of Research of the National Bureau of Standards Section C*, 75C, 1971.
-pub fn build_axisymmetric_b_matrix<
-    F: Real,
-    const NODES_PER_ELEMENT: usize,
-    const DOF_PER_ELEMENT: usize,
->(
-    n: &[F; NODES_PER_ELEMENT],
-    grad_phys: &[[F; 2]; NODES_PER_ELEMENT],
-    radius: F,
-) -> Result<[[F; DOF_PER_ELEMENT]; 4], String> {
+pub fn build_axisymmetric_b_matrix<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    n: &[f64; NODES_PER_ELEMENT],
+    grad_phys: &[[f64; 2]; NODES_PER_ELEMENT],
+    radius: f64,
+) -> Result<[[f64; DOF_PER_ELEMENT]; 4], String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    if radius <= F::epsilon() {
+    if radius <= f64::EPSILON {
         return Err(format!(
             "quadrature radius {radius:?} is too close to zero for the axisymmetric hoop-strain term"
         ));
     }
-    let mut b = [[F::zero(); DOF_PER_ELEMENT]; 4];
+    let mut b = [[0.0; DOF_PER_ELEMENT]; 4];
     for i in 0..NODES_PER_ELEMENT {
         let col_r = 2 * i;
         let col_z = col_r + 1;
@@ -64,17 +60,13 @@ pub fn build_axisymmetric_b_matrix<
 /// Multiplying this matrix by the element displacement vector
 /// `[u_x1, u_y1, u_x2, u_y2, ...]^T` gives the strain vector
 /// `[e_xx, e_yy, e_zz, g_xy]^T` at that point, with `e_zz = 0`.
-pub fn build_plane_strain_b_matrix<
-    F: Real,
-    const NODES_PER_ELEMENT: usize,
-    const DOF_PER_ELEMENT: usize,
->(
-    grad_phys: &[[F; 2]; NODES_PER_ELEMENT],
-) -> [[F; DOF_PER_ELEMENT]; 4] {
+pub fn build_plane_strain_b_matrix<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    grad_phys: &[[f64; 2]; NODES_PER_ELEMENT],
+) -> [[f64; DOF_PER_ELEMENT]; 4] {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    let mut b = [[F::zero(); DOF_PER_ELEMENT]; 4];
+    let mut b = [[0.0; DOF_PER_ELEMENT]; 4];
     for (i, grad) in grad_phys.iter().enumerate() {
         let col_x = 2 * i;
         let col_y = col_x + 1;
@@ -93,20 +85,18 @@ pub fn build_plane_strain_b_matrix<
 }
 
 /// Build the formulation-specific strain-displacement matrix `B` at one quadrature point.
-pub fn build_b_matrix<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
-    formulation: Structural2dFormulation<F>,
-    n: &[F; NODES_PER_ELEMENT],
-    grad_phys: &[[F; 2]; NODES_PER_ELEMENT],
-    point: [F; 2],
-) -> Result<[[F; DOF_PER_ELEMENT]; 4], String> {
+pub fn build_b_matrix<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    formulation: Structural2dFormulation,
+    n: &[f64; NODES_PER_ELEMENT],
+    grad_phys: &[[f64; 2]; NODES_PER_ELEMENT],
+    point: [f64; 2],
+) -> Result<[[f64; DOF_PER_ELEMENT]; 4], String> {
     match formulation {
-        Structural2dFormulation::Axisymmetric => {
-            build_axisymmetric_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                n, grad_phys, point[0],
-            )
-        }
+        Structural2dFormulation::Axisymmetric => build_axisymmetric_b_matrix::<
+            NODES_PER_ELEMENT,
+            DOF_PER_ELEMENT,
+        >(n, grad_phys, point[0]),
         Structural2dFormulation::PlaneStrain { .. } => Ok(build_plane_strain_b_matrix::<
-            F,
             NODES_PER_ELEMENT,
             DOF_PER_ELEMENT,
         >(grad_phys)),
@@ -125,17 +115,17 @@ pub fn build_b_matrix<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELE
 /// - E. L. Wilson, "Structural Analysis of Axisymmetric Solids," *AIAA Journal*, 3(12), pp. 2269-2274, December 1965. doi:10.2514/3.3356.
 /// - R. A. Mitchell, R. M. Woolley, and C. R. Fisher, "Formulation and experimental verification of an axisymmetric finite-element structural analysis," *Journal of Research of the National Bureau of Standards Section C*, 75C, 1971.
 /// - I. Fried, "Notes on the finite element analysis of the axisymmetric elastic solid," *International Journal of Solids and Structures*, 10(3), 1974.
-pub fn accumulate_stiffness<F: Real, const DOF_PER_ELEMENT: usize>(
-    ke: &mut [[F; DOF_PER_ELEMENT]; DOF_PER_ELEMENT],
-    d: &[[F; 4]; 4],
-    b: &[[F; DOF_PER_ELEMENT]; 4],
-    scale: F,
+pub fn accumulate_stiffness<const DOF_PER_ELEMENT: usize>(
+    ke: &mut [[f64; DOF_PER_ELEMENT]; DOF_PER_ELEMENT],
+    d: &[[f64; 4]; 4],
+    b: &[[f64; DOF_PER_ELEMENT]; 4],
+    scale: f64,
 ) {
     let db = constitutive_times_b(d, b);
 
     for row in 0..DOF_PER_ELEMENT {
         for col in 0..DOF_PER_ELEMENT {
-            let mut value = F::zero();
+            let mut value = 0.0;
             for k in 0..4 {
                 value = value + b[k][row] * db[k][col];
             }
@@ -152,14 +142,14 @@ pub fn accumulate_stiffness<F: Real, const DOF_PER_ELEMENT: usize>(
 /// This is the local matrix-free application of the elastic stress-strain law used in both
 /// stiffness assembly and stress recovery.  `D` is the per-material `4 x 4` constitutive matrix;
 /// it is not assembled into any larger global matrix.
-pub fn constitutive_times_b<F: Real, const DOF_PER_ELEMENT: usize>(
-    d: &[[F; 4]; 4],
-    b: &[[F; DOF_PER_ELEMENT]; 4],
-) -> [[F; DOF_PER_ELEMENT]; 4] {
-    let mut db = [[F::zero(); DOF_PER_ELEMENT]; 4];
+pub fn constitutive_times_b<const DOF_PER_ELEMENT: usize>(
+    d: &[[f64; 4]; 4],
+    b: &[[f64; DOF_PER_ELEMENT]; 4],
+) -> [[f64; DOF_PER_ELEMENT]; 4] {
+    let mut db = [[0.0; DOF_PER_ELEMENT]; 4];
     for row in 0..4 {
         for col in 0..DOF_PER_ELEMENT {
-            let mut value = F::zero();
+            let mut value = 0.0;
             for k in 0..4 {
                 value = value + d[row][k] * b[k][col];
             }
@@ -173,10 +163,10 @@ pub fn constitutive_times_b<F: Real, const DOF_PER_ELEMENT: usize>(
 ///
 /// This is the local matrix-free application of the elastic stress-strain law used for thermal
 /// stress construction and other quadrature-point stress calculations.
-pub fn constitutive_times_strain<F: Real>(d: &[[F; 4]; 4], strain: &[F; 4]) -> [F; 4] {
-    let mut out = [F::zero(); 4];
+pub fn constitutive_times_strain(d: &[[f64; 4]; 4], strain: &[f64; 4]) -> [f64; 4] {
+    let mut out = [0.0; 4];
     for row in 0..4 {
-        let mut value = F::zero();
+        let mut value = 0.0;
         for k in 0..4 {
             value = value + d[row][k] * strain[k];
         }
@@ -186,14 +176,14 @@ pub fn constitutive_times_strain<F: Real>(d: &[[F; 4]; 4], strain: &[F; 4]) -> [
 }
 
 /// Accumulate `scale * B^T sigma` into one element load vector.
-pub fn accumulate_b_transpose_vector<F: Real, const DOF_PER_ELEMENT: usize>(
-    fe: &mut [F; DOF_PER_ELEMENT],
-    b: &[[F; DOF_PER_ELEMENT]; 4],
-    sigma: &[F; 4],
-    scale: F,
+pub fn accumulate_b_transpose_vector<const DOF_PER_ELEMENT: usize>(
+    fe: &mut [f64; DOF_PER_ELEMENT],
+    b: &[[f64; DOF_PER_ELEMENT]; 4],
+    sigma: &[f64; 4],
+    scale: f64,
 ) {
     for dof in 0..DOF_PER_ELEMENT {
-        let mut value = F::zero();
+        let mut value = 0.0;
         for component in 0..4 {
             value = value + b[component][dof] * sigma[component];
         }

--- a/src/physics/solenoid_stress/convenience.rs
+++ b/src/physics/solenoid_stress/convenience.rs
@@ -143,14 +143,13 @@ pub struct ElevatedQuad9Mesh {
 ///     Elastic stress-strain matrix with shape `(4, 4)` in component order
 ///     `[rr, zz, tt, rz]`. Units are `[stress / strain] = [pressure]`.
 pub fn isotropic_axisymmetric_material(youngs_modulus: f64, poisson_ratio: f64) -> [[f64; 4]; 4] {
-    let two = 2.0;
     let lam =
-        youngs_modulus * poisson_ratio / ((1.0 + poisson_ratio) * (1.0 - two * poisson_ratio));
-    let mu = youngs_modulus / (two * (1.0 + poisson_ratio));
+        youngs_modulus * poisson_ratio / ((1.0 + poisson_ratio) * (1.0 - 2.0 * poisson_ratio));
+    let mu = youngs_modulus / (2.0 * (1.0 + poisson_ratio));
     [
-        [lam + two * mu, lam, lam, 0.0],
-        [lam, lam + two * mu, lam, 0.0],
-        [lam, lam, lam + two * mu, 0.0],
+        [lam + 2.0 * mu, lam, lam, 0.0],
+        [lam, lam + 2.0 * mu, lam, 0.0],
+        [lam, lam, lam + 2.0 * mu, 0.0],
         [0.0, 0.0, 0.0, mu],
     ]
 }
@@ -213,19 +212,18 @@ pub fn rotate_material_in_plane(material: &[[f64; 4]; 4], angle: f64) -> [[f64; 
     let c2 = c * c;
     let s2 = s * s;
     let cs = c * s;
-    let two = 2.0;
 
     // local_strain = strain_to_local * global_strain
     let strain_to_local = [
         [c2, s2, 0.0, cs],
         [s2, c2, 0.0, -cs],
         [0.0, 0.0, 1.0, 0.0],
-        [-two * cs, two * cs, 0.0, c2 - s2],
+        [-2.0 * cs, 2.0 * cs, 0.0, c2 - s2],
     ];
     // global_stress = stress_to_global * local_stress
     let stress_to_global = [
-        [c2, s2, 0.0, -two * cs],
-        [s2, c2, 0.0, two * cs],
+        [c2, s2, 0.0, -2.0 * cs],
+        [s2, c2, 0.0, 2.0 * cs],
         [0.0, 0.0, 1.0, 0.0],
         [cs, -cs, 0.0, c2 - s2],
     ];
@@ -267,12 +265,11 @@ pub fn rotate_thermal_expansion_in_plane(alpha: &[f64; 4], angle: f64) -> [f64; 
     let c2 = c * c;
     let s2 = s * s;
     let cs = c * s;
-    let two = 2.0;
     [
         c2 * alpha[0] + s2 * alpha[1] - cs * alpha[3],
         s2 * alpha[0] + c2 * alpha[1] + cs * alpha[3],
         alpha[2],
-        two * cs * alpha[0] - two * cs * alpha[1] + (c2 - s2) * alpha[3],
+        2.0 * cs * alpha[0] - 2.0 * cs * alpha[1] + (c2 - s2) * alpha[3],
     ]
 }
 
@@ -375,10 +372,9 @@ pub fn infer_quad9_mesh(
             analysis_elements[element_index][4 + local_edge] = midpoint_index;
         }
 
-        let quarter = 0.25;
         let center = [
-            quarter * (coords[0][0] + coords[1][0] + coords[2][0] + coords[3][0]),
-            quarter * (coords[0][1] + coords[1][1] + coords[2][1] + coords[3][1]),
+            0.25 * (coords[0][0] + coords[1][0] + coords[2][0] + coords[3][0]),
+            0.25 * (coords[0][1] + coords[1][1] + coords[2][1] + coords[3][1]),
         ];
         let center_index = analysis_nodes.len();
         analysis_nodes.push(center);

--- a/src/physics/solenoid_stress/convenience.rs
+++ b/src/physics/solenoid_stress/convenience.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use crate::mesh::elements::quad2d::quad4;
-use crate::physics::solenoid_stress::types::{Real, ThermalMaterial, cast};
+use crate::physics::solenoid_stress::types::ThermalMaterial;
 
 /// Per-element quadrature data in element-major flattened form.
 ///
@@ -16,22 +16,22 @@ use crate::physics::solenoid_stress::types::{Real, ThermalMaterial, cast};
 /// `weights_area` and `weights_volume` have flattened shape `(nelem * nq_per_element,)`, and
 /// `nq_per_element` gives the number of consecutive quadrature entries belonging to each element.
 #[derive(Debug, Clone)]
-pub struct Structural2dElementQuadrature<F: Real> {
+pub struct Structural2dElementQuadrature {
     /// Physical quadrature-point coordinates in element-major order.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 2)`.
     /// Units: `[length]`.
-    pub points: Vec<[F; 2]>,
+    pub points: Vec<[f64; 2]>,
     /// Mapped analysis-plane area weights `det(J) w` in element-major order.
     ///
     /// Flattened shape: `(nelem * nq_per_element,)`.
     /// Units: `[area]`.
-    pub weights_area: Vec<F>,
+    pub weights_area: Vec<f64>,
     /// Mapped represented-volume weights in element-major order.
     ///
     /// Flattened shape: `(nelem * nq_per_element,)`.
     /// Units: `[volume]`.
-    pub weights_volume: Vec<F>,
+    pub weights_volume: Vec<f64>,
     /// Number of quadrature points contributed by each element.
     pub nq_per_element: usize,
 }
@@ -40,17 +40,17 @@ pub struct Structural2dElementQuadrature<F: Real> {
 ///
 /// Both vectors have shape `(nelem,)`.
 #[derive(Debug, Clone)]
-pub struct Structural2dElementMeasures<F: Real> {
+pub struct Structural2dElementMeasures {
     /// Analysis-plane area of each element.
     ///
     /// Shape: `(nelem,)`.
     /// Units: `[area]`.
-    pub areas: Vec<F>,
+    pub areas: Vec<f64>,
     /// Represented 3D volume for each element.
     ///
     /// Shape: `(nelem,)`.
     /// Units: `[volume]`.
-    pub volumes: Vec<F>,
+    pub volumes: Vec<f64>,
 }
 
 /// Recovered quadrature-point fields in element-major flattened form.
@@ -60,32 +60,32 @@ pub struct Structural2dElementMeasures<F: Real> {
 /// flattened shape `(nelem * nq_per_element, 4)`. `nq_per_element` records how many consecutive
 /// samples belong to each element.
 #[derive(Debug, Clone)]
-pub struct QuadratureFieldSamples<F: Real> {
+pub struct QuadratureFieldSamples {
     /// Physical quadrature-point coordinates in element-major order.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 2)`.
     /// Units: `[length]`.
-    pub points: Vec<[F; 2]>,
+    pub points: Vec<[f64; 2]>,
     /// Total strain samples `[e_rr, e_zz, e_tt, g_rz]`.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 4)`.
     /// Units: `[strain]`.
-    pub strain: Vec<[F; 4]>,
+    pub strain: Vec<[f64; 4]>,
     /// Thermal strain samples in the same ordering as `strain`.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 4)`.
     /// Units: `[strain]`.
-    pub thermal_strain: Vec<[F; 4]>,
+    pub thermal_strain: Vec<[f64; 4]>,
     /// Elastic strain samples `strain - thermal_strain`.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 4)`.
     /// Units: `[strain]`.
-    pub elastic_strain: Vec<[F; 4]>,
+    pub elastic_strain: Vec<[f64; 4]>,
     /// Stress samples `[sigma_rr, sigma_zz, sigma_tt, tau_rz]`.
     ///
     /// Flattened shape: `(nelem * nq_per_element, 4)`.
     /// Units: `[stress]`.
-    pub stress: Vec<[F; 4]>,
+    pub stress: Vec<[f64; 4]>,
     /// Number of quadrature points contributed by each element.
     pub nq_per_element: usize,
 }
@@ -96,12 +96,12 @@ pub struct QuadratureFieldSamples<F: Real> {
 /// `analysis_nodes` has shape `(n_analysis_nodes, 2)`, and `analysis_elements` has shape
 /// `(nelem, 9)`.
 #[derive(Debug, Clone)]
-pub struct ElevatedQuad9Mesh<F: Real> {
+pub struct ElevatedQuad9Mesh {
     /// Input corner-node coordinates.
     ///
     /// Shape: `(nnode, 2)`.
     /// Units: `[length]`.
-    pub input_nodes: Vec<[F; 2]>,
+    pub input_nodes: Vec<[f64; 2]>,
     /// Input quad4 connectivity.
     ///
     /// Shape: `(nelem, 4)`.
@@ -110,7 +110,7 @@ pub struct ElevatedQuad9Mesh<F: Real> {
     ///
     /// Shape: `(n_analysis_nodes, 2)`.
     /// Units: `[length]`.
-    pub analysis_nodes: Vec<[F; 2]>,
+    pub analysis_nodes: Vec<[f64; 2]>,
     /// Elevated quad9 connectivity.
     ///
     /// Shape: `(nelem, 9)`.
@@ -142,19 +142,16 @@ pub struct ElevatedQuad9Mesh<F: Real> {
 /// Returns:
 ///     Elastic stress-strain matrix with shape `(4, 4)` in component order
 ///     `[rr, zz, tt, rz]`. Units are `[stress / strain] = [pressure]`.
-pub fn isotropic_axisymmetric_material<F: Real>(
-    youngs_modulus: F,
-    poisson_ratio: F,
-) -> [[F; 4]; 4] {
-    let two = cast::<F>(2.0);
-    let lam = youngs_modulus * poisson_ratio
-        / ((F::one() + poisson_ratio) * (F::one() - two * poisson_ratio));
-    let mu = youngs_modulus / (two * (F::one() + poisson_ratio));
+pub fn isotropic_axisymmetric_material(youngs_modulus: f64, poisson_ratio: f64) -> [[f64; 4]; 4] {
+    let two = 2.0;
+    let lam =
+        youngs_modulus * poisson_ratio / ((1.0 + poisson_ratio) * (1.0 - two * poisson_ratio));
+    let mu = youngs_modulus / (two * (1.0 + poisson_ratio));
     [
-        [lam + two * mu, lam, lam, F::zero()],
-        [lam, lam + two * mu, lam, F::zero()],
-        [lam, lam, lam + two * mu, F::zero()],
-        [F::zero(), F::zero(), F::zero(), mu],
+        [lam + two * mu, lam, lam, 0.0],
+        [lam, lam + two * mu, lam, 0.0],
+        [lam, lam, lam + two * mu, 0.0],
+        [0.0, 0.0, 0.0, mu],
     ]
 }
 
@@ -168,12 +165,12 @@ pub fn isotropic_axisymmetric_material<F: Real>(
 ///     Thermal material data with row shape `(5,)`, stored as
 ///     `[alpha_r, alpha_z, alpha_t, alpha_rz, T_ref]`. The first four entries have units
 ///     `[strain / temperature]`; `T_ref` has units `[temperature]`.
-pub fn isotropic_axisymmetric_thermal_material<F: Real>(
-    alpha: F,
-    reference_temperature: F,
-) -> ThermalMaterial<F> {
+pub fn isotropic_axisymmetric_thermal_material(
+    alpha: f64,
+    reference_temperature: f64,
+) -> ThermalMaterial {
     ThermalMaterial {
-        alpha: [alpha, alpha, alpha, F::zero()],
+        alpha: [alpha, alpha, alpha, 0.0],
         reference_temperature,
     }
 }
@@ -190,14 +187,14 @@ pub fn isotropic_axisymmetric_thermal_material<F: Real>(
 ///     Thermal material data with row shape `(5,)`, stored as
 ///     `[alpha_r, alpha_z, alpha_t, alpha_rz, T_ref]`. The first four entries have units
 ///     `[strain / temperature]`; `T_ref` has units `[temperature]`.
-pub fn orthotropic_axisymmetric_thermal_material<F: Real>(
-    alpha_r: F,
-    alpha_z: F,
-    alpha_t: F,
-    reference_temperature: F,
-) -> ThermalMaterial<F> {
+pub fn orthotropic_axisymmetric_thermal_material(
+    alpha_r: f64,
+    alpha_z: f64,
+    alpha_t: f64,
+    reference_temperature: f64,
+) -> ThermalMaterial {
     ThermalMaterial {
-        alpha: [alpha_r, alpha_z, alpha_t, F::zero()],
+        alpha: [alpha_r, alpha_z, alpha_t, 0.0],
         reference_temperature,
     }
 }
@@ -207,8 +204,8 @@ pub fn orthotropic_axisymmetric_thermal_material<F: Real>(
 /// The local component order is `[11, 22, 33, 12]`.  The returned global matrix is expressed in
 /// `[rr, zz, tt, rz]` for axisymmetric use or `[xx, yy, zz, xy]` for plane-strain use.  The angle
 /// is measured from global axis 0 to local material axis 1.
-pub fn rotate_material_in_plane<F: Real>(material: &[[F; 4]; 4], angle: F) -> [[F; 4]; 4] {
-    if angle == F::zero() {
+pub fn rotate_material_in_plane(material: &[[f64; 4]; 4], angle: f64) -> [[f64; 4]; 4] {
+    if angle == 0.0 {
         return *material;
     }
     let c = angle.cos();
@@ -216,27 +213,27 @@ pub fn rotate_material_in_plane<F: Real>(material: &[[F; 4]; 4], angle: F) -> [[
     let c2 = c * c;
     let s2 = s * s;
     let cs = c * s;
-    let two = cast::<F>(2.0);
+    let two = 2.0;
 
     // local_strain = strain_to_local * global_strain
     let strain_to_local = [
-        [c2, s2, F::zero(), cs],
-        [s2, c2, F::zero(), -cs],
-        [F::zero(), F::zero(), F::one(), F::zero()],
-        [-two * cs, two * cs, F::zero(), c2 - s2],
+        [c2, s2, 0.0, cs],
+        [s2, c2, 0.0, -cs],
+        [0.0, 0.0, 1.0, 0.0],
+        [-two * cs, two * cs, 0.0, c2 - s2],
     ];
     // global_stress = stress_to_global * local_stress
     let stress_to_global = [
-        [c2, s2, F::zero(), -two * cs],
-        [s2, c2, F::zero(), two * cs],
-        [F::zero(), F::zero(), F::one(), F::zero()],
-        [cs, -cs, F::zero(), c2 - s2],
+        [c2, s2, 0.0, -two * cs],
+        [s2, c2, 0.0, two * cs],
+        [0.0, 0.0, 1.0, 0.0],
+        [cs, -cs, 0.0, c2 - s2],
     ];
 
-    let mut local_times_strain = [[F::zero(); 4]; 4];
+    let mut local_times_strain = [[0.0; 4]; 4];
     for row in 0..4 {
         for col in 0..4 {
-            let mut value = F::zero();
+            let mut value = 0.0;
             for (k, strain_row) in strain_to_local.iter().enumerate() {
                 value = value + material[row][k] * strain_row[col];
             }
@@ -244,10 +241,10 @@ pub fn rotate_material_in_plane<F: Real>(material: &[[F; 4]; 4], angle: F) -> [[
         }
     }
 
-    let mut rotated = [[F::zero(); 4]; 4];
+    let mut rotated = [[0.0; 4]; 4];
     for row in 0..4 {
         for col in 0..4 {
-            let mut value = F::zero();
+            let mut value = 0.0;
             for (k, local_row) in local_times_strain.iter().enumerate() {
                 value = value + stress_to_global[row][k] * local_row[col];
             }
@@ -261,8 +258,8 @@ pub fn rotate_material_in_plane<F: Real>(material: &[[F; 4]; 4], angle: F) -> [[
 ///
 /// The local input order is `[alpha_1, alpha_2, alpha_3, alpha_12]`; the returned vector is in the
 /// global four-component order for the active 2D formulation.
-pub fn rotate_thermal_expansion_in_plane<F: Real>(alpha: &[F; 4], angle: F) -> [F; 4] {
-    if angle == F::zero() {
+pub fn rotate_thermal_expansion_in_plane(alpha: &[f64; 4], angle: f64) -> [f64; 4] {
+    if angle == 0.0 {
         return *alpha;
     }
     let c = angle.cos();
@@ -270,7 +267,7 @@ pub fn rotate_thermal_expansion_in_plane<F: Real>(alpha: &[F; 4], angle: F) -> [
     let c2 = c * c;
     let s2 = s * s;
     let cs = c * s;
-    let two = cast::<F>(2.0);
+    let two = 2.0;
     [
         c2 * alpha[0] + s2 * alpha[1] - cs * alpha[3],
         s2 * alpha[0] + c2 * alpha[1] + cs * alpha[3],
@@ -283,10 +280,7 @@ pub fn rotate_thermal_expansion_in_plane<F: Real>(alpha: &[F; 4], angle: F) -> [
 ///
 /// The expansion coefficients are transformed with the same engineering-shear convention used by
 /// [`rotate_thermal_expansion_in_plane`], while the reference temperature is unchanged.
-pub fn rotate_thermal_material_in_plane<F: Real>(
-    thermal: &ThermalMaterial<F>,
-    angle: F,
-) -> ThermalMaterial<F> {
+pub fn rotate_thermal_material_in_plane(thermal: &ThermalMaterial, angle: f64) -> ThermalMaterial {
     ThermalMaterial {
         alpha: rotate_thermal_expansion_in_plane(&thermal.alpha, angle),
         reference_temperature: thermal.reference_temperature,
@@ -302,14 +296,14 @@ pub fn rotate_thermal_material_in_plane<F: Real>(
 /// Returns:
 ///     Elastic stress-strain matrix with shape `(4, 4)` in component order
 ///     `[rr, zz, tt, rz]`. Units are `[stress / strain] = [pressure]`.
-pub fn cfsem_radial_material<F: Real>(youngs_modulus: F, poisson_ratio: F) -> [[F; 4]; 4] {
-    let factor = youngs_modulus / (F::one() - poisson_ratio * poisson_ratio);
-    let shear = youngs_modulus / (cast::<F>(2.0) * (F::one() + poisson_ratio));
+pub fn cfsem_radial_material(youngs_modulus: f64, poisson_ratio: f64) -> [[f64; 4]; 4] {
+    let factor = youngs_modulus / (1.0 - poisson_ratio * poisson_ratio);
+    let shear = youngs_modulus / (2.0 * (1.0 + poisson_ratio));
     [
-        [factor, F::zero(), factor * poisson_ratio, F::zero()],
-        [F::zero(), youngs_modulus, F::zero(), F::zero()],
-        [factor * poisson_ratio, F::zero(), factor, F::zero()],
-        [F::zero(), F::zero(), F::zero(), shear],
+        [factor, 0.0, factor * poisson_ratio, 0.0],
+        [0.0, youngs_modulus, 0.0, 0.0],
+        [factor * poisson_ratio, 0.0, factor, 0.0],
+        [0.0, 0.0, 0.0, shear],
     ]
 }
 
@@ -333,10 +327,10 @@ pub fn cfsem_radial_material<F: Real>(youngs_modulus: F, poisson_ratio: F) -> [[
 ///     - `analysis_elements` shape `(nelem, 9)`
 ///     - `corner_node_indices`, `midside_node_indices`, and `center_node_indices` as
 ///       one-dimensional index vectors.
-pub fn infer_quad9_mesh<F: Real>(
-    nodes_rz: &[[F; 2]],
+pub fn infer_quad9_mesh(
+    nodes_rz: &[[f64; 2]],
     elements: &[[usize; 4]],
-) -> Result<ElevatedQuad9Mesh<F>, String> {
+) -> Result<ElevatedQuad9Mesh, String> {
     let node_count = nodes_rz.len();
     for (element_index, conn) in elements.iter().enumerate() {
         for &node in conn {
@@ -369,8 +363,8 @@ pub fn infer_quad9_mesh<F: Real>(
                 index
             } else {
                 let midpoint = [
-                    cast::<F>(0.5) * (coords[local_a][0] + coords[local_b][0]),
-                    cast::<F>(0.5) * (coords[local_a][1] + coords[local_b][1]),
+                    0.5 * (coords[local_a][0] + coords[local_b][0]),
+                    0.5 * (coords[local_a][1] + coords[local_b][1]),
                 ];
                 let index = analysis_nodes.len();
                 analysis_nodes.push(midpoint);
@@ -381,7 +375,7 @@ pub fn infer_quad9_mesh<F: Real>(
             analysis_elements[element_index][4 + local_edge] = midpoint_index;
         }
 
-        let quarter = cast::<F>(0.25);
+        let quarter = 0.25;
         let center = [
             quarter * (coords[0][0] + coords[1][0] + coords[2][0] + coords[3][0]),
             quarter * (coords[0][1] + coords[1][1] + coords[2][1] + coords[3][1]),

--- a/src/physics/solenoid_stress/family.rs
+++ b/src/physics/solenoid_stress/family.rs
@@ -5,7 +5,6 @@ use crate::mesh::quad2d::{Quad4ReferenceElement, Quad9ReferenceElement, QuadRefe
 use crate::mesh::{QuadratureRule, sampling};
 use crate::physics::solenoid_stress::geometry::{FaceSample, VolumeSample};
 use crate::physics::solenoid_stress::model::Structural2dElementType;
-use crate::physics::solenoid_stress::types::Real;
 
 /// Family-specific differences that remain after stiffness, load, and recovery assembly have been
 /// written once generically.
@@ -32,17 +31,17 @@ pub(crate) trait QuadElementFamily<const NODES_PER_ELEMENT: usize> {
     }
 
     /// Evaluate the family-specific volume quadrature samples for one element.
-    fn volume_samples<F: Real>(
-        coords: &[[F; 2]; NODES_PER_ELEMENT],
+    fn volume_samples(
+        coords: &[[f64; 2]; NODES_PER_ELEMENT],
         quadrature: QuadratureRule,
-    ) -> Result<Vec<VolumeSample<F, NODES_PER_ELEMENT>>, String>;
+    ) -> Result<Vec<VolumeSample<f64, NODES_PER_ELEMENT>>, String>;
 
     /// Evaluate the family-specific face quadrature samples for one element face.
-    fn face_samples<F: Real>(
-        coords: &[[F; 2]; NODES_PER_ELEMENT],
+    fn face_samples(
+        coords: &[[f64; 2]; NODES_PER_ELEMENT],
         local_face: u8,
         quadrature: QuadratureRule,
-    ) -> Result<Vec<FaceSample<F, NODES_PER_ELEMENT>>, String>;
+    ) -> Result<Vec<FaceSample<f64, NODES_PER_ELEMENT>>, String>;
 }
 
 /// Marker type for the bilinear four-node quadrilateral family.
@@ -57,19 +56,19 @@ impl QuadElementFamily<{ quad4::NODES_PER_ELEMENT }> for Quad4Family {
     }
 
     /// Delegate `quad4` volume sampling to the generic mesh sampling layer.
-    fn volume_samples<F: Real>(
-        coords: &[[F; 2]; quad4::NODES_PER_ELEMENT],
+    fn volume_samples(
+        coords: &[[f64; 2]; quad4::NODES_PER_ELEMENT],
         quadrature: QuadratureRule,
-    ) -> Result<Vec<VolumeSample<F, { quad4::NODES_PER_ELEMENT }>>, String> {
+    ) -> Result<Vec<VolumeSample<f64, { quad4::NODES_PER_ELEMENT }>>, String> {
         sampling::volume_samples_quad4(coords, quadrature)
     }
 
     /// Delegate `quad4` face sampling to the generic mesh sampling layer.
-    fn face_samples<F: Real>(
-        coords: &[[F; 2]; quad4::NODES_PER_ELEMENT],
+    fn face_samples(
+        coords: &[[f64; 2]; quad4::NODES_PER_ELEMENT],
         local_face: u8,
         quadrature: QuadratureRule,
-    ) -> Result<Vec<FaceSample<F, { quad4::NODES_PER_ELEMENT }>>, String> {
+    ) -> Result<Vec<FaceSample<f64, { quad4::NODES_PER_ELEMENT }>>, String> {
         sampling::face_samples_quad4(coords, local_face, quadrature)
     }
 }
@@ -86,19 +85,19 @@ impl QuadElementFamily<{ quad9::NODES_PER_ELEMENT }> for Quad9Family {
     }
 
     /// Delegate `quad9` volume sampling to the generic mesh sampling layer.
-    fn volume_samples<F: Real>(
-        coords: &[[F; 2]; quad9::NODES_PER_ELEMENT],
+    fn volume_samples(
+        coords: &[[f64; 2]; quad9::NODES_PER_ELEMENT],
         quadrature: QuadratureRule,
-    ) -> Result<Vec<VolumeSample<F, { quad9::NODES_PER_ELEMENT }>>, String> {
+    ) -> Result<Vec<VolumeSample<f64, { quad9::NODES_PER_ELEMENT }>>, String> {
         sampling::volume_samples_quad9(coords, quadrature)
     }
 
     /// Delegate `quad9` face sampling to the generic mesh sampling layer.
-    fn face_samples<F: Real>(
-        coords: &[[F; 2]; quad9::NODES_PER_ELEMENT],
+    fn face_samples(
+        coords: &[[f64; 2]; quad9::NODES_PER_ELEMENT],
         local_face: u8,
         quadrature: QuadratureRule,
-    ) -> Result<Vec<FaceSample<F, { quad9::NODES_PER_ELEMENT }>>, String> {
+    ) -> Result<Vec<FaceSample<f64, { quad9::NODES_PER_ELEMENT }>>, String> {
         sampling::face_samples_quad9(coords, local_face, quadrature)
     }
 }

--- a/src/physics/solenoid_stress/geometry.rs
+++ b/src/physics/solenoid_stress/geometry.rs
@@ -5,16 +5,16 @@
 //! needed by the structural solver.
 
 use crate::mesh::QuadMeshView2d;
-use crate::physics::solenoid_stress::types::{Real, Structural2dFormulation};
+use crate::physics::solenoid_stress::types::Structural2dFormulation;
 
 pub use crate::mesh::{FaceSample, VolumeSample};
 
 /// Validate that every node radius is admissible for an axisymmetric structural mesh.
-pub(crate) fn validate_axisymmetric_nodes<F: Real, const NODES_PER_ELEMENT: usize>(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+pub(crate) fn validate_axisymmetric_nodes<const NODES_PER_ELEMENT: usize>(
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
 ) -> Result<(), String> {
     for (index, node) in mesh.nodes_rz.iter().enumerate() {
-        if node[0] < F::zero() {
+        if node[0] < 0.0 {
             return Err(format!(
                 "node {index} has negative radius {:?}; axisymmetric radius must be nonnegative",
                 node[0]
@@ -25,22 +25,22 @@ pub(crate) fn validate_axisymmetric_nodes<F: Real, const NODES_PER_ELEMENT: usiz
 }
 
 /// Validate mesh connectivity and the axisymmetric radius constraint together.
-pub(crate) fn validate_axisymmetric_mesh<F: Real, const NODES_PER_ELEMENT: usize>(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+pub(crate) fn validate_axisymmetric_mesh<const NODES_PER_ELEMENT: usize>(
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
 ) -> Result<(), String> {
     validate_axisymmetric_nodes(mesh)?;
     mesh.validate_connectivity()
 }
 
 /// Validate mesh connectivity and formulation-specific coordinate constraints.
-pub(crate) fn validate_structural_2d_mesh<F: Real, const NODES_PER_ELEMENT: usize>(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
-    formulation: Structural2dFormulation<F>,
+pub(crate) fn validate_structural_2d_mesh<const NODES_PER_ELEMENT: usize>(
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
+    formulation: Structural2dFormulation,
 ) -> Result<(), String> {
     match formulation {
         Structural2dFormulation::Axisymmetric => validate_axisymmetric_mesh(mesh),
         Structural2dFormulation::PlaneStrain { thickness } => {
-            if thickness <= F::zero() {
+            if thickness <= 0.0 {
                 return Err(format!(
                     "plane-strain thickness must be positive; got {thickness:?}"
                 ));

--- a/src/physics/solenoid_stress/loads/body_force.rs
+++ b/src/physics/solenoid_stress/loads/body_force.rs
@@ -2,7 +2,7 @@ use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, local_dofs, scatter_local_matrix,
+    DOF_PER_NODE, Structural2dFormulation, local_dofs, scatter_local_matrix,
 };
 
 use super::{SparseOperator, collect_sparse_operator_chunks, concat_sparse_operators};
@@ -17,18 +17,14 @@ use super::{SparseOperator, collect_sparse_operator_chunks, concat_sparse_operat
 /// `[energy / distance]`, which is force-like in the virtual-work sense.
 ///
 /// Each block entry therefore has units of volume.
-fn body_force_element_kernel<
-    F: Real,
-    const NODES_PER_ELEMENT: usize,
-    const DOF_PER_ELEMENT: usize,
->(
-    samples: &[VolumeSample<F, NODES_PER_ELEMENT>],
-    formulation: Structural2dFormulation<F>,
-) -> Result<[[F; 2]; DOF_PER_ELEMENT], String> {
+fn body_force_element_kernel<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    samples: &[VolumeSample<f64, NODES_PER_ELEMENT>],
+    formulation: Structural2dFormulation,
+) -> Result<[[f64; 2]; DOF_PER_ELEMENT], String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    let mut local = [[F::zero(); 2]; DOF_PER_ELEMENT];
+    let mut local = [[0.0; 2]; DOF_PER_ELEMENT];
 
     for sample in samples {
         let scale = formulation.volume_scale(sample.point, sample.det_j, sample.weight)?;
@@ -57,15 +53,14 @@ fn body_force_element_kernel<
 ///
 /// Entry units: `[volume]`.
 pub(crate) fn body_force_operator_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
-    formulation: Structural2dFormulation<F>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<SparseOperator<F>, String>
+) -> Result<SparseOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -73,7 +68,7 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
-    body_force_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+    body_force_operator_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
         mesh,
         formulation,
         quadrature,
@@ -84,15 +79,14 @@ where
 
 /// Assemble the global body-force-to-RHS operator using element ranges split across Rayon workers.
 pub(crate) fn body_force_operator_for_family_par<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
-    formulation: Structural2dFormulation<F>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<SparseOperator<F>, String>
+) -> Result<SparseOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -102,7 +96,7 @@ where
     validate_structural_2d_mesh(mesh, formulation)?;
     let nelem = mesh.num_elements();
     let chunks = collect_sparse_operator_chunks(nelem, |start, end| {
-        body_force_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        body_force_operator_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             formulation,
             quadrature,
@@ -120,17 +114,16 @@ where
 }
 
 fn body_force_operator_range_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
-    formulation: Structural2dFormulation<F>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     element_start: usize,
     element_end: usize,
-) -> Result<SparseOperator<F>, String>
+) -> Result<SparseOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -144,11 +137,9 @@ where
     for element_index in element_start..element_end {
         let coords = mesh.element_coords(element_index)?;
         let nodes = mesh.element_nodes(element_index)?;
-        let samples = Family::volume_samples::<F>(&coords, quadrature)?;
-        let local = body_force_element_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-            &samples,
-            formulation,
-        )?;
+        let samples = Family::volume_samples(&coords, quadrature)?;
+        let local =
+            body_force_element_kernel::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples, formulation)?;
         let global_rows = local_dofs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&nodes);
         let global_cols = [2 * element_index, 2 * element_index + 1];
         scatter_local_matrix(

--- a/src/physics/solenoid_stress/loads/mod.rs
+++ b/src/physics/solenoid_stress/loads/mod.rs
@@ -11,7 +11,6 @@
 
 use rayon::prelude::*;
 
-use crate::physics::solenoid_stress::types::Real;
 use crate::{chunksize, ranges_for_len};
 
 mod body_force;
@@ -31,13 +30,13 @@ mod traction;
 /// - temperature operators map nodal temperatures `[temperature]` to reduced RHS entries, so their
 ///   coefficients have units `[energy / (distance * temperature)]`.
 #[derive(Debug, Clone)]
-pub struct SparseOperator<F: Real> {
+pub struct SparseOperator {
     /// Output row index for each stored triplet coefficient.
     pub rows: Vec<usize>,
     /// Input column index for each stored triplet coefficient.
     pub cols: Vec<usize>,
     /// Nonzero operator coefficients in triplet order.
-    pub vals: Vec<F>,
+    pub vals: Vec<f64>,
     /// Number of operator rows.
     pub nrow: usize,
     /// Number of operator columns.
@@ -50,22 +49,22 @@ pub struct SparseOperator<F: Real> {
 /// `f_thermal = temperature_to_rhs @ T + reference_rhs`,
 /// where `T` is the nodal temperature vector `[temperature]`.
 #[derive(Debug, Clone)]
-pub struct ThermalLoadOperator<F: Real> {
+pub struct ThermalLoadOperator {
     /// Sparse operator mapping nodal temperatures `[temperature]` to reduced RHS entries
     /// `[energy / distance]`.
-    pub temperature_to_rhs: SparseOperator<F>,
+    pub temperature_to_rhs: SparseOperator,
     /// Constant reduced RHS contribution from the per-material reference temperatures.
     ///
     /// Units: `[energy / distance]`.
-    pub reference_rhs: Vec<F>,
+    pub reference_rhs: Vec<f64>,
 }
 
-fn concat_sparse_operators<F: Real>(
-    chunks: Vec<SparseOperator<F>>,
+fn concat_sparse_operators(
+    chunks: Vec<SparseOperator>,
     nrow: usize,
     ncol: usize,
     capacity: usize,
-) -> SparseOperator<F> {
+) -> SparseOperator {
     // Worker chunks are emitted in the same order as `ranges_for_len`, so appending their triplet
     // buffers preserves the serial load ordering.  Any duplicate structural rows are handled later
     // by the CSR reduction/compression code.
@@ -90,16 +89,16 @@ fn concat_sparse_operators<F: Real>(
     }
 }
 
-fn concat_thermal_load_operators<F: Real>(
-    chunks: Vec<ThermalLoadOperator<F>>,
+fn concat_thermal_load_operators(
+    chunks: Vec<ThermalLoadOperator>,
     ndof: usize,
     ncol: usize,
     capacity: usize,
-) -> ThermalLoadOperator<F> {
+) -> ThermalLoadOperator {
     // Thermal loads have one sparse temperature operator plus a dense reference-temperature RHS.
     // The sparse part can be concatenated like other loads; the dense offsets must be summed over
     // all worker chunks because every element contributes to the same global RHS vector.
-    let mut reference_rhs = vec![F::zero(); ndof];
+    let mut reference_rhs = vec![0.0; ndof];
     let sparse_chunks = chunks
         .into_iter()
         .map(|chunk| {
@@ -116,10 +115,10 @@ fn concat_thermal_load_operators<F: Real>(
     }
 }
 
-fn collect_sparse_operator_chunks<F: Real>(
+fn collect_sparse_operator_chunks(
     len: usize,
-    build: impl Fn(usize, usize) -> Result<SparseOperator<F>, String> + Sync,
-) -> Result<Vec<SparseOperator<F>>, String> {
+    build: impl Fn(usize, usize) -> Result<SparseOperator, String> + Sync,
+) -> Result<Vec<SparseOperator>, String> {
     // Parallel wrappers differ only in the unit of work they split over: elements for body force
     // and thermal loads, boundary load records for pressure and traction.
     ranges_for_len(len, chunksize(len))
@@ -128,10 +127,10 @@ fn collect_sparse_operator_chunks<F: Real>(
         .collect()
 }
 
-fn collect_thermal_load_operator_chunks<F: Real>(
+fn collect_thermal_load_operator_chunks(
     len: usize,
-    build: impl Fn(usize, usize) -> Result<ThermalLoadOperator<F>, String> + Sync,
-) -> Result<Vec<ThermalLoadOperator<F>>, String> {
+    build: impl Fn(usize, usize) -> Result<ThermalLoadOperator, String> + Sync,
+) -> Result<Vec<ThermalLoadOperator>, String> {
     // Keep thermal chunks typed separately so the reference-temperature RHS cannot be accidentally
     // discarded by a generic sparse-only collector.
     ranges_for_len(len, chunksize(len))

--- a/src/physics/solenoid_stress/loads/pressure.rs
+++ b/src/physics/solenoid_stress/loads/pressure.rs
@@ -2,7 +2,7 @@ use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, PressureLoad, Real, Structural2dFormulation, local_dofs, scatter_local_vector,
+    DOF_PER_NODE, PressureLoad, Structural2dFormulation, local_dofs, scatter_local_vector,
 };
 
 use super::{SparseOperator, collect_sparse_operator_chunks, concat_sparse_operators};
@@ -14,20 +14,20 @@ use super::{SparseOperator, collect_sparse_operator_chunks, concat_sparse_operat
 /// `[energy / distance]`.
 ///
 /// Each vector entry therefore has units of area.
-fn pressure_face_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
-    samples: &[FaceSample<F, NODES_PER_ELEMENT>],
-    formulation: Structural2dFormulation<F>,
-) -> Result<[F; DOF_PER_ELEMENT], String> {
+fn pressure_face_kernel<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    samples: &[FaceSample<f64, NODES_PER_ELEMENT>],
+    formulation: Structural2dFormulation,
+) -> Result<[f64; DOF_PER_ELEMENT], String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    let mut local = [F::zero(); DOF_PER_ELEMENT];
+    let mut local = [0.0; DOF_PER_ELEMENT];
 
     for sample in samples {
         // Rotating the physical tangent gives `n * |dx/ds|`, so the line Jacobian is already
         // embedded in `normal_area`.
         let normal_area = [sample.tangent[1], -sample.tangent[0]];
-        let scale = -formulation.face_scale(sample.point, F::one(), sample.weight)?;
+        let scale = -formulation.face_scale(sample.point, 1.0, sample.weight)?;
         for local_node in 0..NODES_PER_ELEMENT {
             local[2 * local_node] =
                 local[2 * local_node] + scale * sample.n[local_node] * normal_area[0];
@@ -52,16 +52,15 @@ fn pressure_face_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_E
 ///
 /// Entry units: `[area]`.
 pub(crate) fn pressure_operator_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     pressure_faces: &[PressureLoad],
-    formulation: Structural2dFormulation<F>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<SparseOperator<F>, String>
+) -> Result<SparseOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -69,7 +68,7 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
-    pressure_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+    pressure_operator_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
         mesh,
         pressure_faces,
         formulation,
@@ -81,16 +80,15 @@ where
 
 /// Assemble pressure loads using pressure-face ranges split across Rayon workers.
 pub(crate) fn pressure_operator_for_family_par<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     pressure_faces: &[PressureLoad],
-    formulation: Structural2dFormulation<F>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<SparseOperator<F>, String>
+) -> Result<SparseOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -99,7 +97,7 @@ where
     }
     validate_structural_2d_mesh(mesh, formulation)?;
     let chunks = collect_sparse_operator_chunks(pressure_faces.len(), |start, end| {
-        pressure_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        pressure_operator_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             pressure_faces,
             formulation,
@@ -118,18 +116,17 @@ where
 }
 
 fn pressure_operator_range_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     pressure_faces: &[PressureLoad],
-    formulation: Structural2dFormulation<F>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     load_start: usize,
     load_end: usize,
-) -> Result<SparseOperator<F>, String>
+) -> Result<SparseOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -155,9 +152,9 @@ where
         }
         let coords = mesh.element_coords(load.element)?;
         let nodes = mesh.element_nodes(load.element)?;
-        let samples = Family::face_samples::<F>(&coords, load.local_face, quadrature)?;
+        let samples = Family::face_samples(&coords, load.local_face, quadrature)?;
         let local =
-            pressure_face_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples, formulation)?;
+            pressure_face_kernel::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples, formulation)?;
         let global_rows = local_dofs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&nodes);
         scatter_local_vector(
             &mut rows,

--- a/src/physics/solenoid_stress/loads/thermal.rs
+++ b/src/physics/solenoid_stress/loads/thermal.rs
@@ -8,7 +8,7 @@ use crate::physics::solenoid_stress::convenience::{
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, local_dofs, scatter_local_matrix,
+    DOF_PER_NODE, Structural2dFormulation, ThermalMaterial, local_dofs, scatter_local_matrix,
     validate_element_material_inputs,
 };
 
@@ -25,9 +25,9 @@ use super::{
 ///
 /// `reference_rhs` is the constant offset contributed by the material's stress-free reference
 /// temperature and has units `[energy / distance]`.
-struct LocalThermalKernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize> {
-    temperature_to_rhs: [[F; NODES_PER_ELEMENT]; DOF_PER_ELEMENT],
-    reference_rhs: [F; DOF_PER_ELEMENT],
+struct LocalThermalKernel<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize> {
+    temperature_to_rhs: [[f64; NODES_PER_ELEMENT]; DOF_PER_ELEMENT],
+    reference_rhs: [f64; DOF_PER_ELEMENT],
 }
 
 /// Build the local dense thermal load operator for one element.
@@ -36,18 +36,18 @@ struct LocalThermalKernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER
 /// `epsilon_th = alpha * (T - T_ref)`,
 /// where `alpha` has units `[strain / temperature]`.  The returned block therefore maps nodal
 /// temperatures directly to generalized nodal loads.
-fn thermal_element_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
-    samples: &[VolumeSample<F, NODES_PER_ELEMENT>],
-    material: &[[F; 4]; 4],
-    thermal: &ThermalMaterial<F>,
-    formulation: Structural2dFormulation<F>,
-) -> Result<LocalThermalKernel<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>, String> {
+fn thermal_element_kernel<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    samples: &[VolumeSample<f64, NODES_PER_ELEMENT>],
+    material: &[[f64; 4]; 4],
+    thermal: &ThermalMaterial,
+    formulation: Structural2dFormulation,
+) -> Result<LocalThermalKernel<NODES_PER_ELEMENT, DOF_PER_ELEMENT>, String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     let mut local = LocalThermalKernel {
-        temperature_to_rhs: [[F::zero(); NODES_PER_ELEMENT]; DOF_PER_ELEMENT],
-        reference_rhs: [F::zero(); DOF_PER_ELEMENT],
+        temperature_to_rhs: [[0.0; NODES_PER_ELEMENT]; DOF_PER_ELEMENT],
+        reference_rhs: [0.0; DOF_PER_ELEMENT],
     };
     let thermal_stress_unit = constitutive_times_strain(material, &thermal.alpha);
 
@@ -55,14 +55,14 @@ fn thermal_element_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER
         // `B` has units `[1 / length]`, `D * alpha` has units `[stress / temperature]`, and the
         // quadrature scale contributes a physical volume. The resulting local block has units
         // `[force / temperature]`.
-        let b = build_b_matrix::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        let b = build_b_matrix::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             formulation,
             &sample.n,
             &sample.grad_phys,
             sample.point,
         )?;
         let scale = formulation.volume_scale(sample.point, sample.det_j, sample.weight)?;
-        let mut local_unit_rhs = [F::zero(); DOF_PER_ELEMENT];
+        let mut local_unit_rhs = [0.0; DOF_PER_ELEMENT];
         accumulate_b_transpose_vector(&mut local_unit_rhs, &b, &thermal_stress_unit, scale);
 
         for local_temp_node in 0..NODES_PER_ELEMENT {
@@ -103,19 +103,18 @@ fn thermal_element_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER
 /// - `temperature_to_rhs`: `[generalized force / temperature] = [energy / (distance * temperature)]`
 /// - `reference_rhs`: `[generalized force] = [energy / distance]`
 pub(crate) fn temperature_operator_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    thermal_material_table: &[ThermalMaterial<F>],
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    thermal_material_table: &[ThermalMaterial],
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<ThermalLoadOperator<F>, String>
+) -> Result<ThermalLoadOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -128,7 +127,7 @@ where
         material_ids,
         material_orientation_angles,
     )?;
-    temperature_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+    temperature_operator_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
         mesh,
         material_ids,
         material_table,
@@ -143,19 +142,18 @@ where
 
 /// Assemble thermal load operators using element ranges split across Rayon workers.
 pub(crate) fn temperature_operator_for_family_par<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    thermal_material_table: &[ThermalMaterial<F>],
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    thermal_material_table: &[ThermalMaterial],
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<ThermalLoadOperator<F>, String>
+) -> Result<ThermalLoadOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -170,7 +168,7 @@ where
     )?;
     let nelem = mesh.num_elements();
     let chunks = collect_thermal_load_operator_chunks(nelem, |start, end| {
-        temperature_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        temperature_operator_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             material_ids,
             material_table,
@@ -193,21 +191,20 @@ where
 
 #[allow(clippy::too_many_arguments)]
 fn temperature_operator_range_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    thermal_material_table: &[ThermalMaterial<F>],
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    thermal_material_table: &[ThermalMaterial],
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     element_start: usize,
     element_end: usize,
-) -> Result<ThermalLoadOperator<F>, String>
+) -> Result<ThermalLoadOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -216,7 +213,7 @@ where
     let mut rows = Vec::new();
     let mut cols = Vec::new();
     let mut vals = Vec::new();
-    let mut reference_rhs = vec![F::zero(); ndof];
+    let mut reference_rhs = vec![0.0; ndof];
 
     for element_index in element_start..element_end {
         let coords = mesh.element_coords(element_index)?;
@@ -237,8 +234,8 @@ where
         } else {
             (material, thermal)
         };
-        let samples = Family::volume_samples::<F>(&coords, quadrature)?;
-        let local = thermal_element_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        let samples = Family::volume_samples(&coords, quadrature)?;
+        let local = thermal_element_kernel::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             &samples,
             material,
             thermal,

--- a/src/physics/solenoid_stress/loads/traction.rs
+++ b/src/physics/solenoid_stress/loads/traction.rs
@@ -2,7 +2,7 @@ use crate::mesh::{QuadMeshView2d, QuadratureRule};
 use crate::physics::solenoid_stress::family::QuadElementFamily;
 use crate::physics::solenoid_stress::geometry::{FaceSample, validate_structural_2d_mesh};
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, TractionLoad, local_dofs, scatter_local_matrix,
+    DOF_PER_NODE, Structural2dFormulation, TractionLoad, local_dofs, scatter_local_matrix,
 };
 
 use super::{SparseOperator, collect_sparse_operator_chunks, concat_sparse_operators};
@@ -17,14 +17,14 @@ use super::{SparseOperator, collect_sparse_operator_chunks, concat_sparse_operat
 /// `[energy / distance]`.
 ///
 /// Each block entry therefore has units of area.
-fn traction_face_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
-    samples: &[FaceSample<F, NODES_PER_ELEMENT>],
-    formulation: Structural2dFormulation<F>,
-) -> Result<[[F; 2]; DOF_PER_ELEMENT], String> {
+fn traction_face_kernel<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
+    samples: &[FaceSample<f64, NODES_PER_ELEMENT>],
+    formulation: Structural2dFormulation,
+) -> Result<[[f64; 2]; DOF_PER_ELEMENT], String> {
     const {
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
-    let mut local = [[F::zero(); 2]; DOF_PER_ELEMENT];
+    let mut local = [[0.0; 2]; DOF_PER_ELEMENT];
 
     for sample in samples {
         // `|dx/ds|` is the physical line Jacobian for the face quadrature parameter.
@@ -57,16 +57,15 @@ fn traction_face_kernel<F: Real, const NODES_PER_ELEMENT: usize, const DOF_PER_E
 ///
 /// Entry units: `[area]`.
 pub(crate) fn traction_operator_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     traction_faces: &[TractionLoad],
-    formulation: Structural2dFormulation<F>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<SparseOperator<F>, String>
+) -> Result<SparseOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -74,7 +73,7 @@ where
         assert!(DOF_PER_ELEMENT == DOF_PER_NODE * NODES_PER_ELEMENT);
     }
     validate_structural_2d_mesh(mesh, formulation)?;
-    traction_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+    traction_operator_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
         mesh,
         traction_faces,
         formulation,
@@ -86,16 +85,15 @@ where
 
 /// Assemble traction loads using traction-face ranges split across Rayon workers.
 pub(crate) fn traction_operator_for_family_par<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     traction_faces: &[TractionLoad],
-    formulation: Structural2dFormulation<F>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<SparseOperator<F>, String>
+) -> Result<SparseOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -104,7 +102,7 @@ where
     }
     validate_structural_2d_mesh(mesh, formulation)?;
     let chunks = collect_sparse_operator_chunks(traction_faces.len(), |start, end| {
-        traction_operator_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        traction_operator_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             traction_faces,
             formulation,
@@ -123,18 +121,17 @@ where
 }
 
 fn traction_operator_range_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     traction_faces: &[TractionLoad],
-    formulation: Structural2dFormulation<F>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     load_start: usize,
     load_end: usize,
-) -> Result<SparseOperator<F>, String>
+) -> Result<SparseOperator, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -160,9 +157,9 @@ where
         }
         let coords = mesh.element_coords(load.element)?;
         let nodes = mesh.element_nodes(load.element)?;
-        let samples = Family::face_samples::<F>(&coords, load.local_face, quadrature)?;
+        let samples = Family::face_samples(&coords, load.local_face, quadrature)?;
         let local =
-            traction_face_kernel::<F, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples, formulation)?;
+            traction_face_kernel::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&samples, formulation)?;
         let global_rows = local_dofs::<NODES_PER_ELEMENT, DOF_PER_ELEMENT>(&nodes);
         let global_cols = [2 * load_index, 2 * load_index + 1];
         scatter_local_matrix(

--- a/src/physics/solenoid_stress/mod.rs
+++ b/src/physics/solenoid_stress/mod.rs
@@ -511,6 +511,6 @@ pub use model::{
 };
 pub(crate) use types::validate_element_material_inputs;
 pub use types::{
-    DOF_PER_NODE, PressureLoad, Real, Structural2dFormulation, ThermalMaterial, TractionLoad,
+    DOF_PER_NODE, PressureLoad, Structural2dFormulation, ThermalMaterial, TractionLoad,
     dof_per_element,
 };

--- a/src/physics/solenoid_stress/model.rs
+++ b/src/physics/solenoid_stress/model.rs
@@ -31,11 +31,9 @@ use crate::physics::solenoid_stress::recovery::{
     reduced_quadrature_field_operators_for_family_par,
 };
 use crate::physics::solenoid_stress::types::{
-    PressureLoad, Real, StiffnessTriplets, Structural2dFormulation, ThermalMaterial, TractionLoad,
+    PressureLoad, StiffnessTriplets, Structural2dFormulation, ThermalMaterial, TractionLoad,
     dof_per_element,
 };
-
-type F = f64;
 
 /// Public element-family selector for the 2D structural solver.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,44 +90,44 @@ pub struct ReducedRecoveryOperators {
     ///
     /// Flattened shape: `(nelem * nq_per_element, 2)`.
     /// Units: `[length]`.
-    pub points: Vec<[F; 2]>,
+    pub points: Vec<[f64; 2]>,
     /// CSR operator mapping reduced displacements `[length]` to quadrature-point strains
     /// `[dimensionless]`.
     ///
     /// Entry units: `[strain / displacement] = [1 / length]`.
-    pub strain_operator: SparseRowMat<usize, F>,
+    pub strain_operator: SparseRowMat<usize, f64>,
     /// CSR operator mapping reduced displacements `[length]` to quadrature-point stresses.
     ///
     /// Entry units: `[stress / displacement] = [pressure / length]`.
-    pub stress_operator: SparseRowMat<usize, F>,
+    pub stress_operator: SparseRowMat<usize, f64>,
     /// CSR operator mapping nodal temperatures `[temperature]` to quadrature-point thermal strain.
     ///
     /// Entry units: `[strain / temperature]`.
-    pub thermal_strain_operator: SparseRowMat<usize, F>,
+    pub thermal_strain_operator: SparseRowMat<usize, f64>,
     /// CSR operator mapping nodal temperatures `[temperature]` to quadrature-point thermal stress.
     ///
     /// Entry units: `[stress / temperature]`.
-    pub thermal_stress_operator: SparseRowMat<usize, F>,
+    pub thermal_stress_operator: SparseRowMat<usize, f64>,
     /// Constant strain offset induced by nonzero prescribed Dirichlet values.
     ///
     /// Flattened shape: `(4 * nelem * nq_per_element,)`.
     /// Units: `[strain]`.
-    pub strain_constant: Vec<F>,
+    pub strain_constant: Vec<f64>,
     /// Constant stress offset induced by nonzero prescribed Dirichlet values.
     ///
     /// Flattened shape: `(4 * nelem * nq_per_element,)`.
     /// Units: `[stress]`.
-    pub stress_constant: Vec<F>,
+    pub stress_constant: Vec<f64>,
     /// Constant thermal-strain offset induced by per-material reference temperature.
     ///
     /// Flattened shape: `(4 * nelem * nq_per_element,)`.
     /// Units: `[strain]`.
-    pub thermal_strain_constant: Vec<F>,
+    pub thermal_strain_constant: Vec<f64>,
     /// Constant thermal-stress offset induced by per-material reference temperature.
     ///
     /// Flattened shape: `(4 * nelem * nq_per_element,)`.
     /// Units: `[stress]`.
-    pub thermal_stress_constant: Vec<F>,
+    pub thermal_stress_constant: Vec<f64>,
     /// Number of quadrature points contributed by each element.
     pub nq_per_element: usize,
     /// Number of nodal temperatures expected by the thermal recovery operators.
@@ -152,32 +150,32 @@ pub struct Structural2dModel {
     /// `[energy / distance]`.
     ///
     /// Entry units: `[generalized force / displacement] = [energy / distance^2]`.
-    pub stiffness: SparseColMat<usize, F>,
+    pub stiffness: SparseColMat<usize, f64>,
     /// Reduced RHS operator for per-element body-force density amplitudes.
     ///
     /// Shape: `(ndof_reduced, 2 * nelem)`. Columns are grouped by element as `[b_r, b_z]`.
     /// Entry units: `[volume]`.
-    pub body_force_to_rhs: SparseRowMat<usize, F>,
+    pub body_force_to_rhs: SparseRowMat<usize, f64>,
     /// Reduced RHS operator for scalar pressure amplitudes on `pressure_faces`.
     ///
     /// Shape: `(ndof_reduced, n_pressure_faces)`. One column per loaded face.
     /// Entry units: `[area]`.
-    pub pressure_to_rhs: SparseRowMat<usize, F>,
+    pub pressure_to_rhs: SparseRowMat<usize, f64>,
     /// Reduced RHS operator for vector traction amplitudes on `traction_faces`.
     ///
     /// Shape: `(ndof_reduced, 2 * n_traction_faces)`. Columns are grouped by face as `[t_r, t_z]`.
     /// Entry units: `[area]`.
-    pub traction_to_rhs: SparseRowMat<usize, F>,
+    pub traction_to_rhs: SparseRowMat<usize, f64>,
     /// Reduced RHS operator for nodal temperatures.
     ///
     /// Shape: `(ndof_reduced, n_temperature_nodes)`.
     /// Entry units: `[generalized force / temperature] = [energy / (distance * temperature)]`.
-    pub temperature_to_rhs: SparseRowMat<usize, F>,
+    pub temperature_to_rhs: SparseRowMat<usize, f64>,
     /// Constant reduced RHS contribution from prescribed displacements and thermal reference state.
     ///
     /// Shape: `(ndof_reduced,)`.
     /// Units: `[energy / distance]`.
-    pub constant_rhs: Vec<F>,
+    pub constant_rhs: Vec<f64>,
     /// Quadrature-point recovery operators and constants associated with this reduced model.
     pub recovery: ReducedRecoveryOperators,
     /// Metadata listing the loaded pressure faces as `[element_index, local_face]`.
@@ -192,7 +190,7 @@ pub struct Structural2dModel {
     ///
     /// Shape: `(n_analysis_nodes, 2)`.
     /// Units: `[length]`.
-    pub analysis_nodes: Vec<[F; 2]>,
+    pub analysis_nodes: Vec<[f64; 2]>,
     /// Flattened analysis connectivity in element-major order.
     ///
     /// Shape: `(nelem * nodes_per_element,)`.
@@ -204,7 +202,7 @@ pub struct Structural2dModel {
     /// Volume and face quadrature rule used to assemble the stored operators.
     pub quadrature: QuadratureRule,
     /// Structural 2D formulation used by the backend.
-    pub formulation: Structural2dFormulation<F>,
+    pub formulation: Structural2dFormulation,
     /// Number of displacement DOFs in the unreduced full system.
     pub ndof_full: usize,
     /// Number of displacement DOFs remaining after Dirichlet reduction.
@@ -223,8 +221,8 @@ pub struct Structural2dModel {
     ///
     /// Shape: `(n_fixed,)`.
     /// Units: `[length]`.
-    pub fixed_values: Vec<F>,
-    lu: Option<Lu<usize, F>>,
+    pub fixed_values: Vec<f64>,
+    lu: Option<Lu<usize, f64>>,
 }
 
 impl Structural2dModel {
@@ -245,11 +243,11 @@ impl Structural2dModel {
     ///     `[generalized force] = [energy / distance]`.
     pub fn build_rhs(
         &self,
-        body_force: Option<&[F]>,
-        pressure_values: Option<&[F]>,
-        traction_values: Option<&[F]>,
-        nodal_temperature: Option<&[F]>,
-    ) -> Result<Vec<F>, String> {
+        body_force: Option<&[f64]>,
+        pressure_values: Option<&[f64]>,
+        traction_values: Option<&[f64]>,
+        nodal_temperature: Option<&[f64]>,
+    ) -> Result<Vec<f64>, String> {
         let mut rhs = self.constant_rhs.clone();
         apply_csr_operator(&self.body_force_to_rhs, body_force, "body_force", &mut rhs)?;
         apply_csr_operator(
@@ -298,13 +296,13 @@ impl Structural2dModel {
     /// Returns:
     ///     Full displacement vector with shape `(ndof_full,)` and component ordering
     ///     `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
-    pub fn solve(&mut self, rhs: &[F]) -> Result<Vec<F>, String> {
+    pub fn solve(&mut self, rhs: &[f64]) -> Result<Vec<f64>, String> {
         let reduced_solution = self.solve_direct_reduced(rhs)?;
         Ok(self.recover_full(&reduced_solution))
     }
 
     /// Solve the reduced structural system with the cached sparse LU factorization.
-    fn solve_direct_reduced(&mut self, rhs: &[F]) -> Result<Vec<F>, String> {
+    fn solve_direct_reduced(&mut self, rhs: &[f64]) -> Result<Vec<f64>, String> {
         if rhs.len() != self.ndof_reduced {
             return Err(format!(
                 "rhs has length {}, but reduced system has {} rows",
@@ -323,7 +321,7 @@ impl Structural2dModel {
             );
         }
         let lu = self.lu.as_ref().expect("lu cache should be initialized");
-        let mut reduced_solution = Col::<F>::zeros(self.ndof_reduced);
+        let mut reduced_solution = Col::<f64>::zeros(self.ndof_reduced);
         for (index, value) in rhs.iter().copied().enumerate() {
             reduced_solution[index] = value;
         }
@@ -343,7 +341,7 @@ impl Structural2dModel {
     /// Returns:
     ///     Full displacement vector with shape `(ndof_full,)` and component ordering
     ///     `[u_r0, u_z0, u_r1, u_z1, ...]`. Units are `[length]`.
-    pub fn recover_full(&self, reduced_solution: &[F]) -> Vec<F> {
+    pub fn recover_full(&self, reduced_solution: &[f64]) -> Vec<f64> {
         assert!(
             reduced_solution.len() == self.ndof_reduced,
             "reduced_solution has length {}, but reduced system has {} rows",
@@ -368,10 +366,10 @@ impl Structural2dModel {
     ///     - `weights_area` length `nelem * nq_per_element` with units `[area]`
     ///     - `weights_volume` length `nelem * nq_per_element` with units `[volume]`
     ///     - `nq_per_element` giving the number of consecutive quadrature entries per element
-    pub fn element_quadrature(&self) -> Result<Structural2dElementQuadrature<F>, String> {
+    pub fn element_quadrature(&self) -> Result<Structural2dElementQuadrature, String> {
         match self.element_type {
             Structural2dElementType::Quad4 => {
-                element_quadrature_for_family::<F, Quad4Family, { quad4::NODES_PER_ELEMENT }>(
+                element_quadrature_for_family::<Quad4Family, { quad4::NODES_PER_ELEMENT }>(
                     &self.analysis_nodes,
                     &self.analysis_elements_flat,
                     self.nelem,
@@ -380,7 +378,7 @@ impl Structural2dModel {
                 )
             }
             Structural2dElementType::Quad9 => {
-                element_quadrature_for_family::<F, Quad9Family, { quad9::NODES_PER_ELEMENT }>(
+                element_quadrature_for_family::<Quad9Family, { quad9::NODES_PER_ELEMENT }>(
                     &self.analysis_nodes,
                     &self.analysis_elements_flat,
                     self.nelem,
@@ -397,7 +395,7 @@ impl Structural2dModel {
     ///     Per-element measures with:
     ///     - `areas` shape `(nelem,)` and units `[area]`
     ///     - `volumes` shape `(nelem,)` and units `[volume]`
-    pub fn element_measures(&self) -> Result<Structural2dElementMeasures<F>, String> {
+    pub fn element_measures(&self) -> Result<Structural2dElementMeasures, String> {
         let quadrature = self.element_quadrature()?;
         let mut areas = vec![0.0; self.nelem];
         let mut volumes = vec![0.0; self.nelem];
@@ -432,9 +430,9 @@ impl Structural2dModel {
     ///     - `nq_per_element` gives the number of consecutive samples per element
     pub fn evaluate_quadrature(
         &self,
-        displacements_full: &[F],
-        nodal_temperature: Option<&[F]>,
-    ) -> Result<QuadratureFieldSamples<F>, String> {
+        displacements_full: &[f64],
+        nodal_temperature: Option<&[f64]>,
+    ) -> Result<QuadratureFieldSamples, String> {
         if displacements_full.len() != self.ndof_full {
             return Err(format!(
                 "displacements_full has length {}, but full system has {} DOFs",
@@ -501,16 +499,16 @@ impl Structural2dModel {
 #[allow(clippy::too_many_arguments)]
 /// Assemble the reduced 2D structural model and all associated operators.
 pub fn assemble_structural_2d(
-    nodes_rz: &[[F; 2]],
+    nodes_rz: &[[f64; 2]],
     elements: Structural2dElements<'_>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
+    material_table: &[[[f64; 4]; 4]],
     pressure_faces: &[PressureLoad],
     traction_faces: &[TractionLoad],
-    thermal_material_table: Option<&[ThermalMaterial<F>]>,
-    material_orientation_angles: Option<&[F]>,
-    prescribed: &[(usize, F)],
-    formulation: Structural2dFormulation<F>,
+    thermal_material_table: Option<&[ThermalMaterial]>,
+    material_orientation_angles: Option<&[f64]>,
+    prescribed: &[(usize, f64)],
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     par: bool,
 ) -> Result<Structural2dModel, String> {
@@ -562,7 +560,13 @@ pub fn assemble_structural_2d(
 /// - fixed DOF values,
 /// - the full-to-reduced lookup table,
 /// - and a dense lookup of fixed values by full DOF index.
-type ReducedLayout<F> = (Vec<usize>, Vec<usize>, Vec<F>, Vec<usize>, Vec<Option<F>>);
+type ReducedLayout = (
+    Vec<usize>,
+    Vec<usize>,
+    Vec<f64>,
+    Vec<usize>,
+    Vec<Option<f64>>,
+);
 
 #[allow(clippy::too_many_arguments)]
 /// Assemble the full set of reduced operators for one specific quadrilateral family.
@@ -571,16 +575,16 @@ type ReducedLayout<F> = (Vec<usize>, Vec<usize>, Vec<F>, Vec<usize>, Vec<Option<
 /// operators, applies Dirichlet reduction, compresses the final sparse matrices, and packages the
 /// result into the public `Structural2dModel`.
 fn build_model_for_family<Family, const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
-    nodes_rz: &[[F; 2]],
+    nodes_rz: &[[f64; 2]],
     elements: &[[usize; NODES_PER_ELEMENT]],
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
+    material_table: &[[[f64; 4]; 4]],
     pressure_faces: &[PressureLoad],
     traction_faces: &[TractionLoad],
-    thermal_material_table: Option<&[ThermalMaterial<F>]>,
-    material_orientation_angles: Option<&[F]>,
-    prescribed: &[(usize, F)],
-    formulation: Structural2dFormulation<F>,
+    thermal_material_table: Option<&[ThermalMaterial]>,
+    material_orientation_angles: Option<&[f64]>,
+    prescribed: &[(usize, f64)],
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     par: bool,
 ) -> Result<Structural2dModel, String>
@@ -602,19 +606,15 @@ where
     // The parallel path keeps worker chunks separate so each chunk can be reduced and sorted
     // independently before a k-way merge builds the canonical CSC structure.
     let stiffness = if par {
-        let stiffness_chunks = assemble_stiffness_chunks_for_family_par::<
-            F,
-            Family,
-            NODES_PER_ELEMENT,
-            DOF_PER_ELEMENT,
-        >(
-            mesh,
-            material_ids,
-            material_table,
-            material_orientation_angles,
-            formulation,
-            quadrature,
-        )?;
+        let stiffness_chunks =
+            assemble_stiffness_chunks_for_family_par::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                mesh,
+                material_ids,
+                material_table,
+                material_orientation_angles,
+                formulation,
+                quadrature,
+            )?;
         let sorted_chunks = reduce_sort_stiffness_chunks(
             stiffness_chunks,
             &global_to_reduced,
@@ -625,7 +625,7 @@ where
         csc_from_sorted_triplet_chunks(ndof_reduced, ndof_reduced, sorted_chunks)
     } else {
         let stiffness_full =
-            assemble_stiffness_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            assemble_stiffness_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
                 mesh,
                 material_ids,
                 material_table,
@@ -648,50 +648,47 @@ where
     let reduce_operator =
         |operator| reduce_row_operator_to_csr(operator, &global_to_reduced, ndof_reduced);
 
-    let (temperature_to_rhs, thermal_reference_rhs, n_temperature_nodes) = if let Some(
-        thermal_material_table,
-    ) =
-        thermal_material_table
-    {
-        // Thermal loading has both a temperature-dependent operator and a constant offset from
-        // per-material reference temperature, so keep those two pieces separate until the end.
-        let thermal_full = if par {
-            temperature_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                material_ids,
-                material_table,
-                thermal_material_table,
-                material_orientation_angles,
-                formulation,
-                quadrature,
+    let (temperature_to_rhs, thermal_reference_rhs, n_temperature_nodes) =
+        if let Some(thermal_material_table) = thermal_material_table {
+            // Thermal loading has both a temperature-dependent operator and a constant offset from
+            // per-material reference temperature, so keep those two pieces separate until the end.
+            let thermal_full = if par {
+                temperature_operator_for_family_par::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                    mesh,
+                    material_ids,
+                    material_table,
+                    thermal_material_table,
+                    material_orientation_angles,
+                    formulation,
+                    quadrature,
+                )
+            } else {
+                temperature_operator_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+                    mesh,
+                    material_ids,
+                    material_table,
+                    thermal_material_table,
+                    material_orientation_angles,
+                    formulation,
+                    quadrature,
+                )
+            }?;
+            let reduced_reference_rhs = free_dofs
+                .iter()
+                .map(|&dof| thermal_full.reference_rhs[dof])
+                .collect::<Vec<_>>();
+            (
+                reduce_operator(thermal_full.temperature_to_rhs)?,
+                reduced_reference_rhs,
+                nodes_rz.len(),
             )
         } else {
-            temperature_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
-                mesh,
-                material_ids,
-                material_table,
-                thermal_material_table,
-                material_orientation_angles,
-                formulation,
-                quadrature,
+            (
+                csr_from_parts(ndof_reduced, 0, Vec::new(), Vec::new(), Vec::new())?,
+                vec![0.0; ndof_reduced],
+                0,
             )
-        }?;
-        let reduced_reference_rhs = free_dofs
-            .iter()
-            .map(|&dof| thermal_full.reference_rhs[dof])
-            .collect::<Vec<_>>();
-        (
-            reduce_operator(thermal_full.temperature_to_rhs)?,
-            reduced_reference_rhs,
-            nodes_rz.len(),
-        )
-    } else {
-        (
-            csr_from_parts(ndof_reduced, 0, Vec::new(), Vec::new(), Vec::new())?,
-            vec![0.0; ndof_reduced],
-            0,
-        )
-    };
+        };
     // `constant_rhs` already contains the Dirichlet offset from stiffness reduction. Add the
     // reference-temperature contribution so all load-independent terms live in one vector.
     for (dst, src) in constant_rhs.iter_mut().zip(&thermal_reference_rhs) {
@@ -701,13 +698,13 @@ where
     // These operators are stored directly in reduced row space because `build_rhs(...)` and
     // `solve(...)` work only with the constrained system.
     let body_force_operator = if par {
-        body_force_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        body_force_operator_for_family_par::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             formulation,
             quadrature,
         )?
     } else {
-        body_force_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        body_force_operator_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             formulation,
             quadrature,
@@ -715,14 +712,14 @@ where
     };
     let body_force_to_rhs = reduce_operator(body_force_operator)?;
     let pressure_operator = if par {
-        pressure_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        pressure_operator_for_family_par::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             pressure_faces,
             formulation,
             quadrature,
         )?
     } else {
-        pressure_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        pressure_operator_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             pressure_faces,
             formulation,
@@ -731,14 +728,14 @@ where
     };
     let pressure_to_rhs = reduce_operator(pressure_operator)?;
     let traction_operator = if par {
-        traction_operator_for_family_par::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        traction_operator_for_family_par::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             traction_faces,
             formulation,
             quadrature,
         )?
     } else {
-        traction_operator_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        traction_operator_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             traction_faces,
             formulation,
@@ -751,7 +748,6 @@ where
     // instead of building full-space triplets and reducing them afterwards.
     let recovery_reduced = if par {
         reduced_quadrature_field_operators_for_family_par::<
-            F,
             Family,
             NODES_PER_ELEMENT,
             DOF_PER_ELEMENT,
@@ -768,7 +764,7 @@ where
             ndof_reduced,
         )
     } else {
-        reduced_quadrature_field_operators_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+        reduced_quadrature_field_operators_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
             mesh,
             material_ids,
             material_table,
@@ -833,10 +829,7 @@ where
 }
 
 /// Partition full-system displacement DOFs into free and fixed sets for Dirichlet reduction.
-fn reduce_layout<F: Real>(
-    ndof_full: usize,
-    prescribed: &[(usize, F)],
-) -> Result<ReducedLayout<F>, String> {
+fn reduce_layout(ndof_full: usize, prescribed: &[(usize, f64)]) -> Result<ReducedLayout, String> {
     let mut prescribed_sorted = prescribed.to_vec();
     prescribed_sorted.sort_by_key(|&(dof, _)| dof);
     for window in prescribed_sorted.windows(2) {
@@ -884,14 +877,14 @@ fn reduce_layout<F: Real>(
 /// Reduce full-system stiffness triplets to the free DOF subspace.
 ///
 /// This helper also accumulates the Dirichlet offset `-K_fc u_c` into `constant_rhs`.
-fn reduce_square_triplets<F: Real>(
+fn reduce_square_triplets(
     rows: &[usize],
     cols: &[usize],
-    vals: &[F],
+    vals: &[f64],
     global_to_reduced: &[usize],
-    fixed_lookup: &[Option<F>],
-    constant_rhs: &mut [F],
-) -> Vec<Triplet<usize, usize, F>> {
+    fixed_lookup: &[Option<f64>],
+    constant_rhs: &mut [f64],
+) -> Vec<Triplet<usize, usize, f64>> {
     let mut triplets = Vec::with_capacity(vals.len());
     for ((&row, &col), &value) in rows.iter().zip(cols).zip(vals) {
         let reduced_row = global_to_reduced[row];
@@ -913,17 +906,17 @@ fn reduce_square_triplets<F: Real>(
 /// still create duplicate `(row, col)` entries inside a chunk, so this function canonicalizes each
 /// chunk before the final k-way merge.  The Dirichlet RHS offsets are accumulated per chunk to
 /// avoid shared mutable state during the parallel pass.
-fn reduce_sort_stiffness_chunks<F: Real>(
-    chunks: Vec<StiffnessTriplets<F>>,
+fn reduce_sort_stiffness_chunks(
+    chunks: Vec<StiffnessTriplets>,
     global_to_reduced: &[usize],
-    fixed_lookup: &[Option<F>],
-    constant_rhs: &mut [F],
+    fixed_lookup: &[Option<f64>],
+    constant_rhs: &mut [f64],
     ndof_reduced: usize,
-) -> Vec<Vec<Triplet<usize, usize, F>>> {
+) -> Vec<Vec<Triplet<usize, usize, f64>>> {
     let reduced_chunks = chunks
         .into_par_iter()
         .map(|chunk| {
-            let mut local_rhs = vec![F::zero(); ndof_reduced];
+            let mut local_rhs = vec![0.0; ndof_reduced];
             let triplets = reduce_square_triplets(
                 &chunk.rows,
                 &chunk.cols,
@@ -947,15 +940,15 @@ fn reduce_sort_stiffness_chunks<F: Real>(
 }
 
 /// Return triplets in canonical CSC order with duplicate `(column, row)` entries coalesced.
-fn sort_coalesce_triplets<F: Real>(
-    mut triplets: Vec<Triplet<usize, usize, F>>,
-) -> Vec<Triplet<usize, usize, F>> {
+fn sort_coalesce_triplets(
+    mut triplets: Vec<Triplet<usize, usize, f64>>,
+) -> Vec<Triplet<usize, usize, f64>> {
     triplets.sort_by(|a, b| a.col.cmp(&b.col).then_with(|| a.row.cmp(&b.row)));
 
     let mut coalesced = Vec::with_capacity(triplets.len());
-    let mut pending: Option<Triplet<usize, usize, F>> = None;
+    let mut pending: Option<Triplet<usize, usize, f64>> = None;
     for triplet in triplets {
-        if triplet.val == F::zero() {
+        if triplet.val == 0.0 {
             continue;
         }
         match pending {
@@ -964,7 +957,7 @@ fn sort_coalesce_triplets<F: Real>(
                 pending = Some(current);
             }
             Some(current) => {
-                if current.val != F::zero() {
+                if current.val != 0.0 {
                     coalesced.push(current);
                 }
                 pending = Some(triplet);
@@ -973,7 +966,7 @@ fn sort_coalesce_triplets<F: Real>(
         }
     }
     if let Some(current) = pending
-        && current.val != F::zero()
+        && current.val != 0.0
     {
         coalesced.push(current);
     }
@@ -981,11 +974,11 @@ fn sort_coalesce_triplets<F: Real>(
 }
 
 /// Drop rows belonging to fixed displacement DOFs from one full-system load operator.
-fn reduce_row_operator<F: Real>(
-    operator: SparseOperator<F>,
+fn reduce_row_operator(
+    operator: SparseOperator,
     global_to_reduced: &[usize],
     nrow_reduced: usize,
-) -> SparseOperator<F> {
+) -> SparseOperator {
     let mut rows = Vec::with_capacity(operator.vals.len());
     let mut cols = Vec::with_capacity(operator.vals.len());
     let mut vals = Vec::with_capacity(operator.vals.len());
@@ -1012,11 +1005,11 @@ fn reduce_row_operator<F: Real>(
 }
 
 /// Reduce one full-system load operator and compress it into CSR form.
-fn reduce_row_operator_to_csr<F: Real>(
-    operator: SparseOperator<F>,
+fn reduce_row_operator_to_csr(
+    operator: SparseOperator,
     global_to_reduced: &[usize],
     nrow_reduced: usize,
-) -> Result<SparseRowMat<usize, F>, String> {
+) -> Result<SparseRowMat<usize, f64>, String> {
     let operator = reduce_row_operator(operator, global_to_reduced, nrow_reduced);
     csr_from_parts(
         operator.nrow,
@@ -1028,13 +1021,13 @@ fn reduce_row_operator_to_csr<F: Real>(
 }
 
 /// Compress triplet data into a CSR matrix with checked shape and index validity.
-fn csr_from_parts<F: Real>(
+fn csr_from_parts(
     nrow: usize,
     ncol: usize,
     rows: Vec<usize>,
     cols: Vec<usize>,
-    vals: Vec<F>,
-) -> Result<SparseRowMat<usize, F>, String> {
+    vals: Vec<f64>,
+) -> Result<SparseRowMat<usize, f64>, String> {
     let triplets = rows
         .into_iter()
         .zip(cols)
@@ -1046,7 +1039,7 @@ fn csr_from_parts<F: Real>(
 }
 
 /// Build a CSR matrix from already canonical row pointers, column indices, and values.
-fn csr_from_canonical_parts<F: Real>(parts: CsrOperatorParts<F>) -> SparseRowMat<usize, F> {
+fn csr_from_canonical_parts(parts: CsrOperatorParts) -> SparseRowMat<usize, f64> {
     let symbolic = SymbolicSparseRowMat::new_checked(
         parts.nrow,
         parts.ncol,
@@ -1058,11 +1051,11 @@ fn csr_from_canonical_parts<F: Real>(parts: CsrOperatorParts<F>) -> SparseRowMat
 }
 
 /// Compress stiffness triplets into the CSC format used by the cached sparse LU factorization.
-fn csc_from_triplets<F: Real>(
+fn csc_from_triplets(
     nrow: usize,
     ncol: usize,
-    mut triplets: Vec<Triplet<usize, usize, F>>,
-) -> SparseColMat<usize, F> {
+    mut triplets: Vec<Triplet<usize, usize, f64>>,
+) -> SparseColMat<usize, f64> {
     triplets.sort_by(|a, b| a.col.cmp(&b.col).then_with(|| a.row.cmp(&b.row)));
 
     let (col_ptr, row_idx, vals) = pack_sorted_triplets_to_csc(nrow, ncol, triplets);
@@ -1101,7 +1094,7 @@ impl PartialOrd for TripletCursor {
     }
 }
 
-struct CscPartsBuilder<F: Real> {
+struct CscPartsBuilder {
     /// Number of matrix rows.
     nrow: usize,
     /// Number of matrix columns.
@@ -1111,14 +1104,14 @@ struct CscPartsBuilder<F: Real> {
     /// Row index for each stored value.
     row_idx: Vec<usize>,
     /// Nonzero values in column-major CSC order.
-    vals: Vec<F>,
+    vals: Vec<f64>,
     /// First column whose pointer has not yet been finalized.
     next_col: usize,
     /// Most recent sorted entry, held back so duplicates can be coalesced before writing.
-    pending: Option<Triplet<usize, usize, F>>,
+    pending: Option<Triplet<usize, usize, f64>>,
 }
 
-impl<F: Real> CscPartsBuilder<F> {
+impl CscPartsBuilder {
     /// Start a CSC builder that accepts triplets sorted by `(column, row)`.
     fn new(nrow: usize, ncol: usize, capacity: usize) -> Self {
         let mut col_ptr = Vec::with_capacity(ncol + 1);
@@ -1135,10 +1128,10 @@ impl<F: Real> CscPartsBuilder<F> {
     }
 
     /// Append one sorted triplet, coalescing duplicates and skipping exact zeros.
-    fn push_sorted(&mut self, triplet: Triplet<usize, usize, F>) {
+    fn push_sorted(&mut self, triplet: Triplet<usize, usize, f64>) {
         debug_assert!(triplet.row < self.nrow);
         debug_assert!(triplet.col < self.ncol);
-        if triplet.val == F::zero() {
+        if triplet.val == 0.0 {
             return;
         }
         match self.pending {
@@ -1155,7 +1148,7 @@ impl<F: Real> CscPartsBuilder<F> {
     }
 
     /// Finalize pending entries and close all remaining column pointers.
-    fn finish(mut self) -> (Vec<usize>, Vec<usize>, Vec<F>) {
+    fn finish(mut self) -> (Vec<usize>, Vec<usize>, Vec<f64>) {
         if let Some(current) = self.pending.take() {
             self.push_entry(current);
         }
@@ -1168,12 +1161,12 @@ impl<F: Real> CscPartsBuilder<F> {
     }
 
     /// Write one already coalesced CSC entry and fill empty-column pointers before it.
-    fn push_entry(&mut self, entry: Triplet<usize, usize, F>) {
+    fn push_entry(&mut self, entry: Triplet<usize, usize, f64>) {
         while self.next_col < entry.col {
             self.col_ptr.push(self.row_idx.len());
             self.next_col += 1;
         }
-        if entry.val != F::zero() {
+        if entry.val != 0.0 {
             self.row_idx.push(entry.row);
             self.vals.push(entry.val);
         }
@@ -1181,21 +1174,21 @@ impl<F: Real> CscPartsBuilder<F> {
 }
 
 /// Merge already sorted/coalesced triplet chunks into the CSC format used by sparse LU.
-fn csc_from_sorted_triplet_chunks<F: Real>(
+fn csc_from_sorted_triplet_chunks(
     nrow: usize,
     ncol: usize,
-    chunks: Vec<Vec<Triplet<usize, usize, F>>>,
-) -> SparseColMat<usize, F> {
+    chunks: Vec<Vec<Triplet<usize, usize, f64>>>,
+) -> SparseColMat<usize, f64> {
     let (col_ptr, row_idx, vals) = merge_sorted_triplet_chunks_to_csc(nrow, ncol, &chunks);
     let symbolic = SymbolicSparseColMat::new_checked(nrow, ncol, col_ptr, None, row_idx);
     SparseColMat::new(symbolic, vals)
 }
 
-fn merge_sorted_triplet_chunks_to_csc<F: Real>(
+fn merge_sorted_triplet_chunks_to_csc(
     nrow: usize,
     ncol: usize,
-    chunks: &[Vec<Triplet<usize, usize, F>>],
-) -> (Vec<usize>, Vec<usize>, Vec<F>) {
+    chunks: &[Vec<Triplet<usize, usize, f64>>],
+) -> (Vec<usize>, Vec<usize>, Vec<f64>) {
     let capacity = chunks.iter().map(Vec::len).sum::<usize>();
     let mut builder = CscPartsBuilder::new(nrow, ncol, capacity);
     let mut heap = BinaryHeap::with_capacity(chunks.len());
@@ -1232,11 +1225,11 @@ fn merge_sorted_triplet_chunks_to_csc<F: Real>(
 }
 
 /// Pack triplets sorted by `(column, row)` into canonical CSC arrays.
-fn pack_sorted_triplets_to_csc<F: Real>(
+fn pack_sorted_triplets_to_csc(
     nrow: usize,
     ncol: usize,
-    triplets: Vec<Triplet<usize, usize, F>>,
-) -> (Vec<usize>, Vec<usize>, Vec<F>) {
+    triplets: Vec<Triplet<usize, usize, f64>>,
+) -> (Vec<usize>, Vec<usize>, Vec<f64>) {
     let mut builder = CscPartsBuilder::new(nrow, ncol, triplets.len());
     for triplet in triplets {
         builder.push_sorted(triplet);
@@ -1245,11 +1238,11 @@ fn pack_sorted_triplets_to_csc<F: Real>(
 }
 
 /// Apply one reduced CSR load operator to a dense load-amplitude vector and accumulate the result.
-fn apply_csr_operator<F: Real>(
-    operator: &SparseRowMat<usize, F>,
-    input: Option<&[F]>,
+fn apply_csr_operator(
+    operator: &SparseRowMat<usize, f64>,
+    input: Option<&[f64]>,
     name: &str,
-    output: &mut [F],
+    output: &mut [f64],
 ) -> Result<(), String> {
     if operator.ncols() == 0 {
         if let Some(input) = input {
@@ -1272,7 +1265,7 @@ fn apply_csr_operator<F: Real>(
     for row in 0..operator.nrows() {
         let start = operator.row_ptr()[row];
         let end = operator.row_ptr()[row + 1];
-        let mut sum = F::zero();
+        let mut sum = 0.0;
         for index in start..end {
             sum = sum + operator.val()[index] * input[operator.col_idx()[index]];
         }
@@ -1282,17 +1275,17 @@ fn apply_csr_operator<F: Real>(
 }
 
 /// Gather one element's node coordinates from the flattened analysis connectivity.
-fn element_coords_from_flat<F: Real, const NODES_PER_ELEMENT: usize>(
-    analysis_nodes: &[[F; 2]],
+fn element_coords_from_flat<const NODES_PER_ELEMENT: usize>(
+    analysis_nodes: &[[f64; 2]],
     analysis_elements_flat: &[usize],
     element_index: usize,
-) -> Result<[[F; 2]; NODES_PER_ELEMENT], String> {
+) -> Result<[[f64; 2]; NODES_PER_ELEMENT], String> {
     let start = element_index * NODES_PER_ELEMENT;
     let end = start + NODES_PER_ELEMENT;
     let conn = analysis_elements_flat
         .get(start..end)
         .ok_or_else(|| format!("element index {element_index} out of bounds"))?;
-    let mut coords = [[F::zero(); 2]; NODES_PER_ELEMENT];
+    let mut coords = [[0.0; 2]; NODES_PER_ELEMENT];
     for (local_node, &node) in conn.iter().enumerate() {
         coords[local_node] = *analysis_nodes.get(node).ok_or_else(|| {
             format!(
@@ -1305,13 +1298,13 @@ fn element_coords_from_flat<F: Real, const NODES_PER_ELEMENT: usize>(
 }
 
 /// Recompute physical quadrature points and mapped weights for one stored element family.
-fn element_quadrature_for_family<F: Real, Family, const NODES_PER_ELEMENT: usize>(
-    analysis_nodes: &[[F; 2]],
+fn element_quadrature_for_family<Family, const NODES_PER_ELEMENT: usize>(
+    analysis_nodes: &[[f64; 2]],
     analysis_elements_flat: &[usize],
     nelem: usize,
-    formulation: Structural2dFormulation<F>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<Structural2dElementQuadrature<F>, String>
+) -> Result<Structural2dElementQuadrature, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -1320,7 +1313,7 @@ where
     let mut weights_volume = Vec::new();
     let mut nq_per_element = None;
     for element_index in 0..nelem {
-        let coords = element_coords_from_flat::<F, NODES_PER_ELEMENT>(
+        let coords = element_coords_from_flat::<NODES_PER_ELEMENT>(
             analysis_nodes,
             analysis_elements_flat,
             element_index,
@@ -1356,12 +1349,12 @@ where
 }
 
 /// Multiply one CSR operator by a dense input vector.
-fn csr_matvec<F: Real>(operator: &SparseRowMat<usize, F>, input: &[F]) -> Vec<F> {
-    let mut output = vec![F::zero(); operator.nrows()];
+fn csr_matvec(operator: &SparseRowMat<usize, f64>, input: &[f64]) -> Vec<f64> {
+    let mut output = vec![0.0; operator.nrows()];
     for row in 0..operator.nrows() {
         let start = operator.row_ptr()[row];
         let end = operator.row_ptr()[row + 1];
-        let mut sum = F::zero();
+        let mut sum = 0.0;
         for index in start..end {
             sum = sum + operator.val()[index] * input[operator.col_idx()[index]];
         }
@@ -1371,11 +1364,11 @@ fn csr_matvec<F: Real>(operator: &SparseRowMat<usize, F>, input: &[F]) -> Vec<F>
 }
 
 /// Validate one optional temperature vector against the model's thermal operator width.
-fn normalize_temperature<'a, F: Real>(
-    temperature: Option<&'a [F]>,
+fn normalize_temperature<'a>(
+    temperature: Option<&'a [f64]>,
     expected_len: usize,
     name: &str,
-) -> Result<&'a [F], String> {
+) -> Result<&'a [f64], String> {
     match (expected_len, temperature) {
         (0, Some(values)) if !values.is_empty() => Err(format!(
             "{name} was provided, but this model has no thermal operator"
@@ -1393,7 +1386,7 @@ fn normalize_temperature<'a, F: Real>(
 }
 
 /// Add one constant vector to a dense field vector.
-fn add_constant<F: Real>(mut values: Vec<F>, constant: &[F]) -> Vec<F> {
+fn add_constant(mut values: Vec<f64>, constant: &[f64]) -> Vec<f64> {
     assert!(
         values.len() == constant.len(),
         "cannot add vectors of lengths {} and {}",
@@ -1407,7 +1400,7 @@ fn add_constant<F: Real>(mut values: Vec<F>, constant: &[F]) -> Vec<F> {
 }
 
 /// Subtract one dense vector from another.
-fn subtract_vectors<F: Real>(lhs: &[F], rhs: &[F]) -> Result<Vec<F>, String> {
+fn subtract_vectors(lhs: &[f64], rhs: &[f64]) -> Result<Vec<f64>, String> {
     if lhs.len() != rhs.len() {
         return Err(format!(
             "cannot subtract vectors of lengths {} and {}",
@@ -1419,7 +1412,7 @@ fn subtract_vectors<F: Real>(lhs: &[F], rhs: &[F]) -> Result<Vec<F>, String> {
 }
 
 /// Pack a flattened quadrature field into one `[rr, zz, tt, rz]` sample per point.
-fn pack_rank4_field<F: Real>(flat: Vec<F>) -> Result<Vec<[F; 4]>, String> {
+fn pack_rank4_field(flat: Vec<f64>) -> Result<Vec<[f64; 4]>, String> {
     if flat.len() % 4 != 0 {
         return Err(format!(
             "quadrature field has {} entries, which is not divisible by 4",

--- a/src/physics/solenoid_stress/recovery.rs
+++ b/src/physics/solenoid_stress/recovery.rs
@@ -52,7 +52,7 @@ use crate::physics::solenoid_stress::geometry::{VolumeSample, validate_structura
 #[cfg(test)]
 use crate::physics::solenoid_stress::types::scatter_local_matrix;
 use crate::physics::solenoid_stress::types::{
-    DOF_PER_NODE, Real, Structural2dFormulation, ThermalMaterial, validate_element_material_inputs,
+    DOF_PER_NODE, Structural2dFormulation, ThermalMaterial, validate_element_material_inputs,
 };
 use crate::{chunksize, ranges_for_len};
 
@@ -63,11 +63,11 @@ use crate::{chunksize, ranges_for_len};
 #[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
-pub struct QuadratureFieldOperators<F: Real> {
+pub struct QuadratureFieldOperators {
     /// Quadrature-point coordinates `(r, z)` in element-major order.
     ///
     /// Units: `[length]`.
-    pub points: Vec<[F; 2]>,
+    pub points: Vec<[f64; 2]>,
     /// Sparse row indices for the strain operator triplets.
     pub strain_rows: Vec<usize>,
     /// Sparse column indices for the strain operator triplets.
@@ -77,7 +77,7 @@ pub struct QuadratureFieldOperators<F: Real> {
     /// Sparse values for the strain operator triplets.
     ///
     /// Units: `[strain / displacement] = [1 / length]`.
-    pub strain_vals: Vec<F>,
+    pub strain_vals: Vec<f64>,
     /// Sparse row indices for the stress operator triplets.
     pub stress_rows: Vec<usize>,
     /// Sparse column indices for the stress operator triplets.
@@ -87,7 +87,7 @@ pub struct QuadratureFieldOperators<F: Real> {
     /// Sparse values for the stress operator triplets.
     ///
     /// Units: `[stress / displacement] = [pressure / length]`.
-    pub stress_vals: Vec<F>,
+    pub stress_vals: Vec<f64>,
     /// Sparse row indices for the thermal-strain operator triplets.
     pub thermal_strain_rows: Vec<usize>,
     /// Sparse column indices for the thermal-strain operator triplets.
@@ -97,7 +97,7 @@ pub struct QuadratureFieldOperators<F: Real> {
     /// Sparse values for the thermal-strain operator triplets.
     ///
     /// Units: `[strain / temperature]`.
-    pub thermal_strain_vals: Vec<F>,
+    pub thermal_strain_vals: Vec<f64>,
     /// Sparse row indices for the thermal-stress operator triplets.
     pub thermal_stress_rows: Vec<usize>,
     /// Sparse column indices for the thermal-stress operator triplets.
@@ -107,15 +107,15 @@ pub struct QuadratureFieldOperators<F: Real> {
     /// Sparse values for the thermal-stress operator triplets.
     ///
     /// Units: `[stress / temperature]`.
-    pub thermal_stress_vals: Vec<F>,
+    pub thermal_stress_vals: Vec<f64>,
     /// Constant quadrature-point thermal strain contribution from per-material reference temperature.
     ///
     /// Units: `[strain]`.
-    pub thermal_strain_constant: Vec<F>,
+    pub thermal_strain_constant: Vec<f64>,
     /// Constant quadrature-point thermal stress contribution from per-material reference temperature.
     ///
     /// Units: `[stress]`.
-    pub thermal_stress_constant: Vec<F>,
+    pub thermal_stress_constant: Vec<f64>,
     /// Number of quadrature points contributed by each element.
     pub nq_per_element: usize,
     /// Number of nodal temperatures the thermal operators act on.
@@ -124,7 +124,7 @@ pub struct QuadratureFieldOperators<F: Real> {
 
 /// Canonical CSR operator parts with strictly increasing column indices in each row.
 #[derive(Debug, Clone)]
-pub struct CsrOperatorParts<F: Real> {
+pub struct CsrOperatorParts {
     /// Number of matrix rows.
     pub nrow: usize,
     /// Number of matrix columns.
@@ -134,18 +134,18 @@ pub struct CsrOperatorParts<F: Real> {
     /// Column index for each stored value.
     pub col_idx: Vec<usize>,
     /// Nonzero values in row-major CSR order.
-    pub vals: Vec<F>,
+    pub vals: Vec<f64>,
 }
 
-struct CsrPartsBuilder<F: Real> {
+struct CsrPartsBuilder {
     nrow: usize,
     ncol: usize,
     row_ptr: Vec<usize>,
     col_idx: Vec<usize>,
-    vals: Vec<F>,
+    vals: Vec<f64>,
 }
 
-impl<F: Real> CsrPartsBuilder<F> {
+impl CsrPartsBuilder {
     /// Start a CSR builder whose rows must be appended in increasing row order.
     fn new(nrow: usize, ncol: usize) -> Self {
         let mut row_ptr = Vec::with_capacity(nrow + 1);
@@ -164,11 +164,11 @@ impl<F: Real> CsrPartsBuilder<F> {
     /// Recovery assembly naturally emits a small unsorted row from local shape-function
     /// contributions.  Canonicalizing one row at a time avoids a global triplet sort and makes the
     /// finished parts directly suitable for faer's CSR constructor.
-    fn push_canonical_row(&mut self, entries: &mut Vec<(usize, F)>) {
+    fn push_canonical_row(&mut self, entries: &mut Vec<(usize, f64)>) {
         entries.sort_unstable_by_key(|(col, _)| *col);
-        let mut pending: Option<(usize, F)> = None;
+        let mut pending: Option<(usize, f64)> = None;
         for (col, value) in entries.drain(..) {
-            if value == F::zero() {
+            if value == 0.0 {
                 continue;
             }
             match pending {
@@ -176,7 +176,7 @@ impl<F: Real> CsrPartsBuilder<F> {
                     pending = Some((pending_col, pending_value + value));
                 }
                 Some((pending_col, pending_value)) => {
-                    if pending_value != F::zero() {
+                    if pending_value != 0.0 {
                         self.col_idx.push(pending_col);
                         self.vals.push(pending_value);
                     }
@@ -186,7 +186,7 @@ impl<F: Real> CsrPartsBuilder<F> {
             }
         }
         if let Some((col, value)) = pending
-            && value != F::zero()
+            && value != 0.0
         {
             self.col_idx.push(col);
             self.vals.push(value);
@@ -200,7 +200,7 @@ impl<F: Real> CsrPartsBuilder<F> {
     }
 
     /// Finish the builder after exactly `nrow` rows have been appended.
-    fn finish(self) -> CsrOperatorParts<F> {
+    fn finish(self) -> CsrOperatorParts {
         debug_assert_eq!(self.row_ptr.len(), self.nrow + 1);
         CsrOperatorParts {
             nrow: self.nrow,
@@ -214,25 +214,25 @@ impl<F: Real> CsrPartsBuilder<F> {
 
 /// Reduced-space quadrature recovery operators in direct CSR form.
 #[derive(Debug, Clone)]
-pub struct ReducedQuadratureFieldOperators<F: Real> {
+pub struct ReducedQuadratureFieldOperators {
     /// Quadrature-point coordinates `(r, z)` in element-major order.
-    pub points: Vec<[F; 2]>,
+    pub points: Vec<[f64; 2]>,
     /// Reduced displacement-to-strain operator.
-    pub strain_operator: CsrOperatorParts<F>,
+    pub strain_operator: CsrOperatorParts,
     /// Reduced displacement-to-stress operator.
-    pub stress_operator: CsrOperatorParts<F>,
+    pub stress_operator: CsrOperatorParts,
     /// Input-temperature-to-thermal-strain operator.
-    pub thermal_strain_operator: CsrOperatorParts<F>,
+    pub thermal_strain_operator: CsrOperatorParts,
     /// Input-temperature-to-thermal-stress operator.
-    pub thermal_stress_operator: CsrOperatorParts<F>,
+    pub thermal_stress_operator: CsrOperatorParts,
     /// Strain contribution from prescribed displacement DOFs.
-    pub strain_constant: Vec<F>,
+    pub strain_constant: Vec<f64>,
     /// Stress contribution from prescribed displacement DOFs.
-    pub stress_constant: Vec<F>,
+    pub stress_constant: Vec<f64>,
     /// Thermal strain contribution from material reference temperatures.
-    pub thermal_strain_constant: Vec<F>,
+    pub thermal_strain_constant: Vec<f64>,
     /// Thermal stress contribution from material reference temperatures.
-    pub thermal_stress_constant: Vec<F>,
+    pub thermal_stress_constant: Vec<f64>,
     /// Number of quadrature points contributed by each element.
     pub nq_per_element: usize,
     /// Number of nodal temperature inputs, or zero when no thermal material table is present.
@@ -245,11 +245,11 @@ pub struct ReducedQuadratureFieldOperators<F: Real> {
 /// - `thermal_strain`: `[strain / temperature]`
 /// - `thermal_stress`: `[stress / temperature]`
 /// - `thermal_*_constant`: `strain` and `stress`, respectively
-struct LocalThermalSampleKernel<F: Real, const NODES_PER_ELEMENT: usize> {
-    thermal_strain: [[F; NODES_PER_ELEMENT]; 4],
-    thermal_stress: [[F; NODES_PER_ELEMENT]; 4],
-    thermal_strain_constant: [F; 4],
-    thermal_stress_constant: [F; 4],
+struct LocalThermalSampleKernel<const NODES_PER_ELEMENT: usize> {
+    thermal_strain: [[f64; NODES_PER_ELEMENT]; 4],
+    thermal_stress: [[f64; NODES_PER_ELEMENT]; 4],
+    thermal_strain_constant: [f64; 4],
+    thermal_stress_constant: [f64; 4],
 }
 
 /// Build the dense thermal recovery blocks for one quadrature point.
@@ -257,16 +257,16 @@ struct LocalThermalSampleKernel<F: Real, const NODES_PER_ELEMENT: usize> {
 /// This helper builds the local thermal operators and constant offsets associated with the
 /// material reference temperature. Mechanical strain/stress recovery is assembled through the
 /// shared query-coordinate mesh operators.
-fn thermal_sample_kernel<F: Real, const NODES_PER_ELEMENT: usize>(
-    sample: &VolumeSample<F, NODES_PER_ELEMENT>,
-    thermal: &ThermalMaterial<F>,
-    thermal_stress_unit: &[F; 4],
-) -> LocalThermalSampleKernel<F, NODES_PER_ELEMENT> {
+fn thermal_sample_kernel<const NODES_PER_ELEMENT: usize>(
+    sample: &VolumeSample<f64, NODES_PER_ELEMENT>,
+    thermal: &ThermalMaterial,
+    thermal_stress_unit: &[f64; 4],
+) -> LocalThermalSampleKernel<NODES_PER_ELEMENT> {
     let mut local = LocalThermalSampleKernel {
-        thermal_strain: [[F::zero(); NODES_PER_ELEMENT]; 4],
-        thermal_stress: [[F::zero(); NODES_PER_ELEMENT]; 4],
-        thermal_strain_constant: [F::zero(); 4],
-        thermal_stress_constant: [F::zero(); 4],
+        thermal_strain: [[0.0; NODES_PER_ELEMENT]; 4],
+        thermal_stress: [[0.0; NODES_PER_ELEMENT]; 4],
+        thermal_strain_constant: [0.0; 4],
+        thermal_stress_constant: [0.0; 4],
     };
 
     for component in 0..4 {
@@ -293,12 +293,12 @@ fn thermal_sample_kernel<F: Real, const NODES_PER_ELEMENT: usize>(
 /// shape expected by the query-coordinate strain/stress operators, but avoid the `O(nquery *
 /// nelem)` nearest-element search that `query_quad_mesh` performs for arbitrary physical points.
 #[cfg(test)]
-fn element_major_reference_points_range<F: Real>(
+fn element_major_reference_points_range(
     element_start: usize,
     element_end: usize,
     quadrature: QuadratureRule,
-) -> (Vec<usize>, Vec<[F; 2]>) {
-    let references = gauss_volume::<F>(quadrature);
+) -> (Vec<usize>, Vec<[f64; 2]>) {
+    let references = gauss_volume::<f64>(quadrature);
     let nelem = element_end - element_start;
     let mut element_indices = Vec::with_capacity(nelem * references.len());
     let mut reference_points = Vec::with_capacity(nelem * references.len());
@@ -311,18 +311,18 @@ fn element_major_reference_points_range<F: Real>(
     (element_indices, reference_points)
 }
 
-fn append_reduced_displacement_entry<F: Real>(
-    entries: &mut Vec<(usize, F)>,
-    constant: &mut [F],
+fn append_reduced_displacement_entry(
+    entries: &mut Vec<(usize, f64)>,
+    constant: &mut [f64],
     row: usize,
     full_col: usize,
-    value: F,
+    value: f64,
     global_to_reduced: &[usize],
-    fixed_lookup: &[Option<F>],
+    fixed_lookup: &[Option<f64>],
 ) {
     // Fixed displacement columns are eliminated from the operator and folded into the additive
     // recovery constant. Free columns are remapped into reduced-system column indices.
-    if value == F::zero() {
+    if value == 0.0 {
         return;
     }
     let reduced_col = global_to_reduced[full_col];
@@ -333,19 +333,15 @@ fn append_reduced_displacement_entry<F: Real>(
     }
 }
 
-fn append_temperature_entry<F: Real>(entries: &mut Vec<(usize, F)>, col: usize, value: F) {
+fn append_temperature_entry(entries: &mut Vec<(usize, f64)>, col: usize, value: f64) {
     // Temperature is not part of the structural Dirichlet reduction, so thermal recovery columns
     // remain indexed by the input temperature node.
-    if value != F::zero() {
+    if value != 0.0 {
         entries.push((col, value));
     }
 }
 
-fn concat_csr_chunks<F: Real>(
-    chunks: Vec<CsrOperatorParts<F>>,
-    nrow: usize,
-    ncol: usize,
-) -> CsrOperatorParts<F> {
+fn concat_csr_chunks(chunks: Vec<CsrOperatorParts>, nrow: usize, ncol: usize) -> CsrOperatorParts {
     // Each chunk covers a contiguous element range and therefore a contiguous row range.  The
     // per-row column order is already canonical, so concatenation only needs to offset row
     // pointers by the number of stored entries seen so far.
@@ -371,13 +367,13 @@ fn concat_csr_chunks<F: Real>(
     }
 }
 
-fn concat_reduced_quadrature_chunks<F: Real>(
-    chunks: Vec<ReducedQuadratureFieldOperators<F>>,
+fn concat_reduced_quadrature_chunks(
+    chunks: Vec<ReducedQuadratureFieldOperators>,
     nq_per_element: usize,
     ntemp: usize,
     ndof_reduced: usize,
     n_temperature_nodes: usize,
-) -> ReducedQuadratureFieldOperators<F> {
+) -> ReducedQuadratureFieldOperators {
     // Reduced recovery chunks are independent by quadrature row.  Constants and points concatenate
     // in the same row order as the CSR chunks, preserving element-major quadrature ordering.
     let total_points = chunks.iter().map(|chunk| chunk.points.len()).sum::<usize>();
@@ -442,19 +438,18 @@ fn concat_reduced_quadrature_chunks<F: Real>(
 /// - within each quadrature point the row components are ordered `[rr, zz, tt, rz]`.
 #[cfg(test)]
 pub(crate) fn quadrature_field_operators_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    thermal_material_table: Option<&[ThermalMaterial<F>]>,
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    thermal_material_table: Option<&[ThermalMaterial]>,
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
-) -> Result<QuadratureFieldOperators<F>, String>
+) -> Result<QuadratureFieldOperators, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -468,7 +463,7 @@ where
         material_orientation_angles,
     )?;
 
-    quadrature_field_operators_range_for_family::<F, Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+    quadrature_field_operators_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
         mesh,
         material_ids,
         material_table,
@@ -483,22 +478,21 @@ where
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn reduced_quadrature_field_operators_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    thermal_material_table: Option<&[ThermalMaterial<F>]>,
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    thermal_material_table: Option<&[ThermalMaterial]>,
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     global_to_reduced: &[usize],
-    fixed_lookup: &[Option<F>],
+    fixed_lookup: &[Option<f64>],
     ndof_reduced: usize,
-) -> Result<ReducedQuadratureFieldOperators<F>, String>
+) -> Result<ReducedQuadratureFieldOperators, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -511,12 +505,7 @@ where
         material_ids,
         material_orientation_angles,
     )?;
-    reduced_quadrature_field_operators_range_for_family::<
-        F,
-        Family,
-        NODES_PER_ELEMENT,
-        DOF_PER_ELEMENT,
-    >(
+    reduced_quadrature_field_operators_range_for_family::<Family, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
         mesh,
         material_ids,
         material_table,
@@ -534,22 +523,21 @@ where
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn reduced_quadrature_field_operators_for_family_par<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    thermal_material_table: Option<&[ThermalMaterial<F>]>,
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    thermal_material_table: Option<&[ThermalMaterial]>,
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     global_to_reduced: &[usize],
-    fixed_lookup: &[Option<F>],
+    fixed_lookup: &[Option<f64>],
     ndof_reduced: usize,
-) -> Result<ReducedQuadratureFieldOperators<F>, String>
+) -> Result<ReducedQuadratureFieldOperators, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -574,7 +562,6 @@ where
         .into_par_iter()
         .map(|(start, end)| {
             reduced_quadrature_field_operators_range_for_family::<
-                F,
                 Family,
                 NODES_PER_ELEMENT,
                 DOF_PER_ELEMENT,
@@ -606,24 +593,23 @@ where
 
 #[allow(clippy::too_many_arguments)]
 fn reduced_quadrature_field_operators_range_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    thermal_material_table: Option<&[ThermalMaterial<F>]>,
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    thermal_material_table: Option<&[ThermalMaterial]>,
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     global_to_reduced: &[usize],
-    fixed_lookup: &[Option<F>],
+    fixed_lookup: &[Option<f64>],
     ndof_reduced: usize,
     element_start: usize,
     element_end: usize,
-) -> Result<ReducedQuadratureFieldOperators<F>, String>
+) -> Result<ReducedQuadratureFieldOperators, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
@@ -640,10 +626,10 @@ where
     let mut stress_operator = CsrPartsBuilder::new(nrows, ndof_reduced);
     let mut thermal_strain_operator = CsrPartsBuilder::new(nrows, n_temperature_nodes);
     let mut thermal_stress_operator = CsrPartsBuilder::new(nrows, n_temperature_nodes);
-    let mut strain_constant = vec![F::zero(); nrows];
-    let mut stress_constant = vec![F::zero(); nrows];
-    let mut thermal_strain_constant = vec![F::zero(); nrows];
-    let mut thermal_stress_constant = vec![F::zero(); nrows];
+    let mut strain_constant = vec![0.0; nrows];
+    let mut stress_constant = vec![0.0; nrows];
+    let mut thermal_strain_constant = vec![0.0; nrows];
+    let mut thermal_stress_constant = vec![0.0; nrows];
     let mut row_entries = Vec::with_capacity(DOF_PER_ELEMENT);
 
     for element_index in element_start..element_end {
@@ -675,7 +661,7 @@ where
         let thermal_stress_unit =
             thermal_material.map(|thermal| constitutive_times_strain(material, &thermal.alpha));
 
-        for (q_local, sample) in Family::volume_samples::<F>(&coords, quadrature)?
+        for (q_local, sample) in Family::volume_samples(&coords, quadrature)?
             .into_iter()
             .enumerate()
         {
@@ -683,7 +669,6 @@ where
             let row_base = 4 * (local_element_index * nq_per_element + q_local);
             points.push(sample.point);
             let b = crate::physics::solenoid_stress::axisym::build_b_matrix::<
-                F,
                 NODES_PER_ELEMENT,
                 DOF_PER_ELEMENT,
             >(formulation, &sample.n, &sample.grad_phys, sample.point)?;
@@ -713,7 +698,7 @@ where
                     for dof_component in 0..DOF_PER_NODE {
                         let local_dof = DOF_PER_NODE * local_node + dof_component;
                         let full_col = DOF_PER_NODE * nodes[local_node] + dof_component;
-                        let mut value = F::zero();
+                        let mut value = 0.0;
                         for strain_component in 0..4 {
                             value = value
                                 + material[component][strain_component]
@@ -789,48 +774,42 @@ where
 #[allow(clippy::too_many_arguments)]
 #[cfg(test)]
 fn quadrature_field_operators_range_for_family<
-    F: Real,
     Family,
     const NODES_PER_ELEMENT: usize,
     const DOF_PER_ELEMENT: usize,
 >(
-    mesh: QuadMeshView2d<'_, F, NODES_PER_ELEMENT>,
+    mesh: QuadMeshView2d<'_, f64, NODES_PER_ELEMENT>,
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    thermal_material_table: Option<&[ThermalMaterial<F>]>,
-    material_orientation_angles: Option<&[F]>,
-    formulation: Structural2dFormulation<F>,
+    material_table: &[[[f64; 4]; 4]],
+    thermal_material_table: Option<&[ThermalMaterial]>,
+    material_orientation_angles: Option<&[f64]>,
+    formulation: Structural2dFormulation,
     quadrature: QuadratureRule,
     element_start: usize,
     element_end: usize,
-) -> Result<QuadratureFieldOperators<F>, String>
+) -> Result<QuadratureFieldOperators, String>
 where
     Family: QuadElementFamily<NODES_PER_ELEMENT>,
 {
     let nq_per_element = quadrature.points_per_element();
     let nsamples = (element_end - element_start) * nq_per_element;
     let (element_indices, reference_points) =
-        element_major_reference_points_range::<F>(element_start, element_end, quadrature);
+        element_major_reference_points_range(element_start, element_end, quadrature);
     let strain_operator = quad_mesh_strain_operator::<
         Family::ReferenceElement,
-        F,
         NODES_PER_ELEMENT,
         DOF_PER_ELEMENT,
     >(mesh, &element_indices, &reference_points, formulation)?;
-    let stress_operator = quad_mesh_stress_operator::<
-        Family::ReferenceElement,
-        F,
-        NODES_PER_ELEMENT,
-        DOF_PER_ELEMENT,
-    >(
-        mesh,
-        &element_indices,
-        &reference_points,
-        material_ids,
-        material_table,
-        material_orientation_angles,
-        formulation,
-    )?;
+    let stress_operator =
+        quad_mesh_stress_operator::<Family::ReferenceElement, NODES_PER_ELEMENT, DOF_PER_ELEMENT>(
+            mesh,
+            &element_indices,
+            &reference_points,
+            material_ids,
+            material_table,
+            material_orientation_angles,
+            formulation,
+        )?;
 
     let mut points = Vec::with_capacity(nsamples);
     let mut thermal_strain_rows = Vec::new();
@@ -839,8 +818,8 @@ where
     let mut thermal_stress_rows = Vec::new();
     let mut thermal_stress_cols = Vec::new();
     let mut thermal_stress_vals = Vec::new();
-    let mut thermal_strain_constant = vec![F::zero(); nsamples * 4];
-    let mut thermal_stress_constant = vec![F::zero(); nsamples * 4];
+    let mut thermal_strain_constant = vec![0.0; nsamples * 4];
+    let mut thermal_stress_constant = vec![0.0; nsamples * 4];
 
     for element_index in element_start..element_end {
         let coords = mesh.element_coords(element_index)?;
@@ -871,7 +850,7 @@ where
         let thermal_stress_unit =
             thermal_material.map(|thermal| constitutive_times_strain(material, &thermal.alpha));
 
-        for (q_local, sample) in Family::volume_samples::<F>(&coords, quadrature)?
+        for (q_local, sample) in Family::volume_samples(&coords, quadrature)?
             .into_iter()
             .enumerate()
         {
@@ -962,7 +941,7 @@ mod tests {
         let material_ids = [0usize];
         let material_table = [isotropic_axisymmetric_material(200.0e9, 0.27)];
         let operators =
-            quadrature_field_operators_for_family::<f64, Quad4Family, 4, { dof_per_element(4) }>(
+            quadrature_field_operators_for_family::<Quad4Family, 4, { dof_per_element(4) }>(
                 mesh,
                 &material_ids,
                 &material_table,
@@ -993,7 +972,7 @@ mod tests {
         let samples = sampling::volume_samples_quad4(&coords, QuadratureRule::GaussLegendre3)
             .expect("samples");
         for (q_local, sample) in samples.into_iter().enumerate() {
-            let b = build_b_matrix::<f64, 4, 8>(
+            let b = build_b_matrix::<4, 8>(
                 Structural2dFormulation::Axisymmetric,
                 &sample.n,
                 &sample.grad_phys,

--- a/src/physics/solenoid_stress/types.rs
+++ b/src/physics/solenoid_stress/types.rs
@@ -1,6 +1,6 @@
 //! Shared constants and structural types for the solenoid-stress backend.
 
-/// Return the constant `2*pi` in the active floating-point type.
+/// Return the constant `2*pi`.
 pub fn two_pi() -> f64 {
     2.0 * core::f64::consts::PI
 }

--- a/src/physics/solenoid_stress/types.rs
+++ b/src/physics/solenoid_stress/types.rs
@@ -1,51 +1,29 @@
-//! Shared numeric traits and constants for the solenoid-stress backend.
-
-use faer_traits::RealField;
-use num_traits::{Float, FromPrimitive};
-
-/// Floating-point trait bound used throughout the solenoid-stress backend.
-///
-/// Keeping the bound in one place avoids duplicating generic constraints inside the Rust backend,
-/// even though the public Python structural-FEM bindings expose only `f64` entry points.
-pub trait Real:
-    Float + FromPrimitive + RealField + Copy + std::fmt::Debug + Send + Sync + 'static
-{
-}
-
-impl<T> Real for T where
-    T: Float + FromPrimitive + RealField + Copy + std::fmt::Debug + Send + Sync + 'static
-{
-}
-
-/// Cast a literal `f64` constant into the active floating-point type.
-pub fn cast<F: Real>(value: f64) -> F {
-    F::from_f64(value).expect("finite f64 literal should cast to target float")
-}
+//! Shared constants and structural types for the solenoid-stress backend.
 
 /// Return the constant `2*pi` in the active floating-point type.
-pub fn two_pi<F: Real>() -> F {
-    cast(2.0 * core::f64::consts::PI)
+pub fn two_pi() -> f64 {
+    2.0 * core::f64::consts::PI
 }
 
 /// Structural 2D reduction used by the quadrilateral FEM backend.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Structural2dFormulation<F: Real> {
+pub enum Structural2dFormulation {
     /// Axisymmetric reduction in `(r, z)` with hoop strain `e_tt = u_r / r`.
     Axisymmetric,
     /// Plane-strain reduction in `(x, y)` with `e_zz = 0` and finite model thickness.
     PlaneStrain {
         /// Out-of-plane thickness used to convert analysis-plane integrals into 3D volume.
-        thickness: F,
+        thickness: f64,
     },
 }
 
-impl<F: Real> Structural2dFormulation<F> {
+impl Structural2dFormulation {
     /// Parse the compact formulation code used by the low-level Python binding.
-    pub fn from_code(code: u8, thickness: F) -> Result<Self, String> {
+    pub fn from_code(code: u8, thickness: f64) -> Result<Self, String> {
         match code {
             0 => Ok(Self::Axisymmetric),
             1 => {
-                if thickness <= F::zero() {
+                if thickness <= 0.0 {
                     return Err(format!(
                         "plane-strain thickness must be positive; got {thickness:?}"
                     ));
@@ -67,32 +45,37 @@ impl<F: Real> Structural2dFormulation<F> {
     }
 
     /// Return the axisymmetric swept-volume or planar-thickness measure for one volume sample.
-    pub fn volume_scale(self, point: [F; 2], det_j: F, weight: F) -> Result<F, String> {
+    pub fn volume_scale(self, point: [f64; 2], det_j: f64, weight: f64) -> Result<f64, String> {
         match self {
             Self::Axisymmetric => {
-                if point[0] < F::zero() {
+                if point[0] < 0.0 {
                     return Err(format!(
                         "quadrature point has negative radius {:?}; axisymmetric radius must be nonnegative",
                         point[0]
                     ));
                 }
-                Ok(two_pi::<F>() * point[0] * det_j * weight)
+                Ok(two_pi() * point[0] * det_j * weight)
             }
             Self::PlaneStrain { thickness } => Ok(thickness * det_j * weight),
         }
     }
 
     /// Return the axisymmetric swept-surface or planar-thickness measure for one face sample.
-    pub fn face_scale(self, point: [F; 2], line_jacobian: F, weight: F) -> Result<F, String> {
+    pub fn face_scale(
+        self,
+        point: [f64; 2],
+        line_jacobian: f64,
+        weight: f64,
+    ) -> Result<f64, String> {
         match self {
             Self::Axisymmetric => {
-                if point[0] < F::zero() {
+                if point[0] < 0.0 {
                     return Err(format!(
                         "face quadrature point has negative radius {:?}; axisymmetric radius must be nonnegative",
                         point[0]
                     ));
                 }
-                Ok(two_pi::<F>() * point[0] * line_jacobian * weight)
+                Ok(two_pi() * point[0] * line_jacobian * weight)
             }
             Self::PlaneStrain { thickness } => Ok(thickness * line_jacobian * weight),
         }
@@ -125,10 +108,10 @@ pub fn local_dofs<const NODES_PER_ELEMENT: usize, const DOF_PER_ELEMENT: usize>(
 }
 
 /// Validate per-element material-index arrays shared by assembly and recovery code.
-pub(crate) fn validate_element_material_inputs<F: Real>(
+pub(crate) fn validate_element_material_inputs(
     nelem: usize,
     material_ids: &[usize],
-    material_orientation_angles: Option<&[F]>,
+    material_orientation_angles: Option<&[f64]>,
 ) -> Result<(), String> {
     if material_ids.len() != nelem {
         return Err(format!(
@@ -150,17 +133,17 @@ pub(crate) fn validate_element_material_inputs<F: Real>(
 }
 
 /// Scatter one local vector into sparse triplet storage.
-pub(crate) fn scatter_local_vector<F: Real, const NROW: usize>(
+pub(crate) fn scatter_local_vector<const NROW: usize>(
     rows: &mut Vec<usize>,
     cols: &mut Vec<usize>,
-    vals: &mut Vec<F>,
+    vals: &mut Vec<f64>,
     global_rows: &[usize; NROW],
     global_col: usize,
-    local: &[F; NROW],
+    local: &[f64; NROW],
 ) {
     for row in 0..NROW {
         let value = local[row];
-        if value != F::zero() {
+        if value != 0.0 {
             rows.push(global_rows[row]);
             cols.push(global_col);
             vals.push(value);
@@ -169,18 +152,18 @@ pub(crate) fn scatter_local_vector<F: Real, const NROW: usize>(
 }
 
 /// Scatter one local dense block into sparse triplet storage.
-pub(crate) fn scatter_local_matrix<F: Real, const NROW: usize, const NCOL: usize>(
+pub(crate) fn scatter_local_matrix<const NROW: usize, const NCOL: usize>(
     rows: &mut Vec<usize>,
     cols: &mut Vec<usize>,
-    vals: &mut Vec<F>,
+    vals: &mut Vec<f64>,
     global_rows: &[usize; NROW],
     global_cols: &[usize; NCOL],
-    local: &[[F; NCOL]; NROW],
+    local: &[[f64; NCOL]; NROW],
 ) {
     for row in 0..NROW {
         for col in 0..NCOL {
             let value = local[row][col];
-            if value != F::zero() {
+            if value != 0.0 {
                 rows.push(global_rows[row]);
                 cols.push(global_cols[col]);
                 vals.push(value);
@@ -215,17 +198,17 @@ pub struct TractionLoad {
 
 /// Per-material thermal-expansion data for the 2D thermoelastic model.
 #[derive(Clone, Copy, Debug)]
-pub struct ThermalMaterial<F: Real> {
+pub struct ThermalMaterial {
     /// Thermal strain coefficients in the active four-component strain order.
     ///
     /// Axisymmetric models use `[rr, zz, tt, rz]`; plane-strain models use `[xx, yy, zz, xy]`.
     ///
     /// Units: `[strain / temperature]`.
-    pub alpha: [F; 4],
+    pub alpha: [f64; 4],
     /// Stress-free reference temperature for this material.
     ///
     /// Units: `[temperature]`.
-    pub reference_temperature: F,
+    pub reference_temperature: f64,
 }
 
 /// Sparse triplets for the assembled structural stiffness matrix before CSC compression.
@@ -234,11 +217,11 @@ pub struct ThermalMaterial<F: Real> {
 /// `[generalized nodal force / displacement] = [energy / distance^2]`,
 /// which is the axisymmetric analogue of stiffness.
 #[derive(Debug, Clone)]
-pub struct StiffnessTriplets<F: Real> {
+pub struct StiffnessTriplets {
     /// Sparse row indices for the assembled stiffness-operator triplets.
     pub rows: Vec<usize>,
     /// Sparse column indices for the assembled stiffness-operator triplets.
     pub cols: Vec<usize>,
     /// Sparse values for the assembled stiffness-operator triplets.
-    pub vals: Vec<F>,
+    pub vals: Vec<f64>,
 }

--- a/src/physics/solenoid_stress/types.rs
+++ b/src/physics/solenoid_stress/types.rs
@@ -1,9 +1,7 @@
 //! Shared constants and structural types for the solenoid-stress backend.
 
-/// Return the constant `2*pi`.
-pub fn two_pi() -> f64 {
-    2.0 * core::f64::consts::PI
-}
+/// Axisymmetric revolution factor.
+pub const TWO_PI: f64 = 2.0 * core::f64::consts::PI;
 
 /// Structural 2D reduction used by the quadrilateral FEM backend.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -54,7 +52,7 @@ impl Structural2dFormulation {
                         point[0]
                     ));
                 }
-                Ok(two_pi() * point[0] * det_j * weight)
+                Ok(TWO_PI * point[0] * det_j * weight)
             }
             Self::PlaneStrain { thickness } => Ok(thickness * det_j * weight),
         }
@@ -75,7 +73,7 @@ impl Structural2dFormulation {
                         point[0]
                     ));
                 }
-                Ok(two_pi() * point[0] * line_jacobian * weight)
+                Ok(TWO_PI * point[0] * line_jacobian * weight)
             }
             Self::PlaneStrain { thickness } => Ok(thickness * line_jacobian * weight),
         }

--- a/src/python.rs
+++ b/src/python.rs
@@ -169,10 +169,10 @@ fn read_axisym_material_ids(
         .map_err(Into::into)
 }
 
-fn read_axisym_material_table<F: physics::solenoid_stress::Real + NumpyElement>(
+fn read_axisym_material_table(
     name: &str,
-    material_table: PyReadonlyArray3<'_, F>,
-) -> PyResult<Vec<[[F; 4]; 4]>> {
+    material_table: PyReadonlyArray3<'_, f64>,
+) -> PyResult<Vec<[[f64; 4]; 4]>> {
     let view = material_table.as_array();
     let shape = view.shape();
     if shape.len() != 3 || shape[1] != 4 || shape[2] != 4 {
@@ -183,7 +183,7 @@ fn read_axisym_material_table<F: physics::solenoid_stress::Real + NumpyElement>(
     }
     let mut out = Vec::with_capacity(shape[0]);
     for matrix in view.outer_iter() {
-        let mut entry = [[F::zero(); 4]; 4];
+        let mut entry = [[0.0; 4]; 4];
         for row in 0..4 {
             for col in 0..4 {
                 entry[row][col] = matrix[[row, col]];
@@ -194,10 +194,10 @@ fn read_axisym_material_table<F: physics::solenoid_stress::Real + NumpyElement>(
     Ok(out)
 }
 
-fn read_axisym_thermal_material_table<F: physics::solenoid_stress::Real + NumpyElement>(
+fn read_axisym_thermal_material_table(
     name: &str,
-    thermal_material_table: PyReadonlyArray2<'_, F>,
-) -> PyResult<Vec<physics::solenoid_stress::ThermalMaterial<F>>> {
+    thermal_material_table: PyReadonlyArray2<'_, f64>,
+) -> PyResult<Vec<physics::solenoid_stress::ThermalMaterial>> {
     let view = thermal_material_table.as_array();
     let shape = view.shape();
     if shape.len() != 2 || shape[1] != 5 {
@@ -216,10 +216,10 @@ fn read_axisym_thermal_material_table<F: physics::solenoid_stress::Real + NumpyE
     Ok(out)
 }
 
-fn read_axisym_material_orientation_angles<F: NumpyElement + Copy>(
+fn read_axisym_material_orientation_angles(
     name: &str,
-    angles: PyReadonlyArray1<'_, F>,
-) -> PyResult<Vec<F>> {
+    angles: PyReadonlyArray1<'_, f64>,
+) -> PyResult<Vec<f64>> {
     let view = angles.as_array();
     let shape = view.shape();
     if shape.len() != 1 {
@@ -361,10 +361,10 @@ fn flatten_rank4_samples<F: Copy>(samples: Vec<[F; 4]>) -> Vec<F> {
     out
 }
 
-fn read_axisym_prescribed<F: NumpyElement + Copy>(
+fn read_axisym_prescribed(
     prescribed_dofs: PyReadonlyArray1<'_, u64>,
-    prescribed_values: PyReadonlyArray1<'_, F>,
-) -> PyResult<Vec<(usize, F)>> {
+    prescribed_values: PyReadonlyArray1<'_, f64>,
+) -> PyResult<Vec<(usize, f64)>> {
     let dofs = prescribed_dofs.as_array();
     let values = prescribed_values.as_array();
     if dofs.ndim() != 1 {
@@ -1084,7 +1084,7 @@ fn quad_mesh_query_for_element_type<F>(
     max_iterations: usize,
 ) -> PyResult<mesh::quad2d::QuadMeshQueryResult<F>>
 where
-    F: physics::solenoid_stress::Real + NumpyElement,
+    F: mesh::Scalar + NumpyElement,
 {
     match element_type {
         "quad4" => {
@@ -1231,7 +1231,7 @@ fn quad_mesh_interpolation_operator_for_element_type<F>(
     element_type: &str,
 ) -> PyResult<mesh::quad2d::QuadMeshSparseOperator<F>>
 where
-    F: physics::solenoid_stress::Real + NumpyElement,
+    F: mesh::Scalar + NumpyElement,
 {
     match element_type {
         "quad4" => {
@@ -1273,21 +1273,18 @@ where
     }
 }
 
-fn quad_mesh_strain_operator_for_element_type<F>(
-    nodes: &[[F; 2]],
+fn quad_mesh_strain_operator_for_element_type(
+    nodes: &[[f64; 2]],
     elements: PyReadonlyArray2<'_, u64>,
     element_indices: &[usize],
-    reference_points: &[[F; 2]],
+    reference_points: &[[f64; 2]],
     element_type: &str,
-    formulation: physics::solenoid_stress::Structural2dFormulation<F>,
-) -> PyResult<mesh::quad2d::QuadMeshSparseOperator<F>>
-where
-    F: physics::solenoid_stress::Real + NumpyElement,
-{
+    formulation: physics::solenoid_stress::Structural2dFormulation,
+) -> PyResult<mesh::quad2d::QuadMeshSparseOperator<f64>> {
     match element_type {
         "quad4" => {
             let elements = read_axisym_elements::<4>("elements", elements)?;
-            mesh::quad2d::quad_mesh_strain_operator::<mesh::quad2d::Quad4ReferenceElement, _, 4, 8>(
+            mesh::quad2d::quad_mesh_strain_operator::<mesh::quad2d::Quad4ReferenceElement, 4, 8>(
                 mesh::QuadMeshView2d {
                     nodes_rz: nodes,
                     elements: &elements,
@@ -1300,7 +1297,7 @@ where
         }
         "quad9" => {
             let elements = read_axisym_elements::<9>("elements", elements)?;
-            mesh::quad2d::quad_mesh_strain_operator::<mesh::quad2d::Quad9ReferenceElement, _, 9, 18>(
+            mesh::quad2d::quad_mesh_strain_operator::<mesh::quad2d::Quad9ReferenceElement, 9, 18>(
                 mesh::QuadMeshView2d {
                     nodes_rz: nodes,
                     elements: &elements,
@@ -1318,24 +1315,21 @@ where
     }
 }
 
-fn quad_mesh_stress_operator_for_element_type<F>(
-    nodes: &[[F; 2]],
+fn quad_mesh_stress_operator_for_element_type(
+    nodes: &[[f64; 2]],
     elements: PyReadonlyArray2<'_, u64>,
     element_indices: &[usize],
-    reference_points: &[[F; 2]],
+    reference_points: &[[f64; 2]],
     material_ids: &[usize],
-    material_table: &[[[F; 4]; 4]],
-    material_orientation_angles: Option<&[F]>,
+    material_table: &[[[f64; 4]; 4]],
+    material_orientation_angles: Option<&[f64]>,
     element_type: &str,
-    formulation: physics::solenoid_stress::Structural2dFormulation<F>,
-) -> PyResult<mesh::quad2d::QuadMeshSparseOperator<F>>
-where
-    F: physics::solenoid_stress::Real + NumpyElement,
-{
+    formulation: physics::solenoid_stress::Structural2dFormulation,
+) -> PyResult<mesh::quad2d::QuadMeshSparseOperator<f64>> {
     match element_type {
         "quad4" => {
             let elements = read_axisym_elements::<4>("elements", elements)?;
-            mesh::quad2d::quad_mesh_stress_operator::<mesh::quad2d::Quad4ReferenceElement, _, 4, 8>(
+            mesh::quad2d::quad_mesh_stress_operator::<mesh::quad2d::Quad4ReferenceElement, 4, 8>(
                 mesh::QuadMeshView2d {
                     nodes_rz: nodes,
                     elements: &elements,
@@ -1351,7 +1345,7 @@ where
         }
         "quad9" => {
             let elements = read_axisym_elements::<9>("elements", elements)?;
-            mesh::quad2d::quad_mesh_stress_operator::<mesh::quad2d::Quad9ReferenceElement, _, 9, 18>(
+            mesh::quad2d::quad_mesh_stress_operator::<mesh::quad2d::Quad9ReferenceElement, 9, 18>(
                 mesh::QuadMeshView2d {
                     nodes_rz: nodes,
                     elements: &elements,


### PR DESCRIPTION
This PR continues the removal of type generics in the 2D FEM module that were needed to support f32 compatibility.